### PR TITLE
adds sass-lint

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -1,0 +1,51 @@
+# Linter Options
+options:
+  # Don't merge default rules
+  merge-default-rules: false
+  # Set the formatter to 'stylish' From https://github.com/eslint/eslint/tree/master/lib/formatters
+  formatter: stylish
+
+# File Options
+files:
+  include: 'books/**/*.s+(a|c)ss'
+  ignore:
+    # This is here **ONLY** because :match("...") causes an unignorable failure
+    - 'books/rulesets/common/_modify.scss'
+
+# Rule Configuration
+rules:
+  extends-before-mixins: 2
+  extends-before-declarations: 2
+  placeholder-in-extend: 2
+  mixins-before-declarations:
+    - 2
+    -
+      exclude:
+        - breakpoint
+        - mq
+
+  no-warn: 1
+  no-debug: 1
+  no-ids: 1 # This is only used for ToC nav element. TODO: Fix after https://github.com/sasstools/sass-lint/pull/677
+  no-important: 2
+  # hex-notation:
+  #   - 2
+  #   -
+  #     style: uppercase
+  indentation:
+    - 1
+    -
+      size: 2
+  property-sort-order:
+    - 1
+    -
+      order:
+        - display
+        - margin
+      ignore-custom-properties: true
+  variable-for-property:
+    - 2
+    -
+      properties:
+        - margin
+        # - content # Commented since easybake allows more stuff in the content()

--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@
 
 There are 2 major parts to cooking a book (_listed above_). You will first need to get the single-file HTML from the server (`fetch-book`) and then convert the single-file HTML locally into the "baked" book via `bake-book`. Once you have done the first part, you can run `./scripts/bake-book statistics` to your :heart:'s content!
 
+# Test
+
+1. run `./scripts/test`
+
+This will run the linter, generate sassdocs, and generate the guides to verify they work.
+
 # Documentation
 
 1. run `./scripts/generate-docs` to generate the SASS Docs

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "devDependencies": {
     "css-coverage": "0.0.8",
     "kss": "^2.4.0",
+    "sass-lint": "^1.9.1",
     "sassdoc": "^2.1.20"
+  },
+  "scripts": {
+    "test": "sass-lint --verbose"
   }
 }

--- a/scripts/test
+++ b/scripts/test
@@ -1,7 +1,9 @@
 #!/bin/sh
 set -e
 
-# Just make sure the docs and guides still generate
+npm test # Run the linter
+
+# Make sure the docs and guides still generate
 
 ./scripts/generate-docs
 ./scripts/generate-guide statistics


### PR DESCRIPTION
To run it: `./scripts/test`

Currently, everything is marked as a warning but once the indentations are fixed these would be changed into errors.

# Screenshot

![image](https://cloud.githubusercontent.com/assets/253202/18497292/fb884048-79fa-11e6-836e-27b67c143278.png)

# TODO (future PR)

- clean up the current linting errors
- move the `:match("...")` SASS into a separate file so it can be ignored (because sass-lint does not parse the file)
- [x] add the linting to `./scripts/test` so Travis runs it (if #48 is merged first)


/cc @helenemccarron