### PR TITLE
Add config file for book UUIDs and which ruleset they map to

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@
 /books/data/
 /data/*-raw.html
 /data/*-cooked.html
+# The following file is used for diffing 2 versions of a book
+/data/*-prepared.html
 # CSS Code coverage
 /data/*.lcov
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 
 # Cook a New Book
 
-1. run `./scripts/fetch-book statistics ${ID}`
-  - **Example:** `./scripts/fetch-book statistics 69619d2b-68f0-44b0-b074-a9b2bf90b2c6@11.330`
-  - **Note:** This will require you to log in via ssh. Also, make sure the **ID** contains the version.
+1. run `./scripts/fetch-book statistics`
+  - **Note:** To see the list of books available see `./books.txt`
+  - **Note:** This will require you to log in via ssh.
   - **Note:** your can set the ssh username by running `USER=myusername ./scripts/fetch-book ...`
 1. run `./scripts/bake-book statistics`
 
@@ -17,7 +17,7 @@ There are 2 major parts to cooking a book (_listed above_). You will first need 
 
 ## Add a New Book to the config
 
-Sometimes you need to add a new book (like "dark-matter") into this repo. Here are the steps to add it:
+Sometimes you need to add a new book (like "dark-matter-for-dummies") into this repo. Here are the steps to add it:
 
 1. Find the UUID of the book you want
   - point your browser to `cte-cnx-dev.cnx.org` and find a book you want.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This will run the linter, generate sassdocs, and generate the guides to verify t
 
 ## CSS Coverage
 
-1. run `./scripts/fetch-book ${BOOK_NAME} ${UUID}` to fetch the Raw HTML for a book
+1. run `./scripts/fetch-book ${BOOK_NAME}` to fetch the Raw HTML for a book
 1. run `./scripts/report-book-coverage ${BOOK_NAME}` to generate the CSS Coverage file
 1. run `genhtml ...` (exact output is shown in the previous step) to generate an HTML report
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,6 @@
 
 # Cook a New Book
 
-1. Find the UUID of the book you want
-  - point your browser to `cte-cnx-dev.cnx.org` and find a book you want.
-  - click "More Information" and copy the **ID**
 1. run `./scripts/fetch-book statistics ${ID}`
   - **Example:** `./scripts/fetch-book statistics 69619d2b-68f0-44b0-b074-a9b2bf90b2c6@11.330`
   - **Note:** This will require you to log in via ssh. Also, make sure the **ID** contains the version.
@@ -16,6 +13,17 @@
 1. run `./scripts/bake-book statistics`
 
 There are 2 major parts to cooking a book (_listed above_). You will first need to get the single-file HTML from the server (`fetch-book`) and then convert the single-file HTML locally into the "baked" book via `bake-book`. Once you have done the first part, you can run `./scripts/bake-book statistics` to your :heart:'s content!
+
+
+## Add a New Book to the config
+
+Sometimes you need to add a new book (like "dark-matter") into this repo. Here are the steps to add it:
+
+1. Find the UUID of the book you want
+  - point your browser to `cte-cnx-dev.cnx.org` and find a book you want.
+  - click "More Information" and copy the **ID**
+1. add an entry to `./books.txt`
+
 
 # Test
 

--- a/books.txt
+++ b/books.txt
@@ -1,0 +1,38 @@
+BOOK_LIST="statistics statshigh econap macroecon macroeconap microecon microeconap"
+
+statistics_uuid=30189442-6998-4686-ac05-ed152b91b9de
+statistics_ruleset_name=statistics
+
+statshigh_uuid=ace2ec2d-778e-44aa-82c2-57a4e5c3de69
+statshigh_ruleset_name=statistics
+
+
+econap_uuid=69619d2b-68f0-44b0-b074-a9b2bf90b2c6
+econap_ruleset_name=economics
+
+macroecon_uuid=4061c832-098e-4b3c-a1d9-7eb593a2cb31
+macroecon_ruleset_name=economics
+
+macroeconap_uuid=33076054-ec1d-4417-8824-ce354efe42d0
+macroeconap_ruleset_name=economics
+
+microecon_uuid=ea2f225e-6063-41ca-bcd8-36482e15ef65
+microecon_ruleset_name=economics
+
+microeconap_uuid=ca344e2d-6731-43cd-b851-a7b3aa0b37aa
+microeconap_ruleset_name=economics
+
+# These are set as environment variables in the various scripts and are unset when the script is done
+#
+# This way you can just run "fetch-book statshigh" or "bake-book statshigh"
+# without having to provide the UUID or which ruleset to use.
+
+
+
+# Principles of Macroeconomics for AP® Courses: 33076054-ec1d-4417-8824-ce354efe42d0@2.145
+# Macroeconomics: 4061c832-098e-4b3c-a1d9-7eb593a2cb31@10.235
+# Principles of Economics: 69619d2b-68f0-44b0-b074-a9b2bf90b2c6@11.330
+# Microeconomics: ea2f225e-6063-41ca-bcd8-36482e15ef65@10.174
+# Principles of Microeconomics for AP® Courses: ca344e2d-6731-43cd-b851-a7b3aa0b37aa@4.109
+# Statistics: 30189442-6998-4686-ac05-ed152b91b9de@19.2
+# High School Statistics: ace2ec2d-778e-44aa-82c2-57a4e5c3de69@7.16

--- a/scripts/_convert-bookname-to-ruleset-name-and-uuid
+++ b/scripts/_convert-bookname-to-ruleset-name-and-uuid
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -e
+
+
+BOOK_NAME=$1
+BOOK_CONFIG_FILE="./books.txt"
+
+if [ -z "${BOOK_NAME}" ]
+then
+  >&2 echo "This utility script converts a book name (like microecon)"
+  >&2 echo "to the ruleset name the should be used to generate the book"
+  >&2 echo "(like economics) by looking up the value in ./books.txt"
+  >&2 echo "but you need to enter a valid book name as the argument to"
+  >&2 echo "this file"
+  exit 1
+fi
+
+if [ ! -f "${BOOK_CONFIG_FILE}" ]
+then
+  >&2 echo "ERROR: Could not find the file named ${BOOK_CONFIG_FILE}"
+  exit 1
+fi
+
+
+# load up all the vars stored in ${BOOK_CONFIG_FILE}
+eval $(cat ${BOOK_CONFIG_FILE})
+
+
+# Pull out the ruleset name that matches the ${BOOK_NAME}
+RULESET_NAME=$(eval echo \${${BOOK_NAME}_ruleset_name})
+UUID=$(eval echo \${${BOOK_NAME}_uuid})
+
+if [ -z "${RULESET_NAME}" ]
+then
+  >&2 echo "ERROR: could not find a ruleset_name for the book named ${BOOK_NAME}"
+  >&2 echo "Please check the ${BOOK_CONFIG_FILE} file and make sure the entry exits"
+  exit 1
+fi
+
+echo ${RULESET_NAME} ${UUID}

--- a/scripts/bake-book
+++ b/scripts/bake-book
@@ -5,8 +5,6 @@ set -e
 BOOK_NAME=$1
 DEBUG_FLAG=$2
 
-SASS_PATH="./books/rulesets/${BOOK_NAME}.scss"
-CSS_PATH="./books/rulesets/output/${BOOK_NAME}.css"
 RAW_PATH="./data/${BOOK_NAME}-raw.html"
 COOKED_PATH="./data/${BOOK_NAME}-cooked.html"
 
@@ -14,27 +12,33 @@ COOKED_PATH="./data/${BOOK_NAME}-cooked.html"
 
 if [ -z "${BOOK_NAME}" ]
 then
-  echo 'ERROR: Argument Missing. You must specify the name of the book as the 1st argument. For example: physics'
+  >&2 echo 'ERROR: Argument Missing. You must specify the name of the book as the 1st argument. For example: physics'
   exit 1
 fi
 
+RULESET_NAME_AND_UUID=($(./scripts/_convert-bookname-to-ruleset-name-and-uuid ${BOOK_NAME}))
+RULESET_NAME=${RULESET_NAME_AND_UUID[0]}
+SASS_PATH="./books/rulesets/${RULESET_NAME}.scss"
+CSS_PATH="./books/rulesets/output/${RULESET_NAME}.css"
+
 if [ ! -f "${RAW_PATH}" ]
 then
-  echo 'ERROR: Could not find the raw HTML file. Have you run fetch-book yet?'
+  >&2 echo 'ERROR: Could not find the raw HTML file. Have you run fetch-book yet?'
   exit 1
 fi
 
 if [ ! -f "${SASS_PATH}" ]
 then
-  echo "ERROR: Could not find the raw SCSS file at ${SASS_PATH}"
+  >&2 echo "ERROR: Could not find the raw SCSS file at ${SASS_PATH}"
   exit 1
 fi
 
 
-echo "Step 1/2: Compile SASS to CSS"
+>&2 echo "Step 1/2: Compile SASS to CSS (${SASS_PATH})"
 sass ${SASS_PATH} ${CSS_PATH}
 
-echo "Step 2/2: Baking the book (may take a couple minutes). specify additional commandline arguments like -d to this script if you want more debugging"
+>&2 echo "Step 2/2: Baking the book (may take a couple minutes). specify additional commandline arguments like -d to this script if you want more debugging"
+>&2 echo "Info: Baking ${RAW_PATH} to ${COOKED_PATH} using ${CSS_PATH}"
 
 # Remove the cooked file if it exists
 [ -e "${COOKED_PATH}" ] && rm ${COOKED_PATH}

--- a/scripts/diff-book
+++ b/scripts/diff-book
@@ -1,0 +1,31 @@
+#!/bin/sh
+set -e
+
+
+BOOK_NAME=$1
+DEBUG_FLAG=$2
+
+COOKED_PATH="./data/${BOOK_NAME}-cooked.html"
+PREPARED_PATH="./data/${BOOK_NAME}-prepared.html"
+
+# Check command line args
+
+if [ -z "${BOOK_NAME}" ]
+then
+  >&2 echo 'ERROR: Argument Missing. You must specify the name of the book as the 1st argument. For example: physics'
+  >&2 echo 'This script bakes the book and then compares to the prepared book'
+  >&2 echo '(done earlier, usually in another branch)'
+  exit 1
+fi
+
+if [ ! -f "${PREPARED_PATH}" ]
+then
+  >&2 echo 'ERROR: This book was not prepared beforehand.'
+  >&2 echo 'Run diff-book-prepare before running this script'
+  >&2 echo 'so there is something to compare against'
+  exit 1
+fi
+
+./scripts/bake-book ${BOOK_NAME}
+
+diff ${PREPARED_PATH} ${COOKED_PATH}

--- a/scripts/diff-book-prepare
+++ b/scripts/diff-book-prepare
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -e
+
+
+BOOK_NAME=$1
+DEBUG_FLAG=$2
+
+COOKED_PATH="./data/${BOOK_NAME}-cooked.html"
+PREPARED_PATH="./data/${BOOK_NAME}-prepared.html"
+
+# Check command line args
+
+if [ -z "${BOOK_NAME}" ]
+then
+  >&2 echo 'ERROR: Argument Missing. You must specify the name of the book as the 1st argument. For example: physics'
+  >&2 echo 'This script prepares the book to compare against.'
+  >&2 echo 'Typically this step is done in the master branch'
+  >&2 echo 'and then in another branch diff-book is called to see how the HTML changed.'
+  exit 1
+fi
+
+./scripts/bake-book ${BOOK_NAME}
+
+mv ${COOKED_PATH} ${PREPARED_PATH}

--- a/scripts/fetch-book
+++ b/scripts/fetch-book
@@ -7,7 +7,9 @@ set -e
 HOST='cte-cnx-dev.cnx.org'
 
 BOOK_NAME=$1
-BOOK_UUID_AND_VER=$2
+
+RULESET_NAME_AND_UUID=($(./scripts/_convert-bookname-to-ruleset-name-and-uuid ${BOOK_NAME}))
+BOOK_UUID_AND_VER=${RULESET_NAME_AND_UUID[1]}
 
 RAW_PATH="./data/${BOOK_NAME}-raw.html"
 
@@ -15,18 +17,18 @@ RAW_PATH="./data/${BOOK_NAME}-raw.html"
 
 if [ -z "${BOOK_NAME}" ]
 then
-  echo 'ERROR: Argument Missing. You must specify the name of the book as the 1st argument. For example: physics'
+  >&2 echo 'ERROR: Argument Missing. You must specify the name of the book as the 1st argument. For example: physics'
   exit 1
 fi
 
 if [ -z "${BOOK_UUID_AND_VER}" ]
 then
-  echo 'ERROR: Argument Missing. You must specify the UUID of the book to download as the 2nd argument. For example: 30189442-6998-4686-ac05-ed152b91b9de@19.2'
+  >&2 echo 'ERROR: Argument Missing. You must specify the UUID of the book to download as the 2nd argument. For example: 30189442-6998-4686-ac05-ed152b91b9de@19.2'
   exit 1
 fi
 
 
-echo "Step 1/2: Generating an EPUB from the database and converting to a single HTML file (may take a minute)"
+>&2 echo "Step 1/2: Generating an EPUB from the database and converting to a single HTML file (may take a minute)"
 
 TEMP_EPUB_PATH="~/temp.intenral.epub"
 TEMP_HTML_PATH="~/temp.html"
@@ -40,7 +42,7 @@ CMD="${RM_TEMP_EPUB_CMD}; ${RM_TEMP_HTML_CMD}; ${GENERATE_EPUB_CMD} && ${GENERAT
 
 ssh ${USER}@${HOST} ${CMD}
 
-echo "Step 2/2: Copying HTML file from server to local machine"
+>&2 echo "Step 2/2: Copying HTML file from server to local machine"
 scp ${USER}@${HOST}:${TEMP_HTML_PATH} ${RAW_PATH}
 
-echo "Fetch is done. File is available at ${RAW_PATH}"
+>&2 echo "Fetch is done. File is available at ${RAW_PATH}"

--- a/scripts/report-book-coverage
+++ b/scripts/report-book-coverage
@@ -6,7 +6,6 @@ BOOK_NAME=$1
 DEBUG_FLAG1=$2 # could be --debug or --verbose (or both)
 DEBUG_FLAG2=$3
 
-CSS_PATH="./books/rulesets/output/${BOOK_NAME}.css"
 RAW_PATH="./data/${BOOK_NAME}-raw.html"
 LCOV_PATH="./data/${BOOK_NAME}.lcov"
 
@@ -18,17 +17,23 @@ then
   exit 1
 fi
 
+if [ ! -f "${RAW_PATH}" ]
+then
+  echo "ERROR: HTML File missing at ${RAW_PATH}"
+  exit 1
+fi
+
+RULESET_NAME_AND_UUID=($(./scripts/_convert-bookname-to-ruleset-name-and-uuid ${BOOK_NAME}))
+RULESET_NAME=${RULESET_NAME_AND_UUID[0]}
+
+CSS_PATH="./books/rulesets/output/${RULESET_NAME}.css"
+
 if [ ! -f "${CSS_PATH}" ]
 then
   echo "ERROR: CSS File missing at ${CSS_PATH}"
   exit 1
 fi
 
-if [ ! -f "${RAW_PATH}" ]
-then
-  echo "ERROR: HTML File missing at ${RAW_PATH}"
-  exit 1
-fi
 
 
 # Print out the message first because css-coverage will set


### PR DESCRIPTION
... to keep everyone in-sync, make it easier to fetch updates, and make it
easier to bake a book.

So now, to do all the stuff with a book you would do:

```sh
./scripts/fetch-book microeconap
./scripts/bake-book microeconap
./scripts/report-book-coverage microeconap
```

Previously, you:

- had to specify a UUID in order to fetch a book (it now should always get the latest version)
- could not bake a book other than one that matched the ruleset name
- could only have 1 econ or stats book at a time

The names are not the greatest, but they can be changed _really_ easily (just edit `/books.txt`)