### PR TITLE
Add unnumbered support to tables and figures

### DIFF
--- a/books/rulesets/common/_number.scss
+++ b/books/rulesets/common/_number.scss
@@ -109,18 +109,7 @@
       @include utils_title($labeling, bCaption);
       @include setCaptionsHelper($type, $defaultContainer, $hasCaption, $hasTitle);
     }
-    :not(#{$type}) > #{$type}.unnumbered {
-      @if ($type == "table") {
-        caption {
-          move-to: trash;
-        }
-      }
-      @if ($type == "figure") {
-        figcaption {
-          move-to: trash;
-        }
-      }
-    }
+    @include trashUnnumberedCaption($type);
   }
 
   .appendix {
@@ -128,16 +117,20 @@
       @include utils_title($labelingAp, bCaption);
       @include setCaptionsHelper($type, $defaultContainer, $hasCaption, $hasTitle);
     }
-    :not(#{$type}) > #{$type}.unnumbered {
-      @if ($type == "table") {
-        caption {
-          move-to: trash;
-        }
+    @include trashUnnumberedCaption($type);
+  }
+}
+
+@mixin trashUnnumberedCaption ($type) {
+  :not(#{$type}) > #{$type}.unnumbered {
+    @if ($type == "table") {
+      caption {
+        move-to: trash;
       }
-      @if ($type == "figure") {
-        figcaption {
-          move-to: trash;
-        }
+    }
+    @if ($type == "figure") {
+      figcaption {
+        move-to: trash;
       }
     }
   }

--- a/books/rulesets/common/_number.scss
+++ b/books/rulesets/common/_number.scss
@@ -104,17 +104,41 @@
   $hasCaption: map-get($setFigTableCaptions, hasCaption);
   $hasTitle: map-get($setFigTableCaptions, hasTitle);
 
-
   [data-type="chapter"] {
-    :not(#{$type}) > #{$type} {
+    :not(#{$type}) > #{$type}:not(.unnumbered) {
       @include utils_title($labeling, bCaption);
       @include setCaptionsHelper($type, $defaultContainer, $hasCaption, $hasTitle);
     }
+    :not(#{$type}) > #{$type}.unnumbered {
+      @if ($type == "table") {
+        caption {
+          move-to: trash;
+        }
+      }
+      @if ($type == "figure") {
+        figcaption {
+          move-to: trash;
+        }
+      }
+    }
   }
+
   .appendix {
-    :not(#{$type}) > #{$type} {
+    :not(#{$type}) > #{$type}:not(.unnumbered) {
       @include utils_title($labelingAp, bCaption);
       @include setCaptionsHelper($type, $defaultContainer, $hasCaption, $hasTitle);
+    }
+    :not(#{$type}) > #{$type}.unnumbered {
+      @if ($type == "table") {
+        caption {
+          move-to: trash;
+        }
+      }
+      @if ($type == "figure") {
+        figcaption {
+          move-to: trash;
+        }
+      }
     }
   }
 }
@@ -129,14 +153,14 @@
     }
   }
   @if ($hasTitle) {
-    @if $type == "table" {
+    @if ($type == "table") {
       #{$defaultContainer} [data-type="title"] {
         container: span;
         class: "os-title";
         move-to: bCaption;
       }
     }
-    @if $type == "figure" {
+    @if ($type == "figure") {
       [data-type="title"] {
         container: span;
         class: "os-title";

--- a/books/rulesets/common/examples/_all.scss
+++ b/books/rulesets/common/examples/_all.scss
@@ -254,13 +254,14 @@
 /*
   Unnumbered Content
 
-  Content that has been marked with the class .unnumbered by the content team.
+  Content that has been marked with the class `.unnumbered` by the content team.
 
-  This may apply to a note, a table, an equation, a figure. Currently, the ruleset supports only tables and figures
+  Currently, the ruleset supports only tables and figures but
+  this may apply to a note, a table, an equation, a figure. 
 
-  Markup: ./book.unnumbered.html-cooked.html
+  Markup: ./page.unnumbered.html-cooked.html
 
-  Style guide: book.unnumbered
+  Style guide: page.unnumbered
 */
 
 //x=new Set(Array.prototype.slice.call(document.querySelectorAll('*')).map(function(el) { if (el.getAttribute('data-type')) { return "[data-type='" + el.getAttribute('data-type') + "']"; } else if (el.className) {return el.tagName.toLowerCase() + "." + el.className.split(' ').join('.') } else {return el.tagName.toLowerCase()} }))

--- a/books/rulesets/common/examples/_all.scss
+++ b/books/rulesets/common/examples/_all.scss
@@ -251,6 +251,18 @@
   Style guide: book.chapter
 */
 
+/*
+  Unnumbered Content
+
+  Content that has been marked with the class .unnumbered by the content team.
+  T
+  This may apply to a note, a table, an equation, a figure. Currently, the ruleset supports only tables and figures
+
+  Markup: ./book.unnumbered.html-cooked.html
+
+  Style guide: book.unnumbered
+*/
+
 //x=new Set(Array.prototype.slice.call(document.querySelectorAll('*')).map(function(el) { if (el.getAttribute('data-type')) { return "[data-type='" + el.getAttribute('data-type') + "']"; } else if (el.className) {return el.tagName.toLowerCase() + "." + el.className.split(' ').join('.') } else {return el.tagName.toLowerCase()} }))
 
 

--- a/books/rulesets/common/examples/_all.scss
+++ b/books/rulesets/common/examples/_all.scss
@@ -255,7 +255,7 @@
   Unnumbered Content
 
   Content that has been marked with the class .unnumbered by the content team.
-  T
+
   This may apply to a note, a table, an equation, a figure. Currently, the ruleset supports only tables and figures
 
   Markup: ./book.unnumbered.html-cooked.html

--- a/books/rulesets/common/examples/book.unnumbered.html
+++ b/books/rulesets/common/examples/book.unnumbered.html
@@ -1,9 +1,0 @@
-<table class="unnumbered key-terms" data-label=""  summary="The list of Key Terms includes: atom, classical physics, modern physics, physics, quantum mechanics, and theory of relativity.">
-  <caption><span data-type="title">Section Key Terms</span></caption>
-  <tbody>
-    <tr>
-      <td>Some</td>
-      <td>content</td>
-    </tr>
-  </tbody>
-</table>

--- a/books/rulesets/common/examples/book.unnumbered.html
+++ b/books/rulesets/common/examples/book.unnumbered.html
@@ -1,0 +1,9 @@
+<table class="unnumbered key-terms" data-label=""  summary="The list of Key Terms includes: atom, classical physics, modern physics, physics, quantum mechanics, and theory of relativity.">
+  <caption><span data-type="title">Section Key Terms</span></caption>
+  <tbody>
+    <tr>
+      <td>Some</td>
+      <td>content</td>
+    </tr>
+  </tbody>
+</table>

--- a/books/rulesets/common/examples/page.unnumbered.html
+++ b/books/rulesets/common/examples/page.unnumbered.html
@@ -1,0 +1,27 @@
+<div data-type="chapter">
+  <div data-type="page">
+
+    <!-- Markup starts here -->
+    <table class="unnumbered" data-label="">
+      <caption><span data-type="title">Section Key Terms</span></caption>
+      <tbody>
+        <tr>
+          <td>Some</td>
+          <td>content</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <figure class="unnumbered">
+      <div data-type="title">U.S. Minimum Wage and Inflation </div>
+      <div data-type="media">
+        <img
+          src="https://cnx.org/resources/d47864c2ac77d80b1f2ff4c4c7f1b2059669e3e9/Figure_01_00_01.jpg"
+          alt="The spiral galaxy Andromeda"
+        />
+      </div>
+      <figcaption>The Andromeda Galaxy is one of many spiral galaxies...</figcaption>
+    </figure>
+
+  </div>
+</div>

--- a/books/rulesets/output/economics.css
+++ b/books/rulesets/output/economics.css
@@ -217,6 +217,18 @@
 
   Style guide: book.chapter
 */
+/*
+  Unnumbered Content
+
+  Content that has been marked with the class `.unnumbered` by the content team.
+
+  Currently, the ruleset supports only tables and figures but
+  this may apply to a note, a table, an equation, a figure. 
+
+  Markup: ./page.unnumbered.html-cooked.html
+
+  Style guide: page.unnumbered
+*/
 /*==========================================================
   ECONOMICS PAGES
 ==========================================================*/

--- a/books/rulesets/output/economics.css
+++ b/books/rulesets/output/economics.css
@@ -827,114 +827,122 @@
   counter-reset: figure; }
 :pass(5) :not(figure) > figure {
   counter-increment: figure; }
-:pass(5) [data-type="chapter"] :not(table) > table::before {
+:pass(5) [data-type="chapter"] :not(table) > table:not(.unnumbered)::before {
   container: span;
   content: "Table ";
   class: os-title-label;
   move-to: bCaption; }
-:pass(5) [data-type="chapter"] :not(table) > table::before {
+:pass(5) [data-type="chapter"] :not(table) > table:not(.unnumbered)::before {
   container: span;
   content: counter(chapter) "." counter(table);
   class: os-number;
   move-to: bCaption; }
-:pass(5) [data-type="chapter"] :not(table) > table caption {
+:pass(5) [data-type="chapter"] :not(table) > table:not(.unnumbered) caption {
   container: span;
   class: "os-caption";
   move-to: bCaption; }
-:pass(5) [data-type="chapter"] :not(table) > table caption [data-type="title"] {
+:pass(5) [data-type="chapter"] :not(table) > table:not(.unnumbered) caption [data-type="title"] {
   container: span;
   class: "os-title";
   move-to: bCaption; }
-:pass(5) [data-type="chapter"] :not(table) > table::after {
+:pass(5) [data-type="chapter"] :not(table) > table:not(.unnumbered)::after {
   container: div;
   class: "os-caption-container";
   content: pending(bCaption);
   move-to: bCaptionContainer; }
-:pass(5) [data-type="chapter"] :not(table) > table::outside {
+:pass(5) [data-type="chapter"] :not(table) > table:not(.unnumbered)::outside {
   class: os-table;
   container: div;
   content: content() pending(bCaptionContainer); }
-:pass(5) .appendix :not(table) > table::before {
+:pass(5) [data-type="chapter"] :not(table) > table.unnumbered caption {
+  move-to: trash; }
+:pass(5) .appendix :not(table) > table:not(.unnumbered)::before {
   container: span;
   content: "Table ";
   class: os-title-label;
   move-to: bCaption; }
-:pass(5) .appendix :not(table) > table::before {
+:pass(5) .appendix :not(table) > table:not(.unnumbered)::before {
   container: span;
   content: counter(appendix,upper-alpha) "." counter(table);
   class: os-number;
   move-to: bCaption; }
-:pass(5) .appendix :not(table) > table caption {
+:pass(5) .appendix :not(table) > table:not(.unnumbered) caption {
   container: span;
   class: "os-caption";
   move-to: bCaption; }
-:pass(5) .appendix :not(table) > table caption [data-type="title"] {
+:pass(5) .appendix :not(table) > table:not(.unnumbered) caption [data-type="title"] {
   container: span;
   class: "os-title";
   move-to: bCaption; }
-:pass(5) .appendix :not(table) > table::after {
+:pass(5) .appendix :not(table) > table:not(.unnumbered)::after {
   container: div;
   class: "os-caption-container";
   content: pending(bCaption);
   move-to: bCaptionContainer; }
-:pass(5) .appendix :not(table) > table::outside {
+:pass(5) .appendix :not(table) > table:not(.unnumbered)::outside {
   class: os-table;
   container: div;
   content: content() pending(bCaptionContainer); }
-:pass(5) [data-type="chapter"] :not(figure) > figure::before {
+:pass(5) .appendix :not(table) > table.unnumbered caption {
+  move-to: trash; }
+:pass(5) [data-type="chapter"] :not(figure) > figure:not(.unnumbered)::before {
   container: span;
   content: "Figure ";
   class: os-title-label;
   move-to: bCaption; }
-:pass(5) [data-type="chapter"] :not(figure) > figure::before {
+:pass(5) [data-type="chapter"] :not(figure) > figure:not(.unnumbered)::before {
   container: span;
   content: counter(chapter) "." counter(figure);
   class: os-number;
   move-to: bCaption; }
-:pass(5) [data-type="chapter"] :not(figure) > figure figcaption {
+:pass(5) [data-type="chapter"] :not(figure) > figure:not(.unnumbered) figcaption {
   container: span;
   class: "os-caption";
   move-to: bCaption; }
-:pass(5) [data-type="chapter"] :not(figure) > figure [data-type="title"] {
+:pass(5) [data-type="chapter"] :not(figure) > figure:not(.unnumbered) [data-type="title"] {
   container: span;
   class: "os-title";
   move-to: bCaption; }
-:pass(5) [data-type="chapter"] :not(figure) > figure::after {
+:pass(5) [data-type="chapter"] :not(figure) > figure:not(.unnumbered)::after {
   container: div;
   class: "os-caption-container";
   content: pending(bCaption);
   move-to: bCaptionContainer; }
-:pass(5) [data-type="chapter"] :not(figure) > figure::outside {
+:pass(5) [data-type="chapter"] :not(figure) > figure:not(.unnumbered)::outside {
   class: os-figure;
   container: div;
   content: content() pending(bCaptionContainer); }
-:pass(5) .appendix :not(figure) > figure::before {
+:pass(5) [data-type="chapter"] :not(figure) > figure.unnumbered figcaption {
+  move-to: trash; }
+:pass(5) .appendix :not(figure) > figure:not(.unnumbered)::before {
   container: span;
   content: "Figure ";
   class: os-title-label;
   move-to: bCaption; }
-:pass(5) .appendix :not(figure) > figure::before {
+:pass(5) .appendix :not(figure) > figure:not(.unnumbered)::before {
   container: span;
   content: counter(appendix,upper-alpha) "." counter(figure);
   class: os-number;
   move-to: bCaption; }
-:pass(5) .appendix :not(figure) > figure figcaption {
+:pass(5) .appendix :not(figure) > figure:not(.unnumbered) figcaption {
   container: span;
   class: "os-caption";
   move-to: bCaption; }
-:pass(5) .appendix :not(figure) > figure [data-type="title"] {
+:pass(5) .appendix :not(figure) > figure:not(.unnumbered) [data-type="title"] {
   container: span;
   class: "os-title";
   move-to: bCaption; }
-:pass(5) .appendix :not(figure) > figure::after {
+:pass(5) .appendix :not(figure) > figure:not(.unnumbered)::after {
   container: div;
   class: "os-caption-container";
   content: pending(bCaption);
   move-to: bCaptionContainer; }
-:pass(5) .appendix :not(figure) > figure::outside {
+:pass(5) .appendix :not(figure) > figure:not(.unnumbered)::outside {
   class: os-figure;
   container: div;
   content: content() pending(bCaptionContainer); }
+:pass(5) .appendix :not(figure) > figure.unnumbered figcaption {
+  move-to: trash; }
 :pass(5) [data-type="chapter"] [data-type="page"] [data-type="note"] > .os-title {
   container: h3; }
 :pass(5) [data-type="chapter"] [data-type="page"] [data-type="note"] .os-body > [data-type="title"] {

--- a/books/rulesets/output/statistics.css
+++ b/books/rulesets/output/statistics.css
@@ -748,98 +748,106 @@
   counter-reset: figure; }
 :pass(5) :not(figure) > figure {
   counter-increment: figure; }
-:pass(5) [data-type="chapter"] :not(table) > table::before {
+:pass(5) [data-type="chapter"] :not(table) > table:not(.unnumbered)::before {
   container: span;
   content: "Table ";
   class: os-title-label;
   move-to: bCaption; }
-:pass(5) [data-type="chapter"] :not(table) > table::before {
+:pass(5) [data-type="chapter"] :not(table) > table:not(.unnumbered)::before {
   container: span;
   content: counter(chapter) "." counter(table);
   class: os-number;
   move-to: bCaption; }
-:pass(5) [data-type="chapter"] :not(table) > table caption [data-type="title"] {
+:pass(5) [data-type="chapter"] :not(table) > table:not(.unnumbered) caption [data-type="title"] {
   container: span;
   class: "os-title";
   move-to: bCaption; }
-:pass(5) [data-type="chapter"] :not(table) > table::after {
+:pass(5) [data-type="chapter"] :not(table) > table:not(.unnumbered)::after {
   container: div;
   class: "os-caption-container";
   content: pending(bCaption);
   move-to: bCaptionContainer; }
-:pass(5) [data-type="chapter"] :not(table) > table::outside {
+:pass(5) [data-type="chapter"] :not(table) > table:not(.unnumbered)::outside {
   class: os-table;
   container: div;
   content: content() pending(bCaptionContainer); }
-:pass(5) .appendix :not(table) > table::before {
+:pass(5) [data-type="chapter"] :not(table) > table.unnumbered caption {
+  move-to: trash; }
+:pass(5) .appendix :not(table) > table:not(.unnumbered)::before {
   container: span;
   content: "Table ";
   class: os-title-label;
   move-to: bCaption; }
-:pass(5) .appendix :not(table) > table::before {
+:pass(5) .appendix :not(table) > table:not(.unnumbered)::before {
   container: span;
   content: counter(appendix,upper-alpha) "." counter(table);
   class: os-number;
   move-to: bCaption; }
-:pass(5) .appendix :not(table) > table caption [data-type="title"] {
+:pass(5) .appendix :not(table) > table:not(.unnumbered) caption [data-type="title"] {
   container: span;
   class: "os-title";
   move-to: bCaption; }
-:pass(5) .appendix :not(table) > table::after {
+:pass(5) .appendix :not(table) > table:not(.unnumbered)::after {
   container: div;
   class: "os-caption-container";
   content: pending(bCaption);
   move-to: bCaptionContainer; }
-:pass(5) .appendix :not(table) > table::outside {
+:pass(5) .appendix :not(table) > table:not(.unnumbered)::outside {
   class: os-table;
   container: div;
   content: content() pending(bCaptionContainer); }
-:pass(5) [data-type="chapter"] :not(figure) > figure::before {
+:pass(5) .appendix :not(table) > table.unnumbered caption {
+  move-to: trash; }
+:pass(5) [data-type="chapter"] :not(figure) > figure:not(.unnumbered)::before {
   container: span;
   content: "Figure ";
   class: os-title-label;
   move-to: bCaption; }
-:pass(5) [data-type="chapter"] :not(figure) > figure::before {
+:pass(5) [data-type="chapter"] :not(figure) > figure:not(.unnumbered)::before {
   container: span;
   content: counter(chapter) "." counter(figure);
   class: os-number;
   move-to: bCaption; }
-:pass(5) [data-type="chapter"] :not(figure) > figure figcaption {
+:pass(5) [data-type="chapter"] :not(figure) > figure:not(.unnumbered) figcaption {
   container: span;
   class: "os-caption";
   move-to: bCaption; }
-:pass(5) [data-type="chapter"] :not(figure) > figure::after {
+:pass(5) [data-type="chapter"] :not(figure) > figure:not(.unnumbered)::after {
   container: div;
   class: "os-caption-container";
   content: pending(bCaption);
   move-to: bCaptionContainer; }
-:pass(5) [data-type="chapter"] :not(figure) > figure::outside {
+:pass(5) [data-type="chapter"] :not(figure) > figure:not(.unnumbered)::outside {
   class: os-figure;
   container: div;
   content: content() pending(bCaptionContainer); }
-:pass(5) .appendix :not(figure) > figure::before {
+:pass(5) [data-type="chapter"] :not(figure) > figure.unnumbered figcaption {
+  move-to: trash; }
+:pass(5) .appendix :not(figure) > figure:not(.unnumbered)::before {
   container: span;
   content: "Figure ";
   class: os-title-label;
   move-to: bCaption; }
-:pass(5) .appendix :not(figure) > figure::before {
+:pass(5) .appendix :not(figure) > figure:not(.unnumbered)::before {
   container: span;
   content: counter(appendix,upper-alpha) "." counter(figure);
   class: os-number;
   move-to: bCaption; }
-:pass(5) .appendix :not(figure) > figure figcaption {
+:pass(5) .appendix :not(figure) > figure:not(.unnumbered) figcaption {
   container: span;
   class: "os-caption";
   move-to: bCaption; }
-:pass(5) .appendix :not(figure) > figure::after {
+:pass(5) .appendix :not(figure) > figure:not(.unnumbered)::after {
   container: div;
   class: "os-caption-container";
   content: pending(bCaption);
   move-to: bCaptionContainer; }
-:pass(5) .appendix :not(figure) > figure::outside {
+:pass(5) .appendix :not(figure) > figure:not(.unnumbered)::outside {
   class: os-figure;
   container: div;
   content: content() pending(bCaptionContainer); }
+:pass(5) .appendix :not(figure) > figure.unnumbered figcaption {
+  move-to: trash; }
 
 :pass(6) .os-index-link-separator:last-child {
   move-to: trash; }

--- a/books/rulesets/output/statistics.css
+++ b/books/rulesets/output/statistics.css
@@ -217,15 +217,16 @@
   Style guide: book.chapter
 */
 /*
-  Unnumbered content
+  Unnumbered Content
 
-  Content that has been marked with the class .unnumbered by the content team.
-  T
-  This may apply to a note, a table, an equation, a figure. Currently, the ruleset supports only tables and figures
+  Content that has been marked with the class `.unnumbered` by the content team.
 
-  Markup: ./book.unnumbered.html-cooked.html
+  Currently, the ruleset supports only tables and figures but
+  this may apply to a note, a table, an equation, a figure. 
 
-  Style guide: book.unnumbered
+  Markup: ./page.unnumbered.html-cooked.html
+
+  Style guide: page.unnumbered
 */
 /*==========================================================
   STATISTICS PAGES

--- a/books/rulesets/output/statistics.css
+++ b/books/rulesets/output/statistics.css
@@ -216,6 +216,17 @@
 
   Style guide: book.chapter
 */
+/*
+  Unnumbered content
+
+  Content that has been marked with the class .unnumbered by the content team.
+  T
+  This may apply to a note, a table, an equation, a figure. Currently, the ruleset supports only tables and figures
+
+  Markup: ./book.unnumbered.html-cooked.html
+
+  Style guide: book.unnumbered
+*/
 /*==========================================================
   STATISTICS PAGES
 ==========================================================*/


### PR DESCRIPTION
Tables and figures with the class `.unnumbered` should not have a caption or be numbered