### PR TITLE
Testing: verify CSS files are regenerated when pushing commits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ before_install:
   - rvm default
 install:
   - ./scripts/setup
-script: ./scripts/test
+script: ./scripts/ci

--- a/scripts/ci
+++ b/scripts/ci
@@ -10,7 +10,8 @@ hasChanges=$(git diff)
 
 if [[ ! -z "${hasChanges}" ]]
 then
-  echo "ERROR: The CSS files were not regenerated. Be sure to run ./scripts/test before pushing"
+  echo "ERROR: Running the tests caused unexpected changes in committed files."
+  echo "Were the CSS files regenerated? Be sure to run ./scripts/test before pushing"
   git diff
   exit 1
 fi

--- a/scripts/ci
+++ b/scripts/ci
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -e
+
+# Run the tests (which happens to re-generate the CSS files)
+./scripts/test
+
+# Verify that the CSS files were regenerated so they never become out-of-sync
+
+hasChanges=$(git diff)
+
+if [[ ! -z "${hasChanges}" ]]
+then
+  echo "ERROR: The CSS files were not regenerated. Be sure to run ./scripts/test before pushing"
+  git diff
+  exit 1
+fi


### PR DESCRIPTION
This makes sure that things like https://github.com/Connexions/cnx-recipes/pull/71/commits/1a008d0f657db31739cc9c95cae352d948eb96a3 do not get overlooked.

I created a separate script for Travis that:

1. runs the tests
1. verifies that there were no changes to files stored in git

When CSS files were forgotten, Travis will fail and print out something like:

![image](https://cloud.githubusercontent.com/assets/253202/19050184/81c65200-897b-11e6-8863-a6dd4cfd9c8a.png)

(except that the diff would point to the CSS files, not `./scripts/test` or `./scripts/ci` 😄 )