### PR TITLE
add in some documentation (and validation) for mixins

### DIFF
--- a/books/rulesets/README.md
+++ b/books/rulesets/README.md
@@ -47,6 +47,41 @@ These are the Types used to configure the numbering an collation of a book.
 - `compoundComposite` - bool
 - `isAnswerKey` - bool
 
+These are collected into a list as `$chapterCompositePages` and `$bookCompositePages` in the config file.
+
+
+### Mixins
+
+```sass
+@include reference_refSectionHeaderNodeAs(sectionHeaderNode);
+@include compose_createChapterComposites($chapterCompositePages, sectionHeaderNode);
+
+//After: ???
+@include reference_refSectionHeaderNodeAs(sectionHeaderNode);
+@include reference_refSectionHeaderStringAs(sectionHeaderString);
+@include compose_prepBookComposites($bookCompositePages, sectionHeaderNode, sectionHeaderString);
+
+//Only move solutions after exercises/solutions are numbered
+@include reference_refSectionHeaderNodeAs(sectionHeaderNode);
+@include compose_createEOBSolutions($chapterCompositePages, $pageSolutions, sectionHeaderNode);
+
+//After: prepBookComposites
+@include reference_refChapterHeaderNodeAs(chapterHeaderNode);
+@include compose_prepChapterAreas($bookCompositePages, chapterHeaderNode);
+
+//After: prepBookComposites, prepChapterAreas
+@include compose_createBookComposites($bookCompositePages);
+
+//After: createChapterComposites, createEOCSolutions, createBookComposites
+@include compose_titleEOCComposites($chapterCompositePages);
+@include compose_titleEOBComposites($bookCompositePages);
+
+//After: createChapterComposites, createEOCSolutions, createBookComposites
+@include modify_compositeAutoID();
+@include modify_chapterAutoID();
+
+@include modify_retitleCompositeMetadata();
+```
 
 # TitleContent
 
@@ -56,20 +91,103 @@ Describes numbering and labeling of elements. Also known as FigNumber, TableNumb
 - `number` - set of counters
 - `divider` - string
 
+### Mixins
 
-# setFigure(Table)Caption
+```sass
+//Come up with mixins for common numbering schemes as per Phil's suggestion
+@include count_countChapters(chapter);
+@include number_numberChapters($chapterTitleContent);
+@include count_countAppendices(appendix);
+@include number_numberAppendices($appendixTitleContent);
+@include count_countSections(section);
+@include number_numberSections($sectionTitleContent);
+@include count_countExamples(example);
+@include number_numberExamples($exampleTitleContent, $exampleSolutionTitleContent);
+@include count_countNote(Try, "try");
+@include number_numberNote("try", $tryTitleContent);
+@include number_numberNote("calculator", $calcTitleContent);
+
+
+//After: createChapterComposites
+@include count_countEOCExercises(exercise);
+@include number_numberEOCExercises($exerciseTitleContent, $exerciseTitleContent);
+```
+
+# setFigure(Table)Caption(Number)
 
 - `type` token (can be `table` or `figure`)
 - `defaultContainer` token (can be `caption`)
 - `hasCaption` bool
 - `hasTitle` bool
 
+### Mixins
 
-# $targetLabels
+```sass
+@include count_countTables(table);
+@include count_countFigures(figure);
+@include number_setCaptions($setTableCaption, $captionTableNumber, $captionTableNumberAp);
+@include number_setCaptions($setFigureCaption, $captionFigNumber, $captionFigNumberAp);
+```
+
+# TargetLabel
 
 These are used when creating the text for a link (ie `See Figure 4.3`).
 
-## TargetLabel
-
 - `selector` string
 - `label` nodes? containing things like `"Figure" counter(chapter) "." counter(figure)`
+
+These are collected in `$targetLabels`.
+
+```sass
+//After: composite page creation
+@include count_countChapters(chapter);
+@include count_countAppendices(appendix);
+@include count_countEOCExercises(exercise);
+@include count_countExamples(example);
+@include link_setTargetLabels($targetLabels);
+@include link_setLinkLabels();
+```
+
+
+# ToC
+
+Generating to Table of Contents requires the following mixins (each done in a separate pass).
+
+```sass
+@include toc_prepTOCElements();
+@include toc_putTOCElements();
+@include toc_navTOCUnwrap();
+```
+
+
+# Misc mixins
+
+These are a grab-bag of the rest of mixins that are used. They should eventually be grouped into categories.
+
+```sass
+//Some modifications to be done to the book before any collation
+@include modify_titlePreface();
+@include modify_spanWrapTitles();
+@include modify_simLinkTarget();
+@include modify_trash('.try [data-type="solution"]');
+@include utils_hasSolution();
+
+@include count_countTerms(term);
+@include reference_refPageIDStringAs(pageID);
+@include modify_prepIndexTerms(term, pageID);
+
+//After: createChapterComposites, numberEOCExercises
+@include count_countExercises(exerciseAll);
+@include link_linkToProblemsFromSolutionsEOC("number", "number", exerciseAll);
+
+//After: prepIndexTerms, createBookComposites
+@include modify_addIndexSymbolGroup("index", $symbolsSectionTitle);
+
+@include reference_refBookMetadataNodeAs(bookMetadata);
+@include modify_compositeMetadata(bookMetadata);
+
+//After: All metadata tasks are completed
+@include modify_suppressURI();
+
+@include utils_clearTrash();
+```

--- a/books/rulesets/README.md
+++ b/books/rulesets/README.md
@@ -28,3 +28,48 @@ The common documentation is in `./common/examples/_all.scss` only because phil d
 ## Book-Specific Documentation
 
 The book-specific documentation is done as comments in the `${BOOK_NAME}.scss` and `${BOOK_NAME}-config.scss` files and the Raw HTML snippets are in `./examples/` because each book does not have a directory (yet?).
+
+
+# Mixin Types
+
+These are the Types used to configure the numbering an collation of a book.
+
+# Page
+
+- `name` - string
+- `source` - string class name (usually) sometimes it gets converted to a data-type (should probably be a data-type)
+- `isGlossary` - bool
+- `sortBy` string (selector)
+- `sectionSeparated` - bool
+- `chapterSeparated` - bool
+- `hasSolutions` - bool
+- `isIndex` - bool
+- `compoundComposite` - bool
+- `isAnswerKey` - bool
+
+
+# TitleContent
+
+Describes numbering and labeling of elements. Also known as FigNumber, TableNumber
+
+- `title-label` - string
+- `number` - set of counters
+- `divider` - string
+
+
+# setFigure(Table)Caption
+
+- `type` token (can be `table` or `figure`)
+- `defaultContainer` token (can be `caption`)
+- `hasCaption` bool
+- `hasTitle` bool
+
+
+# $targetLabels
+
+These are used when creating the text for a link (ie `See Figure 4.3`).
+
+## TargetLabel
+
+- `selector` string
+- `label` nodes? containing things like `"Figure" counter(chapter) "." counter(figure)`

--- a/books/rulesets/README.md
+++ b/books/rulesets/README.md
@@ -85,7 +85,8 @@ These are collected into a list as `$chapterCompositePages` and `$bookCompositeP
 
 # TitleContent
 
-Describes numbering and labeling of elements. Also known as FigNumber, TableNumber
+Describes numbering and labeling of elements (mostly just table and figure).
+See `$captionFigNumber` and `$captionTableNumber`.
 
 - `title-label` - string
 - `number` - set of counters

--- a/books/rulesets/common/_compose.scss
+++ b/books/rulesets/common/_compose.scss
@@ -8,12 +8,9 @@
     $source: map-get($page, source);
 
     // Validate
-    @if (type-of($name) != string) {
-      @error 'the name field is required but is missing';
-    }
-    @if (type-of($source) != string) {
-      @error 'the source field is required but is missing';
-    }
+    @include utils_checkType($name, string);
+    @include utils_checkType($source, string);
+
     [data-type="composite-page"].eoc.#{$source}-container {
       $titleContent: (
         text: $name

--- a/books/rulesets/common/_compose.scss
+++ b/books/rulesets/common/_compose.scss
@@ -320,7 +320,7 @@
 ///
 /// When they are separated by chapter/section a new element is created with the Chapter/Section title.
 ///
-/// @arg {list} $compositePages - eah element contains `source` and `hasSolutions`
+/// @arg {list} $compositePages - each element contains `source` and `hasSolutions`
 /// @arg {Map} $solutionPage - contains `source`, `isSeparated`, `sectionSeparated`, and `chapterSeparated`
 /// @arg {string} $sectionHeaderNode
 @mixin compose_createEOBSolutions($compositePages, $solutionPage, $sectionHeaderNode) {

--- a/books/rulesets/common/_compose.scss
+++ b/books/rulesets/common/_compose.scss
@@ -78,18 +78,18 @@
       @if ($isGlossary) {
         div[data-type="#{$source}"] {
           > h3[data-type="glossary-title"] {
-            // TODO: Explain why is this discarded to the trash
+            /* Discard this Page-specific title because a chapter title is added when collated */
             move-to: trash;
           }
         }
       }
       #{$sourceSelector} {
         > h3[data-type="title"] {
-          // TODO: Explain why is this discarded to the trash
+          /* Discard this Page-specific title because a chapter title is added when collated */
           move-to: trash;
         }
         @if ($sectionSeparated) {
-          // TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined
+          /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
           content: nodes(sectionHeaderNode) content();
         }
         move-to: #{$source}-TOCOMPOSITE;

--- a/books/rulesets/common/_compose.scss
+++ b/books/rulesets/common/_compose.scss
@@ -324,7 +324,7 @@
 /// the originating EOC section must also contain sectionSeparated.
 ///
 /// @arg {list} $compositePages - each element contains `source` and `hasSolutions`
-/// @arg {Map} $solutionPage - contains `source`, `isSeparated`, `sectionSeparated`, and `chapterSeparated`
+/// @arg {Map} $solutionPage - contains `source`, `sectionSeparated`, and `chapterSeparated`
 /// @arg {string} $sectionHeaderNode
 @mixin compose_createEOBSolutions($compositePages, $solutionPage, $sectionHeaderNode) {
   $solutionSource: map-get($solutionPage, source);
@@ -333,7 +333,6 @@
 
   // Validate
   @include utils_checkType($solutionSource, string);
-  @include utils_checkType($isSeparated, bool);
   @include utils_checkTypeOptional($sectionSeparated, bool);
   @include utils_checkType($chapterSeparated, bool);
 

--- a/books/rulesets/common/_compose.scss
+++ b/books/rulesets/common/_compose.scss
@@ -49,7 +49,7 @@
   @include utils_checkType($compositePages, list);
 
   @each $page in $compositePages {
-    @include createChapterComposite($page, $sectionHeaderNode);
+    @include _createChapterComposite($page, $sectionHeaderNode);
   }
 }
 
@@ -57,7 +57,7 @@
 /// collates them at the end of a chapter.
 /// @arg {Map} $page - contains `name`, `source`, and optionally `sortBy` and `compoundComposite` and `isGlossary`
 /// @arg {string} $sectionHeaderNode - Curently Unused (because of typo)
-@mixin createChapterComposite($page, $sectionHeaderNode) {
+@mixin _createChapterComposite($page, $sectionHeaderNode) {
   $name: map-get($page, name);
   $source: map-get($page, source);
   $sortBy: map-get($page, sortBy);
@@ -107,21 +107,39 @@
   }
 }
 
+/// @see {mixin} _prepBookComposite
 @mixin compose_prepBookComposites($compositePages, $sectionHeaderNode, $sectionHeaderString) {
   @each $page in $compositePages {
-    @include prepBookComposite($page, $sectionHeaderNode, $sectionHeaderString);
+    @include _prepBookComposite($page, $sectionHeaderNode, $sectionHeaderString);
   }
 }
 
-@mixin prepBookComposite($page, $sectionHeaderNode, $sectionHeaderString) {
+/// Prepares elements that need to be collated.
+/// For example:
+/// - a `[data-type="term"]` is copied and put into the the "bucket" for the end-of-book index.
+/// - collated sections are moved into their corresponding "bucket"
+///
+/// @arg {Map} $page - contains `name`, `source`, and optionally `compoundComposite` and `isIndex`
+/// @arg {string} $sectionHeaderNode - Curently Unused (because of typo)
+/// @arg {string} $sectionHeaderString - Optional, used when `isIndex` is true
+@mixin _prepBookComposite($page, $sectionHeaderNode, $sectionHeaderString) {
   $name: map-get($page, name);
   $source: map-get($page, source);
   $compoundComposite: map-get($page, compoundComposite);
   $isIndex: map-get($page, isIndex);
+
+  // Validate
+  @include utils_checkType($name, string);
+  @include utils_checkType($source, string);
+  @include utils_checkTypeOptional($isIndex, bool);
+  @include utils_checkTypeOptional($compoundComposite, bool);
+  @include utils_checkType($sectionHeaderString, string);
+
   @if (not $compoundComposite) {
     $sourceSelector: if($isIndex, 'div[data-type="page"] span[data-type="term"], div[data-type="composite-page"] span[data-type="term"]', 'section.#{$source}');
     @if ($isIndex) {
       #{$sourceSelector} {
+        // Create an index entry for the term by creating a new element and then moving it
         &::after {
           content: content();
           attr-group-by: attr(group-by);
@@ -135,6 +153,7 @@
           class: "term-section";
           move-to: index-section;
         }
+        // Create a link next to the index term which points to the term in the book
         &::after {
           container: a;
           content: pending(index-section);
@@ -149,10 +168,16 @@
         }
       }
     } @else {
+      $chapterSeparated: map-get($page, chapterSeparated);
+      $sectionSeparated: map-get($page, sectionSeparated);
+      $chapterPages: map-get($page, chapterPages);
+
+      // Validate
+      @include utils_checkType($chapterSeparated, bool);
+      @include utils_checkType($sectionSeparated, bool);
+      @include utils_checkTypeOptional($chapterPages, bool);
+
       [data-type="chapter"] {
-        $chapterSeparated: map-get($page, chapterSeparated);
-        $sectionSeparated: map-get($page, sectionSeparated);
-        $chapterPages: map-get($page, chapterPages);
         #{$sourceSelector} {
           > h3[data-type="title"] {
             move-to: trash;
@@ -180,16 +205,25 @@
   }
 }
 
+/// @see {mixin} _createBookComposite
 @mixin compose_createBookComposites($compositePages) {
   @each $page in $compositePages {
-    @include createBookComposite($page);
+    @include _createBookComposite($page);
   }
 }
 
-@mixin createBookComposite($page) {
+/// Collects elements defined by `$page.source` (a selector-ish thing) and
+/// collates them at the end of the book.
+/// @arg {Map} $page - contains `source`, and optionally `isIndex`
+@mixin _createBookComposite($page) {
   body {
     $source: map-get($page, source);
     $isIndex: map-get($page, isIndex);
+
+    // Validate
+    @include utils_checkType($source, string);
+    @include utils_checkTypeOptional($isIndex, bool);
+
     &::after {
       container: div;
       content: pending(#{$source}-TOCOMPOSITE);
@@ -204,9 +238,20 @@
 
 //ChapterHeaderNode may be causing some weird issues? and may be copying the entire chapter?
 //See if this node needs to become a string, or if chapterHeaderNode is copying more than expected
+
+/// Adds the chapter name to the new Collated Page
+/// @arg {list} $compositePages - list of pages which contain a `source`
+/// @arg {string} $chapterHeaderNode - The title of what should be in here
 @mixin compose_prepChapterAreas($compositePages, $chapterHeaderNode) {
+  // Validate
+  @include utils_checkType($chapterHeaderNode, string);
+
   @each $page in $compositePages {
     $source: map-get($page, source);
+
+    // Validate
+    @include utils_checkType($source, string);
+
     [data-type="chapter"] {
       .#{$source}-chapter-area {
         content: nodes($chapterHeaderNode) content();
@@ -216,12 +261,26 @@
   }
 }
 
+/// Creates a set of exercise solutions at the end of a chapter
+/// @arg {list} $compositePages
+/// @arg {Map} $solutionPage
+/// @arg {string} $sectionHeaderNode
 @mixin compose_createEOCSolutions($compositePages, $solutionPage, $sectionHeaderNode) {
   $solutionSource: map-get($solutionPage, source);
   $sectionSeparated: map-get($solutionPage, sectionSeparated);
+
+  // Validate
+  @include utils_checkType($solutionSource, string);
+  @include utils_checkTypeOptional($sectionSeparated, bool);
+
   @each $page in $compositePages {
     $hasSolutions: map-get($page, hasSolutions);
     $source: map-get($page, source);
+
+    // Validate
+    @include utils_checkType($source, string);
+    @include utils_checkTypeOptional($hasSolutions, bool);
+
     @if ($hasSolutions) {
       [data-type="chapter"] {
         .eoc.#{$source}-container {
@@ -244,6 +303,7 @@
       }
     }
   }
+
   [data-type="chapter"] {
     &::after {
       container: div;
@@ -255,13 +315,33 @@
 }
 
 
+/// Create solutions at the end of the book (by creating a new collated Page).
+/// These can be separated by section, chapter, both, or none.
+///
+/// When they are separated by chapter/section a new element is created with the Chapter/Section title.
+///
+/// @arg {list} $compositePages - eah element contains `source` and `hasSolutions`
+/// @arg {Map} $solutionPage - contains `source`, `isSeparated`, `sectionSeparated`, and `chapterSeparated`
+/// @arg {string} $sectionHeaderNode
 @mixin compose_createEOBSolutions($compositePages, $solutionPage, $sectionHeaderNode) {
   $solutionSource: map-get($solutionPage, source);
   $sectionSeparated: map-get($solutionPage, sectionSeparated);
   $chapterSeparated: map-get($solutionPage,chapterSeparated);
+
+  // Validate
+  @include utils_checkType($solutionSource, string);
+  @include utils_checkType($isSeparated, bool);
+  @include utils_checkTypeOptional($sectionSeparated, bool);
+  @include utils_checkType($chapterSeparated, bool);
+
   @each $page in $compositePages {
     $hasSolutions: map-get($page, hasSolutions);
     $source: map-get($page, source);
+
+    // Validate
+    @include utils_checkTypeOptional($hasSolutions, bool);
+    @include utils_checkType($source, string);
+
     @if ($hasSolutions) {
       [data-type="chapter"] {
         .eoc.#{$source}-container {

--- a/books/rulesets/common/_compose.scss
+++ b/books/rulesets/common/_compose.scss
@@ -320,6 +320,9 @@
 ///
 /// When they are separated by chapter/section a new element is created with the Chapter/Section title.
 ///
+/// Additionally, if sectionSeparated is selected for the EOB composite page,
+/// the originating EOC section must also contain sectionSeparated.
+///
 /// @arg {list} $compositePages - each element contains `source` and `hasSolutions`
 /// @arg {Map} $solutionPage - contains `source`, `isSeparated`, `sectionSeparated`, and `chapterSeparated`
 /// @arg {string} $sectionHeaderNode

--- a/books/rulesets/common/_compose.scss
+++ b/books/rulesets/common/_compose.scss
@@ -1,9 +1,19 @@
 @import "./utils";
 
+/// Creates a title for a set of composite pages at the end of a chapter
+/// @arg {Map} $compositePages - each element in this must contain a `name` and `source`
 @mixin compose_titleEOCComposites($compositePages) {
   @each $page in $compositePages {
     $name: map-get($page, name);
     $source: map-get($page, source);
+
+    // Validate
+    @if (type-of($name) != string) {
+      @error 'the name field is required but is missing';
+    }
+    @if (type-of($source) != string) {
+      @error 'the source field is required but is missing';
+    }
     [data-type="composite-page"].eoc.#{$source}-container {
       $titleContent: (
         text: $name
@@ -13,10 +23,17 @@
   }
 }
 
+/// Creates a title for a set of composite pages at the end of the book
+/// @arg {list} $compositePages - each element in this must contain a `name` and `source`
 @mixin compose_titleEOBComposites($compositePages) {
   @each $page in $compositePages {
     $name: map-get($page, name);
     $source: map-get($page, source);
+
+    // Validate
+    @include utils_checkType($name, string);
+    @include utils_checkType($source, string);
+
     [data-type="composite-page"].eob.#{$source}-container {
       $titleContent: (
         text: $name
@@ -25,18 +42,38 @@
     }
   }
 }
+
+
+/// Creates a title for a set of composite pages at the end of the book
+/// @arg {list} $compositePages - each element in this must contain a `name` and `source`
+/// @arg {string} $sectionHeaderNode - a String whose value is "sectionHeaderNode" (yep, odd). Currently Unused (because of typo)
 @mixin compose_createChapterComposites($compositePages, $sectionHeaderNode) {
+  // Validate
+  @include utils_checkType($compositePages, list);
+
   @each $page in $compositePages {
     @include createChapterComposite($page, $sectionHeaderNode);
   }
 }
 
+/// Collects elements defined by `$page.source` (a selector-ish thing) and
+/// collates them at the end of a chapter.
+/// @arg {Map} $page - contains `name`, `source`, and optionally `sortBy` and `compoundComposite` and `isGlossary`
+/// @arg {string} $sectionHeaderNode - Curently Unused (because of typo)
 @mixin createChapterComposite($page, $sectionHeaderNode) {
+  $name: map-get($page, name);
+  $source: map-get($page, source);
+  $sortBy: map-get($page, sortBy);
+  $compoundComposite: map-get($page, compoundComposite);
+
+  // Validate
+  @include utils_checkType($name, string);
+  @include utils_checkType($source, string);
+  @include utils_checkTypeOptional($sortBy, string);
+  @include utils_checkTypeOptional($compoundComposite, bool);
+  @include utils_checkType($sectionHeaderNode, string);
+
   div[data-type="chapter"] {
-    $name: map-get($page, name);
-    $source: map-get($page, source);
-    $sortBy: map-get($page, sortBy);
-    $compoundComposite: map-get($page, compoundComposite);
     @if (not $compoundComposite) {
       $sectionSeparated: map-get($page, sectionSeparated);
       $isGlossary: map-get($page, isGlossary);
@@ -44,15 +81,18 @@
       @if ($isGlossary) {
         div[data-type="#{$source}"] {
           > h3[data-type="glossary-title"] {
+            // TODO: Explain why is this discarded to the trash
             move-to: trash;
           }
         }
       }
       #{$sourceSelector} {
         > h3[data-type="title"] {
+          // TODO: Explain why is this discarded to the trash
           move-to: trash;
         }
         @if ($sectionSeparated) {
+          // TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined
           content: nodes(sectionHeaderNode) content();
         }
         move-to: #{$source}-TOCOMPOSITE;

--- a/books/rulesets/common/_utils.scss
+++ b/books/rulesets/common/_utils.scss
@@ -109,3 +109,20 @@
     content: clear(trash);
   }
 }
+
+/// Utility mixin that validates the type of a variable.
+/// useful for erroring early. For example, If the developer was expecting an
+/// argument to a mixin to be a `list` but the mixin that uses it several levels
+/// deep actually expected it to be a `bool`
+@mixin utils_checkType($var, $expectedType) {
+  @if (type-of($var) != $expectedType) {
+    @error "The argument is of the wrong type. Expected: #{$expectedType} but got #{type-of($var)}";
+  }
+}
+
+/// @see {mixin} utils_checkTypeOptional
+@mixin utils_checkTypeOptional($var, $expectedType) {
+  @if ($var and type-of($var) != $expectedType) {
+    @error "The optional argument is of the wrong type. Expected: #{$expectedType} but got #{type-of($var)}";
+  }
+}

--- a/books/rulesets/common/_utils.scss
+++ b/books/rulesets/common/_utils.scss
@@ -55,7 +55,7 @@
 /// @arg {String} $toSelector - The selector of the element in the pair that will be linked to
 /// @arg {String} $fromSelector - The selector of the element in the pair that will be the link
 /// @arg {Text} $toCounter [null] - The counter object used to automatically ID the element to be linked to if it doesn't already have an id. If null, the link href will be to an already existing id of the linked-to element
-@mixin hasSolution() {
+@mixin utils_hasSolution() {
   .exercise {
     .solution {
       string-set: isSolution " hasSolution ";

--- a/books/rulesets/economics.scss
+++ b/books/rulesets/economics.scss
@@ -8,7 +8,7 @@
   @include modify_titlePreface();
   @include modify_spanWrapTitles();
   @include modify_simLinkTarget();
-  @include hasSolution();
+  @include utils_hasSolution();
 }
 :pass(1) {
   //Come up with mixins for common numbering schemes as per Phil's suggestion

--- a/books/rulesets/output/economics.css
+++ b/books/rulesets/output/economics.css
@@ -379,10 +379,12 @@
 :pass(1) div[data-type="composite-page"] > [data-type="document-title"] {
   node-set: sectionHeaderNode; }
 :pass(1) div[data-type="chapter"] div[data-type="glossary"] > h3[data-type="glossary-title"] {
+  /* Discard this Page-specific title because a chapter title is added when collated */
   move-to: trash; }
 :pass(1) div[data-type="chapter"] div[data-type="glossary"] dl {
   move-to: glossary-TOCOMPOSITE; }
   :pass(1) div[data-type="chapter"] div[data-type="glossary"] dl > h3[data-type="title"] {
+    /* Discard this Page-specific title because a chapter title is added when collated */
     move-to: trash; }
 :pass(1) div[data-type="chapter"]::after {
   container: div;
@@ -391,9 +393,11 @@
   data-type: "composite-page";
   sort-by: dl > dt, nocase; }
 :pass(1) div[data-type="chapter"] section.summary {
+  /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
   content: nodes(sectionHeaderNode) content();
   move-to: summary-TOCOMPOSITE; }
   :pass(1) div[data-type="chapter"] section.summary > h3[data-type="title"] {
+    /* Discard this Page-specific title because a chapter title is added when collated */
     move-to: trash; }
 :pass(1) div[data-type="chapter"]::after {
   container: div;
@@ -403,6 +407,7 @@
 :pass(1) div[data-type="chapter"] section.self-check-questions {
   move-to: self-check-questions-TOCOMPOSITE; }
   :pass(1) div[data-type="chapter"] section.self-check-questions > h3[data-type="title"] {
+    /* Discard this Page-specific title because a chapter title is added when collated */
     move-to: trash; }
 :pass(1) div[data-type="chapter"]::after {
   container: div;
@@ -412,6 +417,7 @@
 :pass(1) div[data-type="chapter"] section.review-questions {
   move-to: review-questions-TOCOMPOSITE; }
   :pass(1) div[data-type="chapter"] section.review-questions > h3[data-type="title"] {
+    /* Discard this Page-specific title because a chapter title is added when collated */
     move-to: trash; }
 :pass(1) div[data-type="chapter"]::after {
   container: div;
@@ -421,6 +427,7 @@
 :pass(1) div[data-type="chapter"] section.critical-thinking {
   move-to: critical-thinking-TOCOMPOSITE; }
   :pass(1) div[data-type="chapter"] section.critical-thinking > h3[data-type="title"] {
+    /* Discard this Page-specific title because a chapter title is added when collated */
     move-to: trash; }
 :pass(1) div[data-type="chapter"]::after {
   container: div;
@@ -430,6 +437,7 @@
 :pass(1) div[data-type="chapter"] section.problems {
   move-to: problems-TOCOMPOSITE; }
   :pass(1) div[data-type="chapter"] section.problems > h3[data-type="title"] {
+    /* Discard this Page-specific title because a chapter title is added when collated */
     move-to: trash; }
 :pass(1) div[data-type="chapter"]::after {
   container: div;

--- a/books/rulesets/output/statistics.css
+++ b/books/rulesets/output/statistics.css
@@ -416,10 +416,12 @@
 :pass(1) div[data-type="composite-page"] > [data-type="document-title"] {
   node-set: sectionHeaderNode; }
 :pass(1) div[data-type="chapter"] div[data-type="glossary"] > h3[data-type="glossary-title"] {
+  /* Discard this Page-specific title because a chapter title is added when collated */
   move-to: trash; }
 :pass(1) div[data-type="chapter"] div[data-type="glossary"] dl {
   move-to: glossary-TOCOMPOSITE; }
   :pass(1) div[data-type="chapter"] div[data-type="glossary"] dl > h3[data-type="title"] {
+    /* Discard this Page-specific title because a chapter title is added when collated */
     move-to: trash; }
 :pass(1) div[data-type="chapter"]::after {
   container: div;
@@ -428,9 +430,11 @@
   data-type: "composite-page";
   sort-by: dl > dt, nocase; }
 :pass(1) div[data-type="chapter"] section.summary {
+  /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
   content: nodes(sectionHeaderNode) content();
   move-to: summary-TOCOMPOSITE; }
   :pass(1) div[data-type="chapter"] section.summary > h3[data-type="title"] {
+    /* Discard this Page-specific title because a chapter title is added when collated */
     move-to: trash; }
 :pass(1) div[data-type="chapter"]::after {
   container: div;
@@ -438,9 +442,11 @@
   class: "eoc summary-container";
   data-type: "composite-page"; }
 :pass(1) div[data-type="chapter"] section.formula-review {
+  /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
   content: nodes(sectionHeaderNode) content();
   move-to: formula-review-TOCOMPOSITE; }
   :pass(1) div[data-type="chapter"] section.formula-review > h3[data-type="title"] {
+    /* Discard this Page-specific title because a chapter title is added when collated */
     move-to: trash; }
 :pass(1) div[data-type="chapter"]::after {
   container: div;
@@ -448,9 +454,11 @@
   class: "eoc formula-review-container";
   data-type: "composite-page"; }
 :pass(1) div[data-type="chapter"] section.practice {
+  /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
   content: nodes(sectionHeaderNode) content();
   move-to: practice-TOCOMPOSITE; }
   :pass(1) div[data-type="chapter"] section.practice > h3[data-type="title"] {
+    /* Discard this Page-specific title because a chapter title is added when collated */
     move-to: trash; }
 :pass(1) div[data-type="chapter"]::after {
   container: div;
@@ -460,6 +468,7 @@
 :pass(1) div[data-type="chapter"] section.bring-together-exercises {
   move-to: bring-together-exercises-TOCOMPOSITE; }
   :pass(1) div[data-type="chapter"] section.bring-together-exercises > h3[data-type="title"] {
+    /* Discard this Page-specific title because a chapter title is added when collated */
     move-to: trash; }
 :pass(1) div[data-type="chapter"]::after {
   container: div;
@@ -467,9 +476,11 @@
   class: "eoc bring-together-exercises-container";
   data-type: "composite-page"; }
 :pass(1) div[data-type="chapter"] section.free-response {
+  /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
   content: nodes(sectionHeaderNode) content();
   move-to: free-response-TOCOMPOSITE; }
   :pass(1) div[data-type="chapter"] section.free-response > h3[data-type="title"] {
+    /* Discard this Page-specific title because a chapter title is added when collated */
     move-to: trash; }
 :pass(1) div[data-type="chapter"]::after {
   container: div;
@@ -479,6 +490,7 @@
 :pass(1) div[data-type="chapter"] section.bring-together-homework {
   move-to: bring-together-homework-TOCOMPOSITE; }
   :pass(1) div[data-type="chapter"] section.bring-together-homework > h3[data-type="title"] {
+    /* Discard this Page-specific title because a chapter title is added when collated */
     move-to: trash; }
 :pass(1) div[data-type="chapter"]::after {
   container: div;
@@ -486,9 +498,11 @@
   class: "eoc bring-together-homework-container";
   data-type: "composite-page"; }
 :pass(1) div[data-type="chapter"] section.references {
+  /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
   content: nodes(sectionHeaderNode) content();
   move-to: references-TOCOMPOSITE; }
   :pass(1) div[data-type="chapter"] section.references > h3[data-type="title"] {
+    /* Discard this Page-specific title because a chapter title is added when collated */
     move-to: trash; }
 :pass(1) div[data-type="chapter"]::after {
   container: div;

--- a/books/rulesets/statistics.scss
+++ b/books/rulesets/statistics.scss
@@ -21,7 +21,7 @@
   @include modify_spanWrapTitles();
   @include modify_simLinkTarget();
   @include modify_trash('.try [data-type="solution"]');
-  @include hasSolution();
+  @include utils_hasSolution();
 }
 :pass(1) {
   //Come up with mixins for common numbering schemes as per Phil's suggestion

--- a/scripts/compile-books
+++ b/scripts/compile-books
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+for BOOK_NAME in statistics economics
+do
+  SASS_PATH="./books/rulesets/${BOOK_NAME}.scss"
+  CSS_PATH="./books/rulesets/output/${BOOK_NAME}.css"
+
+  sass ${SASS_PATH} ${CSS_PATH}
+done


### PR DESCRIPTION
I started adding documentation for the mixins and thought to add type-validation for the arguments. Is that something useful? or do you think the builtin sass errors are enough? They would not catch cases like:

- developer thinks they should pass in a list but the actual mixin that uses the arg expected it to be a bool
- developer thinks they should pass in a bool but the actual mixin that uses the arg expected it to be a string

If it is not useful then I will just stick with writing sass docs.

/cc @helenemccarron 


# View the Rendered Overview of Types: [README.md](https://github.com/Connexions/cnx-recipes/blob/add-mixin-docs/books/rulesets/README.md#mixin-types)

# TODO (in another PR)

- rename vars so they match the convention listed in this PR (ie use `isSectionSeparated`)
  - change `source` to `sourceType` and use the `[data-type="..."]` selector
- combine several of the mixins into 1 (ie `number_*` and `count_*`)
  - basically anything that is grouped together in the scss doc by virtue of lack-of-vertical-whitespace
- move the `:pass(#)` prefix into the mixin so people do not have to remember when it runs
  - This will require creating an enum of pass names that are used instead of just a number (for search-and-replace and sanity)