### PR TITLE
finds broken internal links in books

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,12 @@ This will run the linter, generate sassdocs, and generate the guides to verify t
 ### Find broken links
 
 1. run `./scripts/bake-book ${BOOK_NAME}` to generate the cooked book
-1. run `./scripts/find-broken-links ${BOOK_NAME}` to find broken links in the cooked book or add `--type raw` to find broken links in the raw book.
+1. run `./scripts/find-broken-links ${BOOK_NAME}` to find broken links in the cooked book
+
+Notes:
+
+- add `--type raw` to find broken links in the raw book
+- add `--verbose` to see warning messages as well as errors
 
 # Documentation
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ Sometimes you need to add a new book (like "dark-matter-for-dummies") into this 
 
 This will run the linter, generate sassdocs, and generate the guides to verify they work.
 
+### Find broken links
+
+1. run `./scripts/bake-book ${BOOK_NAME}` to generate the cooked book
+1. run `./scripts/find-broken-links ${BOOK_NAME}` to find broken links in the cooked book or add `--type raw` to find broken links in the raw book.
+
 # Documentation
 
 1. run `./scripts/generate-docs` to generate the SASS Docs

--- a/package.json
+++ b/package.json
@@ -1,9 +1,11 @@
 {
   "devDependencies": {
     "css-coverage": "~0.1.0",
+    "jsdom": "^9.8.0",
     "kss": "^2.4.0",
     "sass-lint": "^1.9.1",
-    "sassdoc": "^2.1.20"
+    "sassdoc": "^2.1.20",
+    "yargs": "^6.2.0"
   },
   "scripts": {
     "test": "sass-lint --verbose"

--- a/scripts/find-broken-links
+++ b/scripts/find-broken-links
@@ -19,6 +19,16 @@ console.log(`Checking ${htmlPath}`)
 
 var html = fs.readFileSync(htmlPath, 'utf-8')
 
+function generateSelector(el) {
+  if (el.hasAttribute('id')) {
+    return `${el.tagName.toLowerCase()}#${el.getAttribute('id')}`
+  } else if (el.className) {
+    return `${generateSelector(el.parentNode)} > ${el.tagName.toLowerCase()}.${el.className.split(' ').join('.')}` // Replace spaces with dots
+  } else {
+    return `${generateSelector(el.parentNode)} > ${el.tagName.toLowerCase()}`
+  }
+}
+
 jsdom.env(html, [], function(err, window) {
   var errorCount = 0 // Used for exit status
   var links = window.document.querySelectorAll('a[href]')
@@ -28,7 +38,7 @@ jsdom.env(html, [], function(err, window) {
       var target = window.document.getElementById(href.replace('#', ''))
       if (!target) {
         errorCount += 1
-        console.error(`Broken internal link: a[href]="${href}" link-text="${link.textContent}"`)
+        console.error(`Broken internal link: a[href]="${href}" selector="${generateSelector(link)}" link-text="${link.textContent}"`)
       }
     } else {
       // TODO: verify external links

--- a/scripts/find-broken-links
+++ b/scripts/find-broken-links
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+
+'use strict'
+
+var fs = require('fs')
+var path = require('path')
+var jsdom = require('jsdom')
+var argv = require('yargs')
+  .demand(['b'])
+  .alias('b', 'book')
+  .alias('t', 'type')
+  .describe('b', 'Book name (from books.txt)')
+  .describe('t', 'Type (raw or cooked)')
+  .default('t', 'cooked')
+  .argv
+
+var html = fs.readFileSync(path.join(__dirname, `../data/${argv.b}-${argv.t}.html`), 'utf-8')
+
+jsdom.env(html, [], function(err, window) {
+  var errorCount = 0 // Used for exit status
+  var links = window.document.querySelectorAll('a[href]')
+  for (var link of links) {
+    var href = link.getAttribute('href')
+    if (/^#/.test(href)) { // check if the href begins with a # (an internal link)
+      var target = window.document.getElementById(href.replace('#', ''))
+      if (!target) {
+        errorCount += 1
+        console.error(`Broken internal link: a[href]="${href}" link-text="${link.textContent}"`)
+      }
+    } else {
+      // TODO: verify external links
+    }
+  }
+  process.exit(errorCount)
+
+});

--- a/scripts/find-broken-links
+++ b/scripts/find-broken-links
@@ -14,7 +14,10 @@ var argv = require('yargs')
   .default('t', 'cooked')
   .argv
 
-var html = fs.readFileSync(path.join(__dirname, `../data/${argv.b}-${argv.t}.html`), 'utf-8')
+var htmlPath = path.join(__dirname, `../data/${argv.b}-${argv.t}.html`)
+console.log(`Checking ${htmlPath}`)
+
+var html = fs.readFileSync(htmlPath, 'utf-8')
 
 jsdom.env(html, [], function(err, window) {
   var errorCount = 0 // Used for exit status

--- a/scripts/find-broken-links
+++ b/scripts/find-broken-links
@@ -9,8 +9,10 @@ var argv = require('yargs')
   .demand(['b'])
   .alias('b', 'book')
   .alias('t', 'type')
+  .alias('v', 'verbose')
   .describe('b', 'Book name (from books.txt)')
   .describe('t', 'Type (raw or cooked)')
+  .describe('v', 'Verbose (output warnings as well as Errors)')
   .default('t', 'cooked')
   .argv
 
@@ -20,7 +22,7 @@ console.log(`Checking ${htmlPath}`)
 var html = fs.readFileSync(htmlPath, 'utf-8')
 
 function generateSelector(el) {
-  if (el.hasAttribute('id')) {
+  if (el.getAttribute('id')) {
     return `${el.tagName.toLowerCase()}#${el.getAttribute('id')}`
   } else if (el.className) {
     return `${generateSelector(el.parentNode)} > ${el.tagName.toLowerCase()}.${el.className.split(' ').join('.')}` // Replace spaces with dots
@@ -35,10 +37,20 @@ jsdom.env(html, [], function(err, window) {
   for (var link of links) {
     var href = link.getAttribute('href')
     if (/^#/.test(href)) { // check if the href begins with a # (an internal link)
-      var target = window.document.getElementById(href.replace('#', ''))
-      if (!target) {
+      var targetId = href.replace('#', '')
+      var target = window.document.getElementById(targetId)
+      if (!targetId) {
         errorCount += 1
-        console.error(`Broken internal link: a[href]="${href}" selector="${generateSelector(link)}" link-text="${link.textContent}"`)
+        console.error(`ERROR: Empty internal link: a[href]="${href}" selector="${generateSelector(link)}" link-text="${link.textContent}"`)
+      } else if (!target) {
+        // Check if there is an anchor with a name attribute
+        if (window.document.querySelectorAll(`a[name="${targetId}"]`)) {
+          if (argv.v)
+          console.warn(`WARN: Consider using an id attribute instead of a[name]. Found in name="${targetId}" selector="${generateSelector(link)}" link-text="${link.textContent}"`)
+        } else {
+          errorCount += 1
+          console.error(`ERROR: Broken internal link: a[href]="${href}" selector="${generateSelector(link)}" link-text="${link.textContent}"`)
+        }
       }
     } else {
       // TODO: verify external links


### PR DESCRIPTION
(refs #81)

### Find broken links

1. run `./scripts/bake-book ${BOOK_NAME}` to generate the cooked book
1. run `./scripts/find-broken-links ${BOOK_NAME}` to find broken links in the cooked book or add `--type raw` to find broken links in the raw book.


# Example

```
./scripts/find-broken-links --book statshigh
Checking /Users/phil/github/cnx/cnx-recipes/data/statshigh-cooked.html
ERROR: Empty internal link: a[href]="#" selector="div#auto_340ffb0f-e0a3-408b-830d-f92a6517a458@2_fs-idm78922624 > div > a" link-text="1.1"
ERROR: Empty internal link: a[href]="#" selector="div#auto_340ffb0f-e0a3-408b-830d-f92a6517a458@2_fs-idm17652592 > div > a" link-text="1.2"
ERROR: Empty internal link: a[href]="#" selector="div#auto_340ffb0f-e0a3-408b-830d-f92a6517a458@2_fs-idm69138080 > div > a" link-text="1.3"
ERROR: Empty internal link: a[href]="#" selector="div#auto_340ffb0f-e0a3-408b-830d-f92a6517a458@2_fs-idm36890624 > div > a" link-text="1.4"
ERROR: Empty internal link: a[href]="#" selector="div#auto_9342209a-9d01-4e77-aead-49e2df3b2abd@4_eip-idp9281200 > div > a" link-text="1.7"
```