### PR TITLE
add option to fetch multiple books and coverage for multiple books

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ You can pass 3 additional arguments to `report-book-coverage` to change how it r
 - `--verbose` : outputs verbose/debugging output
 - `--ignore-source-map` : covers the CSS even if a sourceMappingURL is found.
 - `--cover-declarations` : generates coverage based on the declarations, not just the selector
+- **Note:** You can run `./scripts/report-book-coverage --all` to generate coverage using all the books
 
 For more details on the commandline options see the [css-coverage](https://www.npmjs.com/package/css-coverage#commandline-options) documentation.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
 1. run `./scripts/fetch-book statistics`
   - **Note:** To see the list of books available see `./books.txt`
   - **Note:** This will require you to log in via ssh.
-  - **Note:** your can set the ssh username by running `USER=myusername ./scripts/fetch-book ...`
+  - **Note:** You can set the ssh username by running `USER=myusername ./scripts/fetch-book ...`
+  - **Note:** You can run `./scripts/fetch-book --all` to fetch all the books
 1. run `./scripts/bake-book statistics`
 
 There are 2 major parts to cooking a book (_listed above_). You will first need to get the single-file HTML from the server (`fetch-book`) and then convert the single-file HTML locally into the "baked" book via `bake-book`. Once you have done the first part, you can run `./scripts/bake-book statistics` to your :heart:'s content!

--- a/scripts/fetch-book
+++ b/scripts/fetch-book
@@ -1,48 +1,63 @@
 #!/bin/sh
 set -e
 
-# . ./bin/activate
-# deactivate
+# This fetches the raw HTML for a book (or all books if using the --all argument) from ${HOST}
 
 HOST='cte-cnx-dev.cnx.org'
 
-BOOK_NAME=$1
+ARG1=$1
 
-RULESET_NAME_AND_UUID=($(./scripts/_convert-bookname-to-ruleset-name-and-uuid ${BOOK_NAME}))
-BOOK_UUID_AND_VER=${RULESET_NAME_AND_UUID[1]}
-
-RAW_PATH="./data/${BOOK_NAME}-raw.html"
 
 # Check command line args
 
-if [ -z "${BOOK_NAME}" ]
+if [ -z "${ARG1}" ]
 then
-  >&2 echo 'ERROR: Argument Missing. You must specify the name of the book as the 1st argument. For example: physics'
+  >&2 echo 'ERROR: Argument Missing. You must specify the name of the book as the 1st argument or --all for all books. For example: physics'
   exit 1
 fi
 
-if [ -z "${BOOK_UUID_AND_VER}" ]
+if [ "${ARG1}" == "--all" ]
 then
-  >&2 echo 'ERROR: Argument Missing. You must specify the UUID of the book to download as the 2nd argument. For example: 30189442-6998-4686-ac05-ed152b91b9de@19.2'
-  exit 1
+  source ./books.txt
+else
+  BOOK_LIST="${ARG1}"
 fi
 
+>&2 echo "Preparing to fetch book(s): ${BOOK_LIST}"
 
->&2 echo "Step 1/2: Generating an EPUB from the database and converting to a single HTML file (may take a minute)"
+for BOOK_NAME in ${BOOK_LIST}
+do
 
-TEMP_EPUB_PATH="~/temp.intenral.epub"
-TEMP_HTML_PATH="~/temp.html"
+  RULESET_NAME_AND_UUID=($(./scripts/_convert-bookname-to-ruleset-name-and-uuid ${BOOK_NAME}))
+  BOOK_UUID_AND_VER=${RULESET_NAME_AND_UUID[1]}
 
-RM_TEMP_EPUB_CMD="[ -e ${TEMP_EPUB_PATH} ] && rm ${TEMP_EPUB_PATH}"
-RM_TEMP_HTML_CMD="[ -e ${TEMP_HTML_PATH} ] && rm ${TEMP_HTML_PATH}"
-GENERATE_EPUB_CMD="/var/cnx/venvs/publishing/bin/cnx-archive-export_epub /etc/cnx/publishing/app.ini ${BOOK_UUID_AND_VER} ${TEMP_EPUB_PATH}"
-GENERATE_HTML_CMD="/var/cnx/venvs/publishing/bin/cnx-epub-single_html ${TEMP_EPUB_PATH} > ${TEMP_HTML_PATH}"
+  RAW_PATH="./data/${BOOK_NAME}-raw.html"
 
-CMD="${RM_TEMP_EPUB_CMD}; ${RM_TEMP_HTML_CMD}; ${GENERATE_EPUB_CMD} && ${GENERATE_HTML_CMD}"
+  if [ -z "${BOOK_UUID_AND_VER}" ]
+  then
+    >&2 echo "ERROR: Could not find Book UUID for book named ${BOOK_NAME}"
+    exit 1
+  fi
 
-ssh ${USER}@${HOST} ${CMD}
+  >&2 echo "Fetching book ${BOOK_NAME} ${BOOK_UUID_AND_VER}"
 
->&2 echo "Step 2/2: Copying HTML file from server to local machine"
-scp ${USER}@${HOST}:${TEMP_HTML_PATH} ${RAW_PATH}
+  >&2 echo "Step 1/2: Generating an EPUB from the database and converting to a single HTML file (may take a minute)"
 
->&2 echo "Fetch is done. File is available at ${RAW_PATH}"
+  TEMP_EPUB_PATH="~/temp.intenral.epub"
+  TEMP_HTML_PATH="~/temp.html"
+
+  RM_TEMP_EPUB_CMD="[ -e ${TEMP_EPUB_PATH} ] && rm ${TEMP_EPUB_PATH}"
+  RM_TEMP_HTML_CMD="[ -e ${TEMP_HTML_PATH} ] && rm ${TEMP_HTML_PATH}"
+  GENERATE_EPUB_CMD="/var/cnx/venvs/publishing/bin/cnx-archive-export_epub /etc/cnx/publishing/app.ini ${BOOK_UUID_AND_VER} ${TEMP_EPUB_PATH}"
+  GENERATE_HTML_CMD="/var/cnx/venvs/publishing/bin/cnx-epub-single_html ${TEMP_EPUB_PATH} > ${TEMP_HTML_PATH}"
+
+  CMD="${RM_TEMP_EPUB_CMD}; ${RM_TEMP_HTML_CMD}; ${GENERATE_EPUB_CMD} && ${GENERATE_HTML_CMD}"
+
+  ssh ${USER}@${HOST} ${CMD}
+
+  >&2 echo "Step 2/2: Copying HTML file from server to local machine"
+  scp ${USER}@${HOST}:${TEMP_HTML_PATH} ${RAW_PATH}
+
+  >&2 echo "Fetch is done. File is available at ${RAW_PATH}"
+
+done

--- a/scripts/report-book-coverage
+++ b/scripts/report-book-coverage
@@ -27,31 +27,50 @@ do
   RAW_PATH="./data/${BOOK_NAME}-raw.html"
   LCOV_PATH="./data/${BOOK_NAME}.lcov"
 
-  if [ ! -f "${RAW_PATH}" ]
+  if [ -f "${RAW_PATH}" ]
   then
-    >&2 echo "ERROR: HTML File missing at ${RAW_PATH}"
-    exit 1
+
+    RULESET_NAME_AND_UUID=($(./scripts/_convert-bookname-to-ruleset-name-and-uuid ${BOOK_NAME}))
+    RULESET_NAME=${RULESET_NAME_AND_UUID[0]}
+
+    CSS_PATH="./books/rulesets/output/${RULESET_NAME}.css"
+
+    if [ ! -f "${CSS_PATH}" ]
+    then
+      >&2 echo "ERROR: CSS File missing at ${CSS_PATH}"
+      exit 1
+    fi
+
+    # Print out the message first because css-coverage will set
+    # a non-zero exit status if there are unused selectors
+    # and the `set -e` at the top of this script will exit at that point
+
+    if [ "${ARG1}" == "--all" ]
+    then
+      >&2 echo "Generating coverage for ${BOOK_NAME} in ${LCOV_PATH}"
+    else
+      >&2 echo "Coverage is being generated. To see an HTML version, run the following:"
+      >&2 echo "genhtml ${LCOV_PATH} --output-directory ./coverage"
+      >&2 echo "Note: to run this you may need to install genhtml. In OSX it is 'brew install lcov'"
+    fi
+
+    ./node_modules/.bin/css-coverage --css ${CSS_PATH} --html ${RAW_PATH} --lcov ${LCOV_PATH} ${DEBUG_FLAG1} ${DEBUG_FLAG2}
+
+  else
+    if [ "${ARG1}" == "--all" ]
+    then
+      >&2 echo "WARNING: Skipping ${BOOK_NAME} because HTML File is missing at ${RAW_PATH}"
+    else
+      >&2 echo "ERROR: HTML File missing at ${RAW_PATH}"
+      exit 1
+    fi
   fi
-
-  RULESET_NAME_AND_UUID=($(./scripts/_convert-bookname-to-ruleset-name-and-uuid ${BOOK_NAME}))
-  RULESET_NAME=${RULESET_NAME_AND_UUID[0]}
-
-  CSS_PATH="./books/rulesets/output/${RULESET_NAME}.css"
-
-  if [ ! -f "${CSS_PATH}" ]
-  then
-    >&2 echo "ERROR: CSS File missing at ${CSS_PATH}"
-    exit 1
-  fi
-
-  # Print out the message first because css-coverage will set
-  # a non-zero exit status if there are unused selectors
-  # and the `set -e` at the top of this script will exit at that point
-
-  >&2 echo "Coverage is being generated. To see an HTML version, run the following:"
-  >&2 echo "genhtml ${LCOV_PATH} --output-directory ./coverage"
-  >&2 echo "Note: to run this you may need to install genhtml. In OSX it is 'brew install lcov'"
-
-  ./node_modules/.bin/css-coverage --css ${CSS_PATH} --html ${RAW_PATH} --lcov ${LCOV_PATH} ${DEBUG_FLAG1} ${DEBUG_FLAG2}
 
 done
+
+if [ "${ARG1}" == "--all" ]
+then
+  >&2 echo "Generated coverage for ${BOOK_LIST}. To see an HTML version, run the following:"
+  >&2 echo "genhtml ./data/*.lcov --output-directory ./coverage"
+  >&2 echo "Note: to run this you may need to install genhtml. In OSX it is 'brew install lcov'"
+fi

--- a/scripts/report-book-coverage
+++ b/scripts/report-book-coverage
@@ -2,46 +2,56 @@
 set -e
 
 
-BOOK_NAME=$1
+ARG1=$1
 DEBUG_FLAG1=$2 # could be --debug or --verbose (or both)
 DEBUG_FLAG2=$3
 
-RAW_PATH="./data/${BOOK_NAME}-raw.html"
-LCOV_PATH="./data/${BOOK_NAME}.lcov"
-
 # Check command line args
 
-if [ -z "${BOOK_NAME}" ]
+if [ -z "${ARG1}" ]
 then
-  echo 'ERROR: Argument Missing. You must specify the name of the book as the 1st argument. For example: physics'
+  >&2 echo 'ERROR: Argument Missing. You must specify the name of the book as the 1st argument or --all for all books. For example: physics'
   exit 1
 fi
 
-if [ ! -f "${RAW_PATH}" ]
+if [ "${ARG1}" == "--all" ]
 then
-  echo "ERROR: HTML File missing at ${RAW_PATH}"
-  exit 1
+  source ./books.txt
+else
+  BOOK_LIST="${ARG1}"
 fi
 
-RULESET_NAME_AND_UUID=($(./scripts/_convert-bookname-to-ruleset-name-and-uuid ${BOOK_NAME}))
-RULESET_NAME=${RULESET_NAME_AND_UUID[0]}
+for BOOK_NAME in ${BOOK_LIST}
+do
 
-CSS_PATH="./books/rulesets/output/${RULESET_NAME}.css"
+  RAW_PATH="./data/${BOOK_NAME}-raw.html"
+  LCOV_PATH="./data/${BOOK_NAME}.lcov"
 
-if [ ! -f "${CSS_PATH}" ]
-then
-  echo "ERROR: CSS File missing at ${CSS_PATH}"
-  exit 1
-fi
+  if [ ! -f "${RAW_PATH}" ]
+  then
+    >&2 echo "ERROR: HTML File missing at ${RAW_PATH}"
+    exit 1
+  fi
 
+  RULESET_NAME_AND_UUID=($(./scripts/_convert-bookname-to-ruleset-name-and-uuid ${BOOK_NAME}))
+  RULESET_NAME=${RULESET_NAME_AND_UUID[0]}
 
+  CSS_PATH="./books/rulesets/output/${RULESET_NAME}.css"
 
-# Print out the message first because css-coverage will set
-# a non-zero exit status if there are unused selectors
-# and the `set -e` at the top of this script will exit at that point
+  if [ ! -f "${CSS_PATH}" ]
+  then
+    >&2 echo "ERROR: CSS File missing at ${CSS_PATH}"
+    exit 1
+  fi
 
-echo "Coverage is being generated. To see an HTML version, run the following:"
-echo "genhtml ${LCOV_PATH} --output-directory ./coverage"
-echo "Note: to run this you may need to install genhtml. In OSX it is 'brew install lcov'"
+  # Print out the message first because css-coverage will set
+  # a non-zero exit status if there are unused selectors
+  # and the `set -e` at the top of this script will exit at that point
 
-./node_modules/.bin/css-coverage --css ${CSS_PATH} --html ${RAW_PATH} --lcov ${LCOV_PATH} ${DEBUG_FLAG1} ${DEBUG_FLAG2}
+  >&2 echo "Coverage is being generated. To see an HTML version, run the following:"
+  >&2 echo "genhtml ${LCOV_PATH} --output-directory ./coverage"
+  >&2 echo "Note: to run this you may need to install genhtml. In OSX it is 'brew install lcov'"
+
+  ./node_modules/.bin/css-coverage --css ${CSS_PATH} --html ${RAW_PATH} --lcov ${LCOV_PATH} ${DEBUG_FLAG1} ${DEBUG_FLAG2}
+
+done


### PR DESCRIPTION
Adds ability to run the following:

- `./scripts/fetch-book --all` which updates all the books.
- `./scripts/report-book-coverage --all` generates CSS coverage of all fetched books

# Observations

`./scripts/report-book-coverage --all --cover-declarations` found several pieces of "dead code", either unused variables or selectors that never matched anything.

**Note:** Some of these might be elements that are created in one pass and then removed in another

## Unused Variables

![image](https://cloud.githubusercontent.com/assets/253202/19125004/678731c8-8b03-11e6-8461-bf0a5fd78a0f.png)

![image](https://cloud.githubusercontent.com/assets/253202/19125041/94d7bc42-8b03-11e6-8d3d-10fa54a22e4f.png)

## Unmatched Selectors

![image](https://cloud.githubusercontent.com/assets/253202/19125076/b37eddce-8b03-11e6-94f1-6bde33c2b28a.png)


# TODO

- [x] maybe use dennis' suggestions in #61

/cc @reedstrm 