### PR TITLE
validate baked files

### DIFF
--- a/scripts/bake-book
+++ b/scripts/bake-book
@@ -50,3 +50,6 @@ then
 fi
 
 cnx-easybake ${DEBUG_FLAG} ${CSS_PATH} ${RAW_PATH} ${COOKED_PATH}
+
+# Validate the cooked file
+cnx-epub-validate-collated ${COOKED_PATH}

--- a/scripts/bake-file
+++ b/scripts/bake-file
@@ -48,3 +48,5 @@ then
 fi
 
 cnx-easybake ${DEBUG_FLAG} ${CSS_PATH} ${RAW_PATH} ${COOKED_PATH}
+# Validate the cooked file
+cnx-epub-validate-collated ${COOKED_PATH}

--- a/scripts/bake-file
+++ b/scripts/bake-file
@@ -48,5 +48,8 @@ then
 fi
 
 cnx-easybake ${DEBUG_FLAG} ${CSS_PATH} ${RAW_PATH} ${COOKED_PATH}
-# Validate the cooked file
-cnx-epub-validate-collated ${COOKED_PATH}
+# Validate the cooked file.
+# Commented because snippets do not pass the data-type="metadata" validation
+# and adding in all those metadata blocks would be cumbersome and distract
+# from the actual use-case which is to show snippets.
+# cnx-epub-validate-collated ${BAKED_PATH}


### PR DESCRIPTION
(refs #87)

This validates the cooked/baked file whenever it is generated
# Example

```
$ ./scripts/bake-book statshigh
...
cnxepub ERROR Bad href: #footnote-ref1
cnxepub ERROR Bad href: #footnote-ref2
cnxepub ERROR Bad href: #footnote-ref3
cnxepub ERROR Bad href: #footnote1
cnxepub ERROR Bad href: #footnote2
cnxepub ERROR Bad href: #footnote3
cnxepub ERROR Bad href: #footnote-ref1
cnxepub ERROR Bad href: #footnote-ref2
cnxepub ERROR Bad href: #footnote-ref3
cnxepub ERROR Bad href: #footnote-ref4
cnxepub ERROR Bad href: #footnote4
cnxepub ERROR Bad href: #footnote1
cnxepub ERROR Bad href: #footnote2
cnxepub ERROR Bad href: #footnote3
cnxepub ERROR Bad href: #element-583
$
```
