### PR TITLE
report coverage of source SASS files

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ This will run the linter, generate sassdocs, and generate the guides to verify t
 1. run `./scripts/report-book-coverage ${BOOK_NAME}` to generate the CSS Coverage file
 1. run `genhtml ...` (exact output is shown in the previous step) to generate an HTML report
 
+You can pass 3 additional arguments to `report-book-coverage` to change how it reports coverage:
+
+- `--verbose` : outputs verbose/debugging output
+- `--ignore-source-map` : covers the CSS even if a sourceMappingURL is found.
+- `--cover-declarations` : generates coverage based on the declarations, not just the selector
+
+For more details on the commandline options see the [css-coverage](https://www.npmjs.com/package/css-coverage#commandline-options) documentation.
 
 ## Experimental
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "css-coverage": "0.0.8",
+    "css-coverage": "~0.1.0",
     "kss": "^2.4.0",
     "sass-lint": "^1.9.1",
     "sassdoc": "^2.1.20"

--- a/scripts/report-book-coverage
+++ b/scripts/report-book-coverage
@@ -39,4 +39,4 @@ echo "Coverage is being generated. To see an HTML version, run the following:"
 echo "genhtml ${LCOV_PATH} --output-directory ./coverage"
 echo "Note: to run this you may need to install genhtml. In OSX it is 'brew install lcov'"
 
-./node_modules/.bin/css-coverage --style ${CSS_PATH} --html ${RAW_PATH} --lcov ${LCOV_PATH} ${DEBUG_FLAG1} ${DEBUG_FLAG2}
+./node_modules/.bin/css-coverage --css ${CSS_PATH} --html ${RAW_PATH} --lcov ${LCOV_PATH} ${DEBUG_FLAG1} ${DEBUG_FLAG2}

--- a/scripts/setup
+++ b/scripts/setup
@@ -20,5 +20,4 @@ pip install --quiet git+https://github.com/Connexions/cnx-epub.git
 deactivate
 
 echo "Step 4/4: Installing sassdoc (depends on NodeJS)"
-npm install bower # needed for css-coverage (for now)
 npm install


### PR DESCRIPTION
Instead of just reporting coverage of the compiled CSS files, this reports coverage of the source SASS files.

# Screenshots

![image](https://cloud.githubusercontent.com/assets/253202/18720199/c13a0e7c-7ff8-11e6-813b-5dae2466cd52.png)

Example of 1 SASS file:

![image](https://cloud.githubusercontent.com/assets/253202/18720282/33bbeeb6-7ff9-11e6-9c46-81a40d791877.png)


Also, you can generate an HTML report of all the books (after running `report-book-coverage` on each book) by running:

```sh
genhtml ./data/*.lcov --output-directory ./coverage/
```

/cc @zroehr because we talked about it a couple days ago