### PR TITLE
Add div support in toc-nav unwrapping

### DIFF
--- a/books/rulesets/common/toc.less
+++ b/books/rulesets/common/toc.less
@@ -141,7 +141,8 @@ nav#toc > ol {
       //Refactor: We are moving towards not using divs as doc-title containers, try to remove >div>span
       // > div > span,
       > h1 > span,
-      > h2 > span {
+      > h2 > span,
+      > div > span {
         pass: @pass-66-nav-unwrap;
         move-to: title-spans;
       }


### PR DESCRIPTION
so that top-level elements without classes won't cause the epub to not validate