### PR TITLE
exercise/solution links use the exercise id instead of a new id

### DIFF
--- a/books/rulesets/common/_link.scss
+++ b/books/rulesets/common/_link.scss
@@ -1,14 +1,24 @@
-@import "./utils";
-
 //EOC composite pages must be created before this runs
-@mixin link_linkToProblemsFromSolutionsEOC($toElement, $fromElement, $problemCounter) {
-  @include utils_linkToFromForward(
-    ".os-hasSolution [data-type="problem"] .os-#{$toElement}",
-    "[data-type="solution"] .os-#{$fromElement}",
-    problem,
-    solution,
-    $problemCounter
-  );
+/// Creates a link to the solution and a link back to the problem for an exercise
+/// Note: This replaces the solution id with a new id whose value is `${EXERCISEID}-solution`
+@mixin link_linkToProblemsFromSolutionsEOC() {
+
+  [data-type="exercise"].os-hasSolution {
+    string-set: exerciseId attr(id);
+
+    [data-type="problem"] .os-number {
+      container: a;
+      attr-href: "#" string(exerciseId) '-solution';
+    }
+
+    [data-type="solution"] {
+      attr-id: string(exerciseId) '-solution';
+      .os-number {
+        container: a;
+        attr-href: "#" string(exerciseId);
+      }
+    }
+  }
 }
 
 

--- a/books/rulesets/common/_utils.scss
+++ b/books/rulesets/common/_utils.scss
@@ -60,39 +60,13 @@
 /// @arg {Text} $toCounter [null] - The counter object used to automatically ID the element to be linked to if it doesn't already have an id. If null, the link href will be to an already existing id of the linked-to element
 /// @group utils
 @mixin utils_hasSolution() {
-  .exercise {
-    .solution {
+  [data-type="exercise"] {
+    [data-type="solution"] {
       string-set: isSolution " os-hasSolution ";
     }
     string-set: isSolution "";
     &::deferred {
       class: attr(class) string(isSolution, " ") ;
-    }
-  }
-}
-
-/// NEEDS DOCUMENTATION
-/// @group needs-docs
-@mixin utils_linkToFromForward($toSelector, $fromSelector, $toName, $fromName, $toCounter: null) {
-  #{$toSelector} {
-    @if ($toCounter != null) {
-      $toID: "#{$toName}-"counter($toCounter);
-      $fromID: "#{$fromName}-"counter($toCounter);
-      container: a;
-      attr-id: $toID;
-      attr-href: "#" #{$fromID};
-      string-set: #{$toName}-ID $toID;
-      string-set: #{$fromName}-ID $fromID;
-    } @else {
-      //FIXME forward links with existing ID Todo
-      string-set: #{$toName}-ID attr(id);
-    }
-  }
-  #{$fromSelector} {
-    &::outside {
-      container: a;
-      attr-id: string(#{$fromName}-ID);
-      attr-href: "#" string(#{$toName}-ID);
     }
   }
 }

--- a/books/rulesets/common/examples/page.exercise.html
+++ b/books/rulesets/common/examples/page.exercise.html
@@ -2,12 +2,12 @@
   <div data-type="page">
 
     <!-- Markup starts here -->
-    <div data-type="exercise" class="exercise">
-      <div data-type="problem" class="problem">
+    <div data-type="exercise" id="ex1">
+      <div data-type="problem">
         <p>If an apple fell 3 meters in 2 seconds, what was the speed of the apple?</p>
       </div>
-      <div data-type="solution" class="solution">
-        <p>If fell 1.5 meters per second</p>
+      <div data-type="solution">
+        <p>It fell 1.5 meters per second</p>
       </div>
     </div>
 

--- a/books/rulesets/economics/book.scss
+++ b/books/rulesets/economics/book.scss
@@ -46,7 +46,7 @@
 :pass(3) {
   //After: createChapterComposites, numberEOCExercises
   @include count_countExercises(exerciseAll);
-  @include link_linkToProblemsFromSolutionsEOC("number", "number", exerciseAll);
+  @include link_linkToProblemsFromSolutionsEOC();
 
   //After: prepBookComposites
   @include reference_refChapterHeaderNodeAs(chapterHeaderNode);

--- a/books/rulesets/economics/examples/book.composite.critical-thinking.html
+++ b/books/rulesets/economics/examples/book.composite.critical-thinking.html
@@ -7,11 +7,11 @@
     <!-- Markup starts here -->
     <section class="critical-thinking">
       <h3 data-type="title">Critical Thinking</h3>
-      <div data-type="exercise" class="exercise">
+      <div data-type="exercise" id="ex1">
         <div data-type="problem">
           <p>What is 2+2?</p>
         </div>
-        <div data-type="solution" class="solution">4</div>
+        <div data-type="solution">4</div>
       </div>
     </section>
     <!-- Markup ends here -->
@@ -25,11 +25,11 @@
     <!-- Markup starts here -->
     <section class="critical-thinking">
       <h3 data-type="title">Critical Thinking</h3>
-      <div data-type="exercise" class="exercise">
+      <div data-type="exercise" id="ex2">
         <div data-type="problem">
           <p>What is 3+3?</p>
         </div>
-        <div data-type="solution" class="solution">6</div>
+        <div data-type="solution">6</div>
       </div>
     </section>
     <!-- Markup ends here -->

--- a/books/rulesets/economics/examples/book.composite.problems.html
+++ b/books/rulesets/economics/examples/book.composite.problems.html
@@ -7,11 +7,11 @@
     <!-- Markup starts here -->
     <section class="problems">
       <h3 data-type="title">Problems</h3>
-      <div data-type="exercise" class="exercise">
+      <div data-type="exercise" id="ex1">
         <div data-type="problem">
           <p>What is 2+2?</p>
         </div>
-        <div data-type="solution" class="solution">4</div>
+        <div data-type="solution">4</div>
       </div>
     </section>
     <!-- Markup ends here -->
@@ -25,11 +25,11 @@
     <!-- Markup starts here -->
     <section class="problems">
       <h3 data-type="title">Problems</h3>
-      <div data-type="exercise" class="exercise">
+      <div data-type="exercise" id="ex2">
         <div data-type="problem">
           <p>What is 3+3?</p>
         </div>
-        <div data-type="solution" class="solution">6</div>
+        <div data-type="solution">6</div>
       </div>
     </section>
     <!-- Markup ends here -->

--- a/books/rulesets/economics/examples/book.composite.review-questions.html
+++ b/books/rulesets/economics/examples/book.composite.review-questions.html
@@ -7,11 +7,11 @@
     <!-- Markup starts here -->
     <section class="review-questions">
       <h3 data-type="title">Review Questions</h3>
-      <div data-type="exercise" class="exercise">
+      <div data-type="exercise" id="ex1">
         <div data-type="problem">
           <p>What is 2+2?</p>
         </div>
-        <div data-type="solution" class="solution">4</div>
+        <div data-type="solution">4</div>
       </div>
     </section>
     <!-- Markup ends here -->
@@ -25,11 +25,11 @@
     <!-- Markup starts here -->
     <section class="review-questions">
       <h3 data-type="title">Review Questions</h3>
-      <div data-type="exercise" class="exercise">
+      <div data-type="exercise" id="ex2">
         <div data-type="problem">
           <p>What is 3+3?</p>
         </div>
-        <div data-type="solution" class="solution">6</div>
+        <div data-type="solution">6</div>
       </div>
     </section>
     <!-- Markup ends here -->

--- a/books/rulesets/economics/examples/book.composite.self-check-questions.html
+++ b/books/rulesets/economics/examples/book.composite.self-check-questions.html
@@ -7,11 +7,11 @@
     <!-- Markup starts here -->
     <section class="self-check-questions">
       <h3 data-type="title">Self-Check Questions</h3>
-      <div data-type="exercise" class="exercise">
+      <div data-type="exercise" id="ex1">
         <div data-type="problem">
           <p>What is 2+2?</p>
         </div>
-        <div data-type="solution" class="solution">4</div>
+        <div data-type="solution">4</div>
       </div>
     </section>
   </div>

--- a/books/rulesets/economics/examples/book.composite.test-prep.html
+++ b/books/rulesets/economics/examples/book.composite.test-prep.html
@@ -7,11 +7,11 @@
     <!-- Markup starts here -->
     <section class="ap-test-prep">
       <h3 data-type="title">Test Prep For AP® Courses</h3>
-      <div data-type="exercise" class="exercise">
+      <div data-type="exercise" id="ex1">
         <div data-type="problem">
           <p>What is 2+2?</p>
         </div>
-        <div data-type="solution" class="solution">4</div>
+        <div data-type="solution">4</div>
       </div>
     </section>
     <!-- Markup ends here -->
@@ -25,11 +25,11 @@
     <!-- Markup starts here -->
     <section class="ap-test-prep">
       <h3 data-type="title">Test Prep For AP® Courses</h3>
-      <div data-type="exercise" class="exercise">
+      <div data-type="exercise" id="ex2">
         <div data-type="problem">
           <p>What is 3+3?</p>
         </div>
-        <div data-type="solution" class="solution">6</div>
+        <div data-type="solution">6</div>
       </div>
     </section>
     <!-- Markup ends here -->

--- a/books/rulesets/output/economics.css
+++ b/books/rulesets/output/economics.css
@@ -363,11 +363,11 @@
     class: "os-text"; }
 :pass(0) a[href*="archive.cnx.org/specials/"] {
   attr-target: "_blank"; }
-:pass(0) .exercise {
+:pass(0) [data-type="exercise"] {
   string-set: isSolution ""; }
-  :pass(0) .exercise .solution {
+  :pass(0) [data-type="exercise"] [data-type="solution"] {
     string-set: isSolution " os-hasSolution "; }
-  :pass(0) .exercise::deferred {
+  :pass(0) [data-type="exercise"]::deferred {
     class: attr(class) string(isSolution, " "); }
 :pass(0) [data-type="note"].linkup::before {
   container: span;
@@ -640,16 +640,16 @@
   counter-reset: exerciseAll; }
 :pass(3) .os-eoc [data-type="exercise"] {
   counter-increment: exerciseAll; }
-:pass(3) .os-hasSolution [data-type=problem] .os-number {
-  container: a;
-  attr-id: "problem-" counter(exerciseAll);
-  attr-href: "#" solution- counter(exerciseAll);
-  string-set: problem-ID "problem-" counter(exerciseAll);
-  string-set: solution-ID "solution-" counter(exerciseAll); }
-:pass(3) [data-type=solution] .os-number::outside {
-  container: a;
-  attr-id: string(solution-ID);
-  attr-href: "#" string(problem-ID); }
+:pass(3) [data-type="exercise"].os-hasSolution {
+  string-set: exerciseId attr(id); }
+  :pass(3) [data-type="exercise"].os-hasSolution [data-type="problem"] .os-number {
+    container: a;
+    attr-href: "#" string(exerciseId) "-solution"; }
+  :pass(3) [data-type="exercise"].os-hasSolution [data-type="solution"] {
+    attr-id: string(exerciseId) "-solution"; }
+    :pass(3) [data-type="exercise"].os-hasSolution [data-type="solution"] .os-number {
+      container: a;
+      attr-href: "#" string(exerciseId); }
 :pass(3) div[data-type="chapter"] {
   node-set: chapterHeaderNode; }
 :pass(3) [data-type="chapter"] .os-solutions-chapter-area {

--- a/books/rulesets/output/statistics.css
+++ b/books/rulesets/output/statistics.css
@@ -268,11 +268,11 @@
   attr-target: "_blank"; }
 :pass(0) .try [data-type="solution"] {
   move-to: trash; }
-:pass(0) .exercise {
+:pass(0) [data-type="exercise"] {
   string-set: isSolution ""; }
-  :pass(0) .exercise .solution {
+  :pass(0) [data-type="exercise"] [data-type="solution"] {
     string-set: isSolution " os-hasSolution "; }
-  :pass(0) .exercise::deferred {
+  :pass(0) [data-type="exercise"]::deferred {
     class: attr(class) string(isSolution, " "); }
 :pass(0) [data-type="metadata"] > [data-type="description"] {
   move-to: trash; }
@@ -582,16 +582,16 @@
   counter-reset: exerciseAll; }
 :pass(3) .os-eoc [data-type="exercise"] {
   counter-increment: exerciseAll; }
-:pass(3) .os-hasSolution [data-type=problem] .os-number {
-  container: a;
-  attr-id: "problem-" counter(exerciseAll);
-  attr-href: "#" solution- counter(exerciseAll);
-  string-set: problem-ID "problem-" counter(exerciseAll);
-  string-set: solution-ID "solution-" counter(exerciseAll); }
-:pass(3) [data-type=solution] .os-number::outside {
-  container: a;
-  attr-id: string(solution-ID);
-  attr-href: "#" string(problem-ID); }
+:pass(3) [data-type="exercise"].os-hasSolution {
+  string-set: exerciseId attr(id); }
+  :pass(3) [data-type="exercise"].os-hasSolution [data-type="problem"] .os-number {
+    container: a;
+    attr-href: "#" string(exerciseId) "-solution"; }
+  :pass(3) [data-type="exercise"].os-hasSolution [data-type="solution"] {
+    attr-id: string(exerciseId) "-solution"; }
+    :pass(3) [data-type="exercise"].os-hasSolution [data-type="solution"] .os-number {
+      container: a;
+      attr-href: "#" string(exerciseId); }
 :pass(3) div[data-type="chapter"] {
   node-set: chapterHeaderNode; }
 :pass(3) [data-type="chapter"] .os-index-chapter-area {

--- a/books/rulesets/statistics/book.scss
+++ b/books/rulesets/statistics/book.scss
@@ -60,7 +60,7 @@
 :pass(3) {
   //After: createChapterComposites, numberEOCExercises
   @include count_countExercises(exerciseAll);
-  @include link_linkToProblemsFromSolutionsEOC("number", "number", exerciseAll);
+  @include link_linkToProblemsFromSolutionsEOC();
 
   //After: prepBookComposites
   @include reference_refChapterHeaderNodeAs(chapterHeaderNode);

--- a/books/rulesets/statistics/examples/book.composite.practice.html
+++ b/books/rulesets/statistics/examples/book.composite.practice.html
@@ -7,8 +7,8 @@
 <!-- Markup starts here -->
 <section class="practice">
   <h3 data-type="title">Practice</h3>
-  <div data-type="exercise" class="exercise">
-    <div data-type="problem" class="problem">
+  <div data-type="exercise" id="ex1">
+    <div data-type="problem">
       <p>“Number of times per week” is what type of data?</p>
       <p>
         <span data-type="list" data-list-type="labeled-item" data-display="inline">
@@ -18,12 +18,12 @@
         </span>
       </p>
     </div>
-    <div data-type="solution" class="solution">b</div>
+    <div data-type="solution">b</div>
   </div>
 
   <p><em data-effect="italics">Use the following information to answer the next four exercises:</em> A study was done to determine the age, number of times per week, and the duration (amount of time) of residents using a local park in San Antonio, Texas. The first house in the neighborhood around the park was selected randomly, and then the resident of every eighth house in the neighborhood around the park was interviewed.</p>
-  <div data-type="exercise" class="exercise">
-    <div data-type="problem" class="problem">
+  <div data-type="exercise" id="ex2">
+    <div data-type="problem">
       <p>The sampling method was</p>
       <p>
         <span data-type="list" data-list-type="labeled-item" data-display="inline">
@@ -34,7 +34,7 @@
         </span>
       </p>
     </div>
-    <div data-type="solution" class="solution">
+    <div data-type="solution">
       <p>b</p>
     </div>
   </div>


### PR DESCRIPTION
(refs https://github.com/Connexions/webview/pull/1460)

It also helps with transclusion and reduces the number of new id’s generated.

<details>
<summary>

Example Raw HTML:</summary>



``` html
<div data-type="exercise" class="exercise">
  <div data-type="problem" class="problem">
    <p>What is 2+2?</p>
  </div>
  <div data-type="solution" class="solution">
    4
  </div>
</div>
```

</details>

<details><summary>

Old cooked HTML:</summary>



``` html
<div data-type="exercise" class="exercise os-hasSolution " id="ex123">
  <div data-type="problem"><a class="os-number" id="problem-1" href="#solution-1">1</a>
    <p>What is 2+2?</p>
  </div>
</div>

<!-- ... and the EOB solutions area: -->

<div class="os-eob os-solutions-container" data-type="composite-page">

  <div data-type="solution" class="solution">
    <a id="solution-1" href="#problem-1">
      <span class="os-number">1</span>4</a>
    4
  </div>
</div>
```

</details>

New Cooked HTML:

``` html
<div data-type="exercise" class="exercise os-hasSolution " id="ex123">
  <div data-type="problem" class="problem">
    <a class="os-number" href="#ex123-solution">1</a>
    <p>What is 2+2?</p>
  </div>
</div>

<!-- ... and the EOB solutions area: -->

<div class="os-eob os-solutions-container" data-type="composite-page">

  <div data-type="solution" id="ex123-solution">
    <a href="#ex123">
      <span class="os-number">1</span>
    </a>
    4
  </div>
</div>
```

Also, this fixes a couple other issues:
1. selectors now use `[data-type="exercise/problem/solution"]` instead of `.exercise/problem/solution`
2. the "4" in the answer is no longer duplicated in the link text
