### PR TITLE
remove unused python packages

### DIFF
--- a/scripts/ci
+++ b/scripts/ci
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 # Run the tests (which happens to re-generate the CSS files)

--- a/scripts/setup
+++ b/scripts/setup
@@ -12,10 +12,7 @@ virtualenv .
 echo "Step 3/4: Installing python packages"
 
 pip install --quiet git+https://github.com/Connexions/cssselect2.git
-pip install --quiet git+https://github.com/Connexions/rhaptos.cnxmlutils.git
-pip install --quiet git+https://github.com/Connexions/cnx-archive.git
 pip install --quiet git+https://github.com/Connexions/cnx-easybake.git
-pip install --quiet git+https://github.com/Connexions/cnx-epub.git
 
 deactivate
 

--- a/scripts/update
+++ b/scripts/update
@@ -20,10 +20,7 @@ pip uninstall --quiet --yes cnx-epub
 echo 'Step 3/4: Reinstalling python packages'
 
 pip install --quiet git+https://github.com/Connexions/cssselect2.git
-pip install --quiet git+https://github.com/Connexions/rhaptos.cnxmlutils.git
-pip install --quiet git+https://github.com/Connexions/cnx-archive.git
 pip install --quiet git+https://github.com/Connexions/cnx-easybake.git
-pip install --quiet git+https://github.com/Connexions/cnx-epub.git
 
 deactivate
 


### PR DESCRIPTION
It seems these packages are no longer used in any of the scripts. I think this is because the cnx-epub work is done on the deployed dev machine rather than locally but I'm not 💯 % sure.

/cc @reedstrm 