### PR TITLE
include sassdoc and coverage changes when updating gh-pages

### DIFF
--- a/scripts/generate-and-update-gh-pages
+++ b/scripts/generate-and-update-gh-pages
@@ -22,8 +22,10 @@ git checkout gh-pages
 git pull # In case gh-pages has updated since you last pulled
 git rebase ${BRANCH_WITH_NEW_STUFF}
 
-./scripts/generate-guide statistics
+./scripts/test
 git add --all styleguide/
+git add --all sassdoc/
+git add --all coverage/
 git commit -m "Updating guide from ${BRANCH_WITH_NEW_STUFF} branch"
 git push --force-with-lease
 

--- a/scripts/generate-and-update-gh-pages
+++ b/scripts/generate-and-update-gh-pages
@@ -27,6 +27,6 @@ git add --all styleguide/
 git add --all sassdoc/
 git add --all coverage/
 git commit -m "Updating guide from ${BRANCH_WITH_NEW_STUFF} branch"
-git push --force-with-lease
+git push --force-with-lease origin gh-pages
 
 git checkout ${BRANCH_WITH_NEW_STUFF}


### PR DESCRIPTION
`./scripts/generate-and-update-gh-pages` now correctly updates the following URLs (the script name is long so you don't accidentally type it!):

- https://connexions.github.io/cnx-recipes/styleguide/
- https://connexions.github.io/cnx-recipes/sassdoc/
- https://connexions.github.io/cnx-recipes/coverage/

You can run it in the `master` branch whenever PR's are merged or in any other branch (useful for reviewing a PR that updates the documentation)

/cc @zroehr so you can see the updated docs (It's been a while since `/sassdoc/` was updated on the page)