### PR TITLE
adds a CSS coverage report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@
 /books/data/
 /data/*-raw.html
 /data/*-cooked.html
+# CSS Code coverage
+/data/*.lcov
 
 # SASS stuff
 /.sass-cache/
@@ -17,3 +19,6 @@
 /books/rulesets/examples/*-cooked.html
 /sassdoc/
 /styleguide/
+
+# CSS coverage report (as a clickable HTML)
+/coverage/

--- a/README.md
+++ b/README.md
@@ -22,3 +22,9 @@ There are 2 major parts to cooking a book (_listed above_). You will first need 
 1. run `./scripts/generate-docs` to generate the SASS Docs
 1. run `./scripts/generate-guide statistics` to generate the HTML Guide for a book
 1. open the generated file in your browser
+
+## CSS Coverage
+
+1. run `./scripts/fetch-book ${BOOK_NAME} ${UUID}` to fetch the Raw HTML for a book
+1. run `./scripts/report-book-coverage ${BOOK_NAME}` to generate the CSS Coverage file
+1. run `genhtml ...` (exact output is shown in the previous step) to generate an HTML report

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "devDependencies": {
+    "bower": "^1.7.9",
     "css-coverage": "0.0.8",
     "kss": "^2.4.0",
     "sassdoc": "^2.1.20"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "devDependencies": {
+    "css-coverage": "0.0.8",
     "kss": "^2.4.0",
     "sassdoc": "^2.1.20"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "devDependencies": {
-    "bower": "^1.7.9",
     "css-coverage": "0.0.8",
     "kss": "^2.4.0",
     "sassdoc": "^2.1.20"

--- a/scripts/report-book-coverage
+++ b/scripts/report-book-coverage
@@ -1,0 +1,41 @@
+#!/bin/sh
+set -e
+
+
+BOOK_NAME=$1
+DEBUG_FLAG1=$2 # could be --debug or --verbose (or both)
+DEBUG_FLAG2=$3
+
+CSS_PATH="./books/rulesets/output/${BOOK_NAME}.css"
+RAW_PATH="./data/${BOOK_NAME}-raw.html"
+LCOV_PATH="./data/${BOOK_NAME}.lcov"
+
+# Check command line args
+
+if [ -z "${BOOK_NAME}" ]
+then
+  echo 'ERROR: Argument Missing. You must specify the name of the book as the 1st argument. For example: physics'
+  exit 1
+fi
+
+if [ ! -f "${CSS_PATH}" ]
+then
+  echo "ERROR: CSS File missing at ${CSS_PATH}"
+  exit 1
+fi
+
+if [ ! -f "${RAW_PATH}" ]
+then
+  echo "ERROR: HTML File missing at ${RAW_PATH}"
+  exit 1
+fi
+
+
+# Print out the message first because css-coverage will set
+# a non-zero exit status if there are unused selectors
+# and the `set -e` at the top of this script will exit at that point
+
+echo "Coverage is being generated. To see an HTML version, run the following:"
+echo "genhtml ${LCOV_PATH} --output-directory ./coverage"
+
+./node_modules/.bin/css-coverage --style ${CSS_PATH} --html ${RAW_PATH} --lcov ${LCOV_PATH} ${DEBUG_FLAG1} ${DEBUG_FLAG2}

--- a/scripts/report-book-coverage
+++ b/scripts/report-book-coverage
@@ -37,5 +37,6 @@ fi
 
 echo "Coverage is being generated. To see an HTML version, run the following:"
 echo "genhtml ${LCOV_PATH} --output-directory ./coverage"
+echo "Note: to run this you may need to install genhtml. In OSX it is `brew install lcov`"
 
 ./node_modules/.bin/css-coverage --style ${CSS_PATH} --html ${RAW_PATH} --lcov ${LCOV_PATH} ${DEBUG_FLAG1} ${DEBUG_FLAG2}

--- a/scripts/setup
+++ b/scripts/setup
@@ -20,4 +20,5 @@ pip install --quiet git+https://github.com/Connexions/cnx-epub.git
 deactivate
 
 echo "Step 4/4: Installing sassdoc (depends on NodeJS)"
+npm install bower # needed for css-coverage (for now)
 npm install


### PR DESCRIPTION
The report can be seen here: https://connexions.github.io/cnx-recipes/coverage/

This uses the Raw HTML for the books plus the CSS files for each book and generates a report showing which selectors were unused (could be removed from the CSS) as well as the ones that were used (and how often they matched)

# Screenshot

![image](https://cloud.githubusercontent.com/assets/253202/18528015/2d02905c-7a95-11e6-8111-7314a6c860c3.png)


**Note:** the coverage correctly handles LESS files but not SASS so I pointed the coverage tool to the `rulesets/output/${BOOK_NAME}.css` file instead of the `rulesets/${BOOK_NAME}.scss` file

# TODO

- [ ] plug it into https://coveralls.io by running all the example HTML snippets through `css-coverage`