### PR TITLE
adds commas between links in the index

### DIFF
--- a/books.txt
+++ b/books.txt
@@ -1,4 +1,4 @@
-BOOK_LIST="statistics statshigh econap macroecon macroeconap microecon microeconap TEAmacroeconap TEAmicroeconap"
+BOOK_LIST="statistics statshigh econ econap macroecon macroeconap microecon microeconap TEAmacroeconap TEAmicroeconap"
 
 statistics_uuid=30189442-6998-4686-ac05-ed152b91b9de
 statistics_ruleset_name=statistics
@@ -6,6 +6,8 @@ statistics_ruleset_name=statistics
 statshigh_uuid=ace2ec2d-778e-44aa-82c2-57a4e5c3de69
 statshigh_ruleset_name=statistics
 
+econ_uuid=69619d2b-68f0-44b0-b074-a9b2bf90b2c6
+econ_ruleset_name=economics
 
 econap_uuid=69619d2b-68f0-44b0-b074-a9b2bf90b2c6
 econap_ruleset_name=economics
@@ -34,7 +36,7 @@ TEAmicroeconap_ruleset_name=economics
 # without having to provide the UUID or which ruleset to use.
 
 
-
+# Economics: 69619d2b-68f0-44b0-b074-a9b2bf90b2c6@11.330
 # Principles of Macroeconomics for AP® Courses: 33076054-ec1d-4417-8824-ce354efe42d0@2.145
 # Macroeconomics: 4061c832-098e-4b3c-a1d9-7eb593a2cb31@10.235
 # Principles of Economics: 69619d2b-68f0-44b0-b074-a9b2bf90b2c6@11.330

--- a/books/rulesets/common/_compose.scss
+++ b/books/rulesets/common/_compose.scss
@@ -158,7 +158,7 @@
         // HACK: generate a span that only contains a space
         &::after {
           container: span;
-          content: ' ';
+          content: ',';
           class: "os-index-link-separator";
           move-to: index-section-link;
         }

--- a/books/rulesets/common/_compose.scss
+++ b/books/rulesets/common/_compose.scss
@@ -155,19 +155,19 @@
         }
         // Create a link next to the index term which points to the term in the book
         // Make sure there is a space between each link
-        // HACK: generate a span that only contains a space
-        &::after {
-          container: span;
-          content: ',';
-          class: "os-index-link-separator";
-          move-to: index-section-link;
-        }
+        // HACK: generate a span that only contains a comma and a space, the last-child one must be removed on the next pass. See modify_trash('.os-index-link-separator:last-child') in book.scss
         &::after {
           container: a;
           content: pending(index-section);
           attr-href: "#" attr(id);
           class: "os-term-section-link";
           move-to: index-section-link
+        }
+        &::after {
+          container: span;
+          content: ', ';
+          class: "os-index-link-separator";
+          move-to: index-section-link;
         }
         &::after {
           content: pending(index-term) pending(index-section-link);

--- a/books/rulesets/common/_compose.scss
+++ b/books/rulesets/common/_compose.scss
@@ -154,6 +154,14 @@
           move-to: index-section;
         }
         // Create a link next to the index term which points to the term in the book
+        // Make sure there is a space between each link
+        // HACK: generate a span that only contains a space
+        &::after {
+          container: span;
+          content: ' ';
+          class: "os-index-link-separator";
+          move-to: index-section-link;
+        }
         &::after {
           container: a;
           content: pending(index-section);

--- a/books/rulesets/common/examples/_all.scss
+++ b/books/rulesets/common/examples/_all.scss
@@ -188,6 +188,15 @@
   Style guide: book.glossary
 */
 
+/*
+  Book Index
+
+  The book Index contains terms and links to their occurences in the book.
+
+  Markup: ./book.index.html-cooked.html
+
+  Style guide: book.index
+*/
 
 
 /*

--- a/books/rulesets/common/examples/book.index.html
+++ b/books/rulesets/common/examples/book.index.html
@@ -1,0 +1,15 @@
+<div data-type="chapter">
+  <h1 data-type="document-title">Chapter Title</h1>
+  <div data-type="page">
+    <div data-type="document-title">Velocity Page</div>
+    Normal book content goes here with a <span data-type="term">Term1</span> and
+    <span data-type="term">Term2</span>
+
+  </div>
+
+  <div data-type="page">
+    <div data-type="document-title">Acceleration Page</div>
+    Normal book content goes here with a <span data-type="term">Term1</span>
+
+  </div>
+</div>

--- a/books/rulesets/economics/book.scss
+++ b/books/rulesets/economics/book.scss
@@ -91,6 +91,7 @@
   @include modify_retitleHeaders();
 }
 :pass(6) {
+  @include modify_trash('.os-index-link-separator:last-child');
   @include modify_retitleCompositeMetadata();
 }
 :pass(7) {

--- a/books/rulesets/output/economics.css
+++ b/books/rulesets/output/economics.css
@@ -595,15 +595,15 @@
   class: "os-term-section";
   move-to: index-section; }
 :pass(2) div[data-type="page"] span[data-type="term"]::after, :pass(2) div[data-type="composite-page"] span[data-type="term"]::after {
-  container: span;
-  content: ' ';
-  class: "os-index-link-separator";
-  move-to: index-section-link; }
-:pass(2) div[data-type="page"] span[data-type="term"]::after, :pass(2) div[data-type="composite-page"] span[data-type="term"]::after {
   container: a;
   content: pending(index-section);
   attr-href: "#" attr(id);
   class: "os-term-section-link";
+  move-to: index-section-link; }
+:pass(2) div[data-type="page"] span[data-type="term"]::after, :pass(2) div[data-type="composite-page"] span[data-type="term"]::after {
+  container: span;
+  content: ', ';
+  class: "os-index-link-separator";
   move-to: index-section-link; }
 :pass(2) div[data-type="page"] span[data-type="term"]::after, :pass(2) div[data-type="composite-page"] span[data-type="term"]::after {
   content: pending(index-term) pending(index-section-link);
@@ -941,6 +941,8 @@
   class: "os-subtitle";
   container: h4; }
 
+:pass(6) .os-index-link-separator:last-child {
+  move-to: trash; }
 :pass(6) [data-type="composite-page"] > [data-type="document-title"] {
   string-set: doc-title-TOMETADATA content(); }
 :pass(6) [data-type="composite-page"] > [data-type="metadata"] > [data-type="document-title"] {

--- a/books/rulesets/output/economics.css
+++ b/books/rulesets/output/economics.css
@@ -162,6 +162,15 @@
   Style guide: book.glossary
 */
 /*
+  Book Index
+
+  The book Index contains terms and links to their occurences in the book.
+
+  Markup: ./book.index.html-cooked.html
+
+  Style guide: book.index
+*/
+/*
   Table
 
   The `table` element may contain a `caption`, `tbody`, `col`, and other _usual_ elements.
@@ -585,6 +594,11 @@
   container: span;
   class: "os-term-section";
   move-to: index-section; }
+:pass(2) div[data-type="page"] span[data-type="term"]::after, :pass(2) div[data-type="composite-page"] span[data-type="term"]::after {
+  container: span;
+  content: ' ';
+  class: "os-index-link-separator";
+  move-to: index-section-link; }
 :pass(2) div[data-type="page"] span[data-type="term"]::after, :pass(2) div[data-type="composite-page"] span[data-type="term"]::after {
   container: a;
   content: pending(index-section);

--- a/books/rulesets/output/statistics.css
+++ b/books/rulesets/output/statistics.css
@@ -161,6 +161,15 @@
   Style guide: book.glossary
 */
 /*
+  Book Index
+
+  The book Index contains terms and links to their occurences in the book.
+
+  Markup: ./book.index.html-cooked.html
+
+  Style guide: book.index
+*/
+/*
   Table
 
   The `table` element may contain a `caption`, `tbody`, `col`, and other _usual_ elements.
@@ -527,6 +536,11 @@
   container: span;
   class: "os-term-section";
   move-to: index-section; }
+:pass(2) div[data-type="page"] span[data-type="term"]::after, :pass(2) div[data-type="composite-page"] span[data-type="term"]::after {
+  container: span;
+  content: ' ';
+  class: "os-index-link-separator";
+  move-to: index-section-link; }
 :pass(2) div[data-type="page"] span[data-type="term"]::after, :pass(2) div[data-type="composite-page"] span[data-type="term"]::after {
   container: a;
   content: pending(index-section);

--- a/books/rulesets/output/statistics.css
+++ b/books/rulesets/output/statistics.css
@@ -537,15 +537,15 @@
   class: "os-term-section";
   move-to: index-section; }
 :pass(2) div[data-type="page"] span[data-type="term"]::after, :pass(2) div[data-type="composite-page"] span[data-type="term"]::after {
-  container: span;
-  content: ' ';
-  class: "os-index-link-separator";
-  move-to: index-section-link; }
-:pass(2) div[data-type="page"] span[data-type="term"]::after, :pass(2) div[data-type="composite-page"] span[data-type="term"]::after {
   container: a;
   content: pending(index-section);
   attr-href: "#" attr(id);
   class: "os-term-section-link";
+  move-to: index-section-link; }
+:pass(2) div[data-type="page"] span[data-type="term"]::after, :pass(2) div[data-type="composite-page"] span[data-type="term"]::after {
+  container: span;
+  content: ', ';
+  class: "os-index-link-separator";
   move-to: index-section-link; }
 :pass(2) div[data-type="page"] span[data-type="term"]::after, :pass(2) div[data-type="composite-page"] span[data-type="term"]::after {
   content: pending(index-term) pending(index-section-link);
@@ -841,6 +841,8 @@
   container: div;
   content: content() pending(bCaptionContainer); }
 
+:pass(6) .os-index-link-separator:last-child {
+  move-to: trash; }
 :pass(6) [data-type="composite-page"] > [data-type="document-title"] {
   string-set: doc-title-TOMETADATA content(); }
 :pass(6) [data-type="composite-page"] > [data-type="metadata"] > [data-type="document-title"] {

--- a/books/rulesets/statistics/book.scss
+++ b/books/rulesets/statistics/book.scss
@@ -101,6 +101,7 @@
   @include number_setCaptions($setFigureCaption, $captionFigNumber, $captionFigNumberAp);
 }
 :pass(6) {
+  @include modify_trash('.os-index-link-separator:last-child');
   @include modify_retitleCompositeMetadata();
 }
 :pass(7) {


### PR DESCRIPTION
Previously, links in the index were smushed together; this adds a space between each link.

![image](https://cloud.githubusercontent.com/assets/253202/19251117/b344f2b0-8f0b-11e6-900e-630959bfbb97.png)


/cc @reedstrm : Is there a way to add a space character to a bucket without creating an element (like via `container: none;`)?

Also, I have a feeling people would prefer each link to be separated by a comma instead of a space. That would require prefixing a comma to each link _except_ the first link; I'm not sure how to do that within `cnx-recipes`