### PR TITLE
rename "cook" to "bake"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@
 # working files
 /books/data/
 /data/*-raw.html
-/data/*-cooked.html
+/data/*-baked.html
 # The following file is used for diffing 2 versions of a book
 /data/*-prepared.html
 # CSS Code coverage
@@ -25,8 +25,8 @@
 # SASS stuff
 /.sass-cache/
 /books/rulesets/output/*.css.map
-/books/rulesets/common/examples/*-cooked.html
-/books/rulesets/examples/*-cooked.html
+/books/rulesets/common/examples/*-baked.html
+/books/rulesets/examples/*-baked.html
 /sassdoc/
 /styleguide/
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Note:** To update the dependencies, run `./scripts/update`
 
-# Cook a New Book
+# Bake a New Book
 
 1. run `./scripts/fetch-book statistics`
   - **Note:** To see the list of books available see `./books.txt`
@@ -13,7 +13,7 @@
   - **Note:** You can run `./scripts/fetch-book --all` to fetch all the books
 1. run `./scripts/bake-book statistics`
 
-There are 2 major parts to cooking a book (_listed above_). You will first need to get the single-file HTML from the server (`fetch-book`) and then convert the single-file HTML locally into the "baked" book via `bake-book`. Once you have done the first part, you can run `./scripts/bake-book statistics` to your :heart:'s content!
+There are 2 major parts to baking a book (_listed above_). You will first need to get the single-file HTML from the server (`fetch-book`) and then convert the single-file HTML locally into the "baked" book via `bake-book`. Once you have done the first part, you can run `./scripts/bake-book statistics` to your :heart:'s content!
 
 
 ## Add a New Book to the config
@@ -59,7 +59,7 @@ To check that there were no regressions in a book what the following process doe
 
 1. bake the book with the old code
 1. bake the book with the new code
-1. compare the 2 cooked HTML files to see if there were any differences
+1. compare the 2 baked HTML files to see if there were any differences
 
 Here are the steps to run it:
 

--- a/books/rulesets/common/examples/_all.scss
+++ b/books/rulesets/common/examples/_all.scss
@@ -6,7 +6,7 @@
   - `[data-type='metadata']` The attribution information for this Page
   - `[data-type='document-title']` The title of the Page
 
-  Markup: ./book.page.html-cooked.html
+  Markup: ./book.page.html-baked.html
 
   Style guide: book.page
 */
@@ -59,7 +59,7 @@
 
   **TODO:** Discuss how to automate glossary-creation
 
-  Markup: ./page.term.html-cooked.html
+  Markup: ./page.term.html-baked.html
 
   Style guide: page.term
 */
@@ -74,7 +74,7 @@
 
   Contains an optional title, and optionally an additional class to help style the note
 
-  Markup: ./page.note.html-cooked.html
+  Markup: ./page.note.html-baked.html
 
   Style guide: page.note
 */
@@ -89,15 +89,15 @@
       - `img[src][alt]` : The image for the Figure
 
   TODO: Maybe this should use the `<picture>` element instead of the `[data-type='media']` element:
-  http://www.html-cooked.html5rocks.com/en/tutorials/responsive/picture-element/
+  http://www.html-baked.html5rocks.com/en/tutorials/responsive/picture-element/
 
   # TODO
 
-  - Decide on what the cooked markup for a figure with a title and caption should look like.
+  - Decide on what the baked markup for a figure with a title and caption should look like.
     - Proposals have mentioned using `<figcaption>` most of the time.
     - Maybe what is in the Raw HTML is _good enough_?
 
-  Markup: ./page.figure.html-cooked.html
+  Markup: ./page.figure.html-baked.html
 
   Style guide: page.figure
 */
@@ -118,7 +118,7 @@
 
   TODO: Move these into a separate "inline" section in the HTML guide
 
-  Markup: ./page.para.html-cooked.html
+  Markup: ./page.para.html-baked.html
 
   Style guide: page.para
 */
@@ -128,7 +128,7 @@
 
   A (sub)section of content which contains a title.
 
-  Markup: ./page.section.html-cooked.html
+  Markup: ./page.section.html-baked.html
 
   Style guide: page.section
 */
@@ -141,7 +141,7 @@
   An example which is usually styled to not be part of the flow of normal content
   (similar to a Note).
 
-  Markup: ./page.example.html-cooked.html
+  Markup: ./page.example.html-baked.html
 
   Style guide: page.example
 */
@@ -158,7 +158,7 @@
 
   Solutions are collated (at the end of section, end of chapter or end of book), they are numbered (the number is the same as the exercise they are associated to) and link back to their exercise.
 
-  Markup: ./page.exercise.html-cooked.html
+  Markup: ./page.exercise.html-baked.html
 
   Style guide: page.exercise
 */
@@ -169,7 +169,7 @@
 
   An equation wraps a MathML formula and is usually numbered.
 
-  Markup: ./page.equation.html-cooked.html
+  Markup: ./page.equation.html-baked.html
 
   Style guide: page.equation
 */
@@ -183,7 +183,7 @@
   It is collated as a separate Page at the end of a Chapter or a Book.
   Also, it is collected from individual glossary elements in each raw Page.
 
-  Markup: ./book.glossary.html-cooked.html
+  Markup: ./book.glossary.html-baked.html
 
   Style guide: book.glossary
 */
@@ -193,7 +193,7 @@
 
   The book Index contains terms and links to their occurences in the book.
 
-  Markup: ./book.index.html-cooked.html
+  Markup: ./book.index.html-baked.html
 
   Style guide: book.index
 */
@@ -208,11 +208,11 @@
 
   # TODO
 
-  - Decide on what the cooked markup for a table with a title and caption should look like.
+  - Decide on what the baked markup for a table with a title and caption should look like.
     - Proposals have mentioned wrapping the `<table>` element with a `.os-table-container` element.
     - Maybe what is in the Raw HTML is _good enough_?
 
-  Markup: ./page.table.html-cooked.html
+  Markup: ./page.table.html-baked.html
 
   Style guide: page.table
 */
@@ -246,7 +246,7 @@
 
   The introduction page typically contains a splash image, a chapter outline and an introductory paragraph.
 
-  Markup: ./book.chapter.html-cooked.html
+  Markup: ./book.chapter.html-baked.html
 
   Style guide: book.chapter
 */
@@ -259,7 +259,7 @@
   Currently, the ruleset supports only tables and figures but
   this may apply to a note, a table, an equation, a figure. 
 
-  Markup: ./page.unnumbered.html-cooked.html
+  Markup: ./page.unnumbered.html-baked.html
 
   Style guide: page.unnumbered
 */

--- a/books/rulesets/economics/_config.scss
+++ b/books/rulesets/economics/_config.scss
@@ -16,7 +16,7 @@ $pageKeyTerms: (
   These should be collated at the end of a chapter
   and separated by which section they came from.
 
-  Markup: ./examples/book.composite.summary.html-cooked.html
+  Markup: ./examples/book.composite.summary.html-baked.html
 
   Style guide: book.composite.summary
 */
@@ -39,7 +39,7 @@ $pageSummary: (
   1. the solution is inside the link text that points back to the problem
   1. new id's are generated rather than using the existing id attributes for the problem and solution
 
-  Markup: ./examples/book.composite.self-check-questions.html-cooked.html
+  Markup: ./examples/book.composite.self-check-questions.html-baked.html
 
   Style guide: book.composite.self-check-questions
 */
@@ -55,7 +55,7 @@ $pageSelfCheck: (
   These should be collated at the end of a chapter
   and have answers collated at the end of the chapter.
 
-  Markup: ./examples/book.composite.review-questions.html-cooked.html
+  Markup: ./examples/book.composite.review-questions.html-baked.html
 
   Style guide: book.composite.review-questions
 */
@@ -71,7 +71,7 @@ $pageReviewQuestions: (
   These should be collated at the end of a chapter
   and have answers collated at the end of the chapter.
 
-  Markup: ./examples/book.composite.critical-thinking.html-cooked.html
+  Markup: ./examples/book.composite.critical-thinking.html-baked.html
 
   Style guide: book.composite.critical-thinking
 */
@@ -86,7 +86,7 @@ $pageCriticalThinking: (
   These should be collated at the end of a chapter
   and have answers collated at the end of the chapter.
 
-  Markup: ./examples/book.composite.problems.html-cooked.html
+  Markup: ./examples/book.composite.problems.html-baked.html
 
   Style guide: book.composite.problems
 */
@@ -102,7 +102,7 @@ $pageProblems: (
   These should be collated at the end of a chapter
   and have answers collated at the end of the chapter.
 
-  Markup: ./examples/book.composite.test-prep.html-cooked.html
+  Markup: ./examples/book.composite.test-prep.html-baked.html
 
   Style guide: book.composite.test-prep
 */
@@ -118,7 +118,7 @@ $pageTestPrep: (
   These should be collated at the end of a chapter
   and separated by which section they came from.
 
-  Markup: ./examples/book.composite.references.html-cooked.html
+  Markup: ./examples/book.composite.references.html-baked.html
 
   Style guide: book.composite.references
 */
@@ -195,7 +195,7 @@ $exerciseTitleContent: (
 
   Contains a title "Link It Up"
 
-  Markup: ./examples/page.note.linkup.html-cooked.html
+  Markup: ./examples/page.note.linkup.html-baked.html
 
   Style guide: page.note.linkup
 */
@@ -209,7 +209,7 @@ $linkupNote: (
 
   Contains a title "Bring It Home" and a body containing a title and the contents of the note.
 
-  Markup: ./examples/page.note.bringhome.html-cooked.html
+  Markup: ./examples/page.note.bringhome.html-baked.html
 
   Style guide: page.note.bringhome
 */
@@ -225,7 +225,7 @@ $bringhomeNote: (
 
   Contains a title "Clear It Up" and a body containing a title and the contents of the note.
 
-  Markup: ./examples/page.note.clearup.html-cooked.html
+  Markup: ./examples/page.note.clearup.html-baked.html
 
   Style guide: page.note.clearup
 */
@@ -240,7 +240,7 @@ $clearupNote: (
 
   Contains a title "Work It Out" and a body containing a title and the contents of the note.
 
-  Markup: ./examples/page.note.workout.html-cooked.html
+  Markup: ./examples/page.note.workout.html-baked.html
 
   Style guide: page.note.workout
 */

--- a/books/rulesets/guide-homepage.md
+++ b/books/rulesets/guide-homepage.md
@@ -1,10 +1,10 @@
 # Output HTML conventions
 
-The purpose of this part is to document and centralize the output HTML decisions and conventions. These are the cooked formats that are delivered to the cnx.org website, the PDF generation system, and external consumers like TEA.
+The purpose of this part is to document and centralize the output HTML decisions and conventions. These are the baked formats that are delivered to the cnx.org website, the PDF generation system, and external consumers like TEA.
 
 - Use `data-*` whenever possible. This applies to anything we use internally.
 - Classes are used when several attributes are needed on one element: `class="eoc practice-container"` `data-type="composite-page"`.
-- No numbering or titling should be accomplished via display css, it needs to be present in the unstyled cooked HTML
+- No numbering or titling should be accomplished via display css, it needs to be present in the unstyled baked HTML
 - All book specific strings are handled via the ruleset, this includes titles for notes/features and “generic” strings like “Chapter” or “Figure”. Instead of using labels in the content, we create all the titles via the ruleset, this provides one location to look for errors if titles are incorrect and prevents localised error when creating content. This is needed for internationalization. The ruleset handles them via variables, none of those should be hard coded.
 - Prefix classes that are created in the ruleset and preserve the classes in the Raw HTML intact.
 - If it’s not needed for styling, it shouldn’t be in the dom.

--- a/books/rulesets/output/economics.css
+++ b/books/rulesets/output/economics.css
@@ -7,7 +7,7 @@
   - `[data-type='metadata']` The attribution information for this Page
   - `[data-type='document-title']` The title of the Page
 
-  Markup: ./book.page.html-cooked.html
+  Markup: ./book.page.html-baked.html
 
   Style guide: book.page
 */
@@ -52,7 +52,7 @@
 
   **TODO:** Discuss how to automate glossary-creation
 
-  Markup: ./page.term.html-cooked.html
+  Markup: ./page.term.html-baked.html
 
   Style guide: page.term
 */
@@ -64,7 +64,7 @@
 
   Contains an optional title, and optionally an additional class to help style the note
 
-  Markup: ./page.note.html-cooked.html
+  Markup: ./page.note.html-baked.html
 
   Style guide: page.note
 */
@@ -78,15 +78,15 @@
       - `img[src][alt]` : The image for the Figure
 
   TODO: Maybe this should use the `<picture>` element instead of the `[data-type='media']` element:
-  http://www.html-cooked.html5rocks.com/en/tutorials/responsive/picture-element/
+  http://www.html-baked.html5rocks.com/en/tutorials/responsive/picture-element/
 
   # TODO
 
-  - Decide on what the cooked markup for a figure with a title and caption should look like.
+  - Decide on what the baked markup for a figure with a title and caption should look like.
     - Proposals have mentioned using `<figcaption>` most of the time.
     - Maybe what is in the Raw HTML is _good enough_?
 
-  Markup: ./page.figure.html-cooked.html
+  Markup: ./page.figure.html-baked.html
 
   Style guide: page.figure
 */
@@ -104,7 +104,7 @@
 
   TODO: Move these into a separate "inline" section in the HTML guide
 
-  Markup: ./page.para.html-cooked.html
+  Markup: ./page.para.html-baked.html
 
   Style guide: page.para
 */
@@ -113,7 +113,7 @@
 
   A (sub)section of content which contains a title.
 
-  Markup: ./page.section.html-cooked.html
+  Markup: ./page.section.html-baked.html
 
   Style guide: page.section
 */
@@ -123,7 +123,7 @@
   An example which is usually styled to not be part of the flow of normal content
   (similar to a Note).
 
-  Markup: ./page.example.html-cooked.html
+  Markup: ./page.example.html-baked.html
 
   Style guide: page.example
 */
@@ -137,7 +137,7 @@
 
   Solutions are collated (at the end of section, end of chapter or end of book), they are numbered (the number is the same as the exercise they are associated to) and link back to their exercise.
 
-  Markup: ./page.exercise.html-cooked.html
+  Markup: ./page.exercise.html-baked.html
 
   Style guide: page.exercise
 */
@@ -146,7 +146,7 @@
 
   An equation wraps a MathML formula and is usually numbered.
 
-  Markup: ./page.equation.html-cooked.html
+  Markup: ./page.equation.html-baked.html
 
   Style guide: page.equation
 */
@@ -157,7 +157,7 @@
   It is collated as a separate Page at the end of a Chapter or a Book.
   Also, it is collected from individual glossary elements in each raw Page.
 
-  Markup: ./book.glossary.html-cooked.html
+  Markup: ./book.glossary.html-baked.html
 
   Style guide: book.glossary
 */
@@ -166,7 +166,7 @@
 
   The book Index contains terms and links to their occurences in the book.
 
-  Markup: ./book.index.html-cooked.html
+  Markup: ./book.index.html-baked.html
 
   Style guide: book.index
 */
@@ -179,11 +179,11 @@
 
   # TODO
 
-  - Decide on what the cooked markup for a table with a title and caption should look like.
+  - Decide on what the baked markup for a table with a title and caption should look like.
     - Proposals have mentioned wrapping the `<table>` element with a `.os-table-container` element.
     - Maybe what is in the Raw HTML is _good enough_?
 
-  Markup: ./page.table.html-cooked.html
+  Markup: ./page.table.html-baked.html
 
   Style guide: page.table
 */
@@ -213,7 +213,7 @@
 
   The introduction page typically contains a splash image, a chapter outline and an introductory paragraph.
 
-  Markup: ./book.chapter.html-cooked.html
+  Markup: ./book.chapter.html-baked.html
 
   Style guide: book.chapter
 */
@@ -225,7 +225,7 @@
   Currently, the ruleset supports only tables and figures but
   this may apply to a note, a table, an equation, a figure. 
 
-  Markup: ./page.unnumbered.html-cooked.html
+  Markup: ./page.unnumbered.html-baked.html
 
   Style guide: page.unnumbered
 */
@@ -238,7 +238,7 @@
   These should be collated at the end of a chapter
   and separated by which section they came from.
 
-  Markup: ./examples/book.composite.summary.html-cooked.html
+  Markup: ./examples/book.composite.summary.html-baked.html
 
   Style guide: book.composite.summary
 */
@@ -255,7 +255,7 @@
   1. the solution is inside the link text that points back to the problem
   1. new id's are generated rather than using the existing id attributes for the problem and solution
 
-  Markup: ./examples/book.composite.self-check-questions.html-cooked.html
+  Markup: ./examples/book.composite.self-check-questions.html-baked.html
 
   Style guide: book.composite.self-check-questions
 */
@@ -265,7 +265,7 @@
   These should be collated at the end of a chapter
   and have answers collated at the end of the chapter.
 
-  Markup: ./examples/book.composite.review-questions.html-cooked.html
+  Markup: ./examples/book.composite.review-questions.html-baked.html
 
   Style guide: book.composite.review-questions
 */
@@ -275,7 +275,7 @@
   These should be collated at the end of a chapter
   and have answers collated at the end of the chapter.
 
-  Markup: ./examples/book.composite.critical-thinking.html-cooked.html
+  Markup: ./examples/book.composite.critical-thinking.html-baked.html
 
   Style guide: book.composite.critical-thinking
 */
@@ -285,7 +285,7 @@
   These should be collated at the end of a chapter
   and have answers collated at the end of the chapter.
 
-  Markup: ./examples/book.composite.problems.html-cooked.html
+  Markup: ./examples/book.composite.problems.html-baked.html
 
   Style guide: book.composite.problems
 */
@@ -296,7 +296,7 @@
   These should be collated at the end of a chapter
   and have answers collated at the end of the chapter.
 
-  Markup: ./examples/book.composite.test-prep.html-cooked.html
+  Markup: ./examples/book.composite.test-prep.html-baked.html
 
   Style guide: book.composite.test-prep
 */
@@ -306,7 +306,7 @@
   These should be collated at the end of a chapter
   and separated by which section they came from.
 
-  Markup: ./examples/book.composite.references.html-cooked.html
+  Markup: ./examples/book.composite.references.html-baked.html
 
   Style guide: book.composite.references
 */
@@ -318,7 +318,7 @@
 
   Contains a title "Link It Up"
 
-  Markup: ./examples/page.note.linkup.html-cooked.html
+  Markup: ./examples/page.note.linkup.html-baked.html
 
   Style guide: page.note.linkup
 */
@@ -327,7 +327,7 @@
 
   Contains a title "Bring It Home" and a body containing a title and the contents of the note.
 
-  Markup: ./examples/page.note.bringhome.html-cooked.html
+  Markup: ./examples/page.note.bringhome.html-baked.html
 
   Style guide: page.note.bringhome
 */
@@ -336,7 +336,7 @@
 
   Contains a title "Clear It Up" and a body containing a title and the contents of the note.
 
-  Markup: ./examples/page.note.clearup.html-cooked.html
+  Markup: ./examples/page.note.clearup.html-baked.html
 
   Style guide: page.note.clearup
 */
@@ -345,7 +345,7 @@
 
   Contains a title "Work It Out" and a body containing a title and the contents of the note.
 
-  Markup: ./examples/page.note.workout.html-cooked.html
+  Markup: ./examples/page.note.workout.html-baked.html
 
   Style guide: page.note.workout
 */

--- a/books/rulesets/output/statistics.css
+++ b/books/rulesets/output/statistics.css
@@ -6,7 +6,7 @@
   - `[data-type='metadata']` The attribution information for this Page
   - `[data-type='document-title']` The title of the Page
 
-  Markup: ./book.page.html-cooked.html
+  Markup: ./book.page.html-baked.html
 
   Style guide: book.page
 */
@@ -51,7 +51,7 @@
 
   **TODO:** Discuss how to automate glossary-creation
 
-  Markup: ./page.term.html-cooked.html
+  Markup: ./page.term.html-baked.html
 
   Style guide: page.term
 */
@@ -63,7 +63,7 @@
 
   Contains an optional title, and optionally an additional class to help style the note
 
-  Markup: ./page.note.html-cooked.html
+  Markup: ./page.note.html-baked.html
 
   Style guide: page.note
 */
@@ -77,15 +77,15 @@
       - `img[src][alt]` : The image for the Figure
 
   TODO: Maybe this should use the `<picture>` element instead of the `[data-type='media']` element:
-  http://www.html-cooked.html5rocks.com/en/tutorials/responsive/picture-element/
+  http://www.html-baked.html5rocks.com/en/tutorials/responsive/picture-element/
 
   # TODO
 
-  - Decide on what the cooked markup for a figure with a title and caption should look like.
+  - Decide on what the baked markup for a figure with a title and caption should look like.
     - Proposals have mentioned using `<figcaption>` most of the time.
     - Maybe what is in the Raw HTML is _good enough_?
 
-  Markup: ./page.figure.html-cooked.html
+  Markup: ./page.figure.html-baked.html
 
   Style guide: page.figure
 */
@@ -103,7 +103,7 @@
 
   TODO: Move these into a separate "inline" section in the HTML guide
 
-  Markup: ./page.para.html-cooked.html
+  Markup: ./page.para.html-baked.html
 
   Style guide: page.para
 */
@@ -112,7 +112,7 @@
 
   A (sub)section of content which contains a title.
 
-  Markup: ./page.section.html-cooked.html
+  Markup: ./page.section.html-baked.html
 
   Style guide: page.section
 */
@@ -122,7 +122,7 @@
   An example which is usually styled to not be part of the flow of normal content
   (similar to a Note).
 
-  Markup: ./page.example.html-cooked.html
+  Markup: ./page.example.html-baked.html
 
   Style guide: page.example
 */
@@ -136,7 +136,7 @@
 
   Solutions are collated (at the end of section, end of chapter or end of book), they are numbered (the number is the same as the exercise they are associated to) and link back to their exercise.
 
-  Markup: ./page.exercise.html-cooked.html
+  Markup: ./page.exercise.html-baked.html
 
   Style guide: page.exercise
 */
@@ -145,7 +145,7 @@
 
   An equation wraps a MathML formula and is usually numbered.
 
-  Markup: ./page.equation.html-cooked.html
+  Markup: ./page.equation.html-baked.html
 
   Style guide: page.equation
 */
@@ -156,7 +156,7 @@
   It is collated as a separate Page at the end of a Chapter or a Book.
   Also, it is collected from individual glossary elements in each raw Page.
 
-  Markup: ./book.glossary.html-cooked.html
+  Markup: ./book.glossary.html-baked.html
 
   Style guide: book.glossary
 */
@@ -165,7 +165,7 @@
 
   The book Index contains terms and links to their occurences in the book.
 
-  Markup: ./book.index.html-cooked.html
+  Markup: ./book.index.html-baked.html
 
   Style guide: book.index
 */
@@ -178,11 +178,11 @@
 
   # TODO
 
-  - Decide on what the cooked markup for a table with a title and caption should look like.
+  - Decide on what the baked markup for a table with a title and caption should look like.
     - Proposals have mentioned wrapping the `<table>` element with a `.os-table-container` element.
     - Maybe what is in the Raw HTML is _good enough_?
 
-  Markup: ./page.table.html-cooked.html
+  Markup: ./page.table.html-baked.html
 
   Style guide: page.table
 */
@@ -212,7 +212,7 @@
 
   The introduction page typically contains a splash image, a chapter outline and an introductory paragraph.
 
-  Markup: ./book.chapter.html-cooked.html
+  Markup: ./book.chapter.html-baked.html
 
   Style guide: book.chapter
 */
@@ -224,7 +224,7 @@
   Currently, the ruleset supports only tables and figures but
   this may apply to a note, a table, an equation, a figure. 
 
-  Markup: ./page.unnumbered.html-cooked.html
+  Markup: ./page.unnumbered.html-baked.html
 
   Style guide: page.unnumbered
 */
@@ -236,7 +236,7 @@
 
   These should be collated at the end of a chapter.
 
-  Markup: ./examples/book.composite.practice.html-cooked.html
+  Markup: ./examples/book.composite.practice.html-baked.html
 
   Style guide: book.composite.practice
 */
@@ -251,7 +251,7 @@
 
   This is a Note that appears in the Introduction page of every chapter.
 
-  Markup: ./examples/page.note.chapter-objectives.html-cooked.html
+  Markup: ./examples/page.note.chapter-objectives.html-baked.html
 
   Style guide: page.note.chapter-objectives
 */

--- a/books/rulesets/statistics/_config.scss
+++ b/books/rulesets/statistics/_config.scss
@@ -27,7 +27,7 @@ $pageFormulaReview: (
 
   These should be collated at the end of a chapter.
 
-  Markup: ./examples/book.composite.practice.html-cooked.html
+  Markup: ./examples/book.composite.practice.html-baked.html
 
   Style guide: book.composite.practice
 */
@@ -224,7 +224,7 @@ $targetLabels: (
 
   This is a Note that appears in the Introduction page of every chapter.
 
-  Markup: ./examples/page.note.chapter-objectives.html-cooked.html
+  Markup: ./examples/page.note.chapter-objectives.html-baked.html
 
   Style guide: page.note.chapter-objectives
 */

--- a/data/README.md
+++ b/data/README.md
@@ -1,1 +1,1 @@
-This directory contains the HTML files for the books, both the raw (downloaded from server) and the cooked ones
+This directory contains the HTML files for the books, both the raw (downloaded from server) and the baked ones

--- a/js/openstax-kss-builder/README.md
+++ b/js/openstax-kss-builder/README.md
@@ -3,10 +3,10 @@ Notes:
 - the code that loads index.html is hardcoded in `kss_handlebars_generator.js` around the line that says "// Compile the Handlebars template."
 
 
-To render both the raw and the cooked in the guide: browser JS will need to:
+To render both the raw and the baked in the guide: browser JS will need to:
 
 x=document.querySelectorAll('[data-language="html"]')[4]
 y=document.createElement('div')
 y.innerHTML=x.innerText
 
-and then pull out the Raw div and the cooked Div.
+and then pull out the Raw div and the baked Div.

--- a/js/openstax-kss-builder/index.html
+++ b/js/openstax-kss-builder/index.html
@@ -20,10 +20,10 @@
   .-toggle-hidden { display: none; }
   .kss-markup .-kss-autogen-guide-markup::before { font-size: 150%; font-weight: bold; }
   .kss-markup .-kss-autogen-guide-markup[data-kss-format="html-raw"]::before { content: 'Raw HTML:'; }
-  .kss-markup .-kss-autogen-guide-markup[data-kss-format="html-cooked"]::before { content: 'Cooked HTML:'; }
+  .kss-markup .-kss-autogen-guide-markup[data-kss-format="html-baked"]::before { content: 'Baked HTML:'; }
 
-  /* Only show the rendered "cooked" HTML */
-  .kss-modifier__example > .-kss-autogen-guide-markup:not([data-kss-format="html-cooked"]) { display: none; }
+  /* Only show the rendered "baked" HTML */
+  .kss-modifier__example > .-kss-autogen-guide-markup:not([data-kss-format="html-baked"]) { display: none; }
   </style>
 </head>
 <body id="kss-node">
@@ -34,7 +34,7 @@
   </header>
 
   <select id="choose-which-format-to-look-at">
-    <option value="html-cooked">Show Cooked HTML</option>
+    <option value="html-baked">Show Baked HTML</option>
     <option value="html-raw">Show Raw HTML</option>
     <option value="-all">Show All Formats</option>
     <option value="-none">Show No Formats</option>

--- a/js/openstax-kss-builder/public/kss.js
+++ b/js/openstax-kss-builder/public/kss.js
@@ -13,7 +13,7 @@
   var markupNodes = toArray(document.querySelectorAll('.kss-markup')).forEach(function(markupEl) {
 
     // The <pre> tag contains text representing 2 <section> elements;
-    // 1 for the Raw HTML and 1 for the cooked HTML.
+    // 1 for the Raw HTML and 1 for the baked HTML.
     //
     // 1. Pull them into a div (so the extra <html> and <body> tags are removed)
     // 2. Insert them back into the DOM with a little heading describing what they do
@@ -23,7 +23,7 @@
     var containerToParseMarkup = document.createElement('div');
     containerToParseMarkup.innerHTML=preEl.innerText;
 
-    // Some conversions apparently don't have a Raw HTML and a Cooked HTML.
+    // Some conversions apparently don't have a Raw HTML and a Baked HTML.
     // probably because they are Page or Metadata snippets and are inline in the HTML
     // so skip them.
     if (containerToParseMarkup.querySelector('.-kss-autogen-guide-markup')) {

--- a/scripts/bake-book
+++ b/scripts/bake-book
@@ -6,7 +6,7 @@ BOOK_NAME=$1
 DEBUG_FLAG=$2
 
 RAW_PATH="./data/${BOOK_NAME}-raw.html"
-COOKED_PATH="./data/${BOOK_NAME}-cooked.html"
+BAKED_PATH="./data/${BOOK_NAME}-baked.html"
 
 # Check command line args
 
@@ -38,10 +38,10 @@ fi
 bundle exec sass ${SASS_PATH} ${CSS_PATH}
 
 >&2 echo "Step 2/2: Baking the book (may take a couple minutes). specify additional commandline arguments like -d to this script if you want more debugging"
->&2 echo "Info: Baking ${RAW_PATH} to ${COOKED_PATH} using ${CSS_PATH}"
+>&2 echo "Info: Baking ${RAW_PATH} to ${BAKED_PATH} using ${CSS_PATH}"
 
-# Remove the cooked file if it exists
-[ -e "${COOKED_PATH}" ] && rm ${COOKED_PATH}
+# Remove the baked file if it exists
+[ -e "${BAKED_PATH}" ] && rm ${BAKED_PATH}
 
 # Activate the venv if not running Travis or already in a virtualenv
 if [[ ! "${CI}" = "true" && -z "${VIRTUAL_ENV}" ]]
@@ -49,7 +49,6 @@ then
   . ./venv/bin/activate
 fi
 
-cnx-easybake ${DEBUG_FLAG} ${CSS_PATH} ${RAW_PATH} ${COOKED_PATH}
-
+cnx-easybake ${DEBUG_FLAG} ${CSS_PATH} ${RAW_PATH} ${BAKED_PATH}
 # Validate the cooked file
-cnx-epub-validate-collated ${COOKED_PATH}
+cnx-epub-validate-collated ${BAKED_PATH}

--- a/scripts/bake-file
+++ b/scripts/bake-file
@@ -3,7 +3,7 @@ set -e
 
 BOOK_NAME=$1
 RAW_PATH=$2
-COOKED_PATH=$3
+BAKED_PATH=$3
 DEBUG_FLAG=$4
 
 SASS_PATH="./books/rulesets/${BOOK_NAME}/book.scss"
@@ -14,7 +14,7 @@ CSS_PATH="./books/rulesets/output/${BOOK_NAME}.css"
 if [ -z "${BOOK_NAME}" ]
 then
   echo 'ERROR: Argument Missing. You must specify the name of the book as the 1st argument. For example: physics'
-  echo 'The required arguments are: BOOK_NAME, RAW_PATH, COOKED_PATH'
+  echo 'The required arguments are: BOOK_NAME, RAW_PATH, BAKED_PATH'
   exit 1
 fi
 
@@ -24,9 +24,9 @@ then
   exit 1
 fi
 
-if [ -z "${COOKED_PATH}" ]
+if [ -z "${BAKED_PATH}" ]
 then
-  echo 'ERROR: You must specify a cooked path'
+  echo 'ERROR: You must specify a baked path'
   exit 1
 fi
 
@@ -37,8 +37,8 @@ then
 fi
 
 
-# Remove the cooked file if it exists
-# [ -e "${COOKED_PATH}" ] && rm ${COOKED_PATH}
+# Remove the baked file if it exists
+# [ -e "${BAKED_PATH}" ] && rm ${BAKED_PATH}
 # commented out because it could be /dev/stdout
 
 # Activate the venv if not running Travis or already in a virtualenv
@@ -47,7 +47,7 @@ then
   . ./venv/bin/activate
 fi
 
-cnx-easybake ${DEBUG_FLAG} ${CSS_PATH} ${RAW_PATH} ${COOKED_PATH}
+cnx-easybake ${DEBUG_FLAG} ${CSS_PATH} ${RAW_PATH} ${BAKED_PATH}
 # Validate the cooked file.
 # Commented because snippets do not pass the data-type="metadata" validation
 # and adding in all those metadata blocks would be cumbersome and distract

--- a/scripts/diff-book
+++ b/scripts/diff-book
@@ -5,7 +5,7 @@ set -e
 BOOK_NAME=$1
 DEBUG_FLAG=$2
 
-COOKED_PATH="./data/${BOOK_NAME}-cooked.html"
+BAKED_PATH="./data/${BOOK_NAME}-baked.html"
 PREPARED_PATH="./data/${BOOK_NAME}-prepared.html"
 
 # Check command line args
@@ -28,4 +28,4 @@ fi
 
 ./scripts/bake-book ${BOOK_NAME}
 
-diff ${PREPARED_PATH} ${COOKED_PATH}
+diff ${PREPARED_PATH} ${BAKED_PATH}

--- a/scripts/diff-book-prepare
+++ b/scripts/diff-book-prepare
@@ -5,7 +5,7 @@ set -e
 BOOK_NAME=$1
 DEBUG_FLAG=$2
 
-COOKED_PATH="./data/${BOOK_NAME}-cooked.html"
+BAKED_PATH="./data/${BOOK_NAME}-baked.html"
 PREPARED_PATH="./data/${BOOK_NAME}-prepared.html"
 
 # Check command line args
@@ -21,4 +21,4 @@ fi
 
 ./scripts/bake-book ${BOOK_NAME}
 
-mv ${COOKED_PATH} ${PREPARED_PATH}
+mv ${BAKED_PATH} ${PREPARED_PATH}

--- a/scripts/generate-guide
+++ b/scripts/generate-guide
@@ -38,7 +38,7 @@ bundle exec sass ${SASS_PATH} ${CSS_PATH} || exit 1
 bundle exec sass ${SASS_PATH} ${BOOK_CSS_PATH} || exit 1
 
 
->&2 echo "Step 2/4: Generate the cooked example HTML files"
+>&2 echo "Step 2/4: Generate the baked example HTML files"
 
 # Create a temporary directory which contains the rulesets/common/ and rulesets/${BOOK_NAME} directories.
 # This is because we want the styleguide to contain docs of all the common/ elements
@@ -54,22 +54,22 @@ cp -R "${BOOK_DOCUMENTATION_DIR}" "${TEMP_DIR}" || exit 1
 
 for FILE_NAME in $(find "${TEMP_DIR}" -name "*.html")
 do
-  >&2 echo "Generating temporary ${FILE_NAME}-cooked.html"
+  >&2 echo "Generating temporary ${FILE_NAME}-baked.html"
   # commented because xmllint does not like html5 element names like <figure>
-  # ./scripts/bake-file ${BOOK_NAME} ${FILE_NAME} /dev/stdout | xmllint --html --format - > ${FILE_NAME}-cooked.html
-  ./scripts/bake-file ${BOOK_NAME} ${FILE_NAME} ${FILE_NAME}-temp1-cooked.html || exit 1
+  # ./scripts/bake-file ${BOOK_NAME} ${FILE_NAME} /dev/stdout | xmllint --html --format - > ${FILE_NAME}-baked.html
+  ./scripts/bake-file ${BOOK_NAME} ${FILE_NAME} ${FILE_NAME}-temp1-baked.html || exit 1
 
-  # Construct an HTML file that contains both the raw and cooked HTML
+  # Construct an HTML file that contains both the raw and baked HTML
   # so it can be separated in the browser
   # (and so Phil does not have to completely rewrite kss becuase it assumes only 1 file for markup)
-  echo '<section class="-kss-autogen-guide-markup" data-kss-format="html-raw">' > ${FILE_NAME}-cooked.html || exit 1
-  cat ${FILE_NAME} >> ${FILE_NAME}-cooked.html || exit 1
-  echo '</section>' >> ${FILE_NAME}-cooked.html || exit 1
-  echo '<section class="-kss-autogen-guide-markup" data-kss-format="html-cooked">' >> ${FILE_NAME}-cooked.html || exit 1
-  cat ${FILE_NAME}-temp1-cooked.html >> ${FILE_NAME}-cooked.html || exit 1
-  echo '</section>' >> ${FILE_NAME}-cooked.html || exit 1
+  echo '<section class="-kss-autogen-guide-markup" data-kss-format="html-raw">' > ${FILE_NAME}-baked.html || exit 1
+  cat ${FILE_NAME} >> ${FILE_NAME}-baked.html || exit 1
+  echo '</section>' >> ${FILE_NAME}-baked.html || exit 1
+  echo '<section class="-kss-autogen-guide-markup" data-kss-format="html-baked">' >> ${FILE_NAME}-baked.html || exit 1
+  cat ${FILE_NAME}-temp1-baked.html >> ${FILE_NAME}-baked.html || exit 1
+  echo '</section>' >> ${FILE_NAME}-baked.html || exit 1
 
-  rm ${FILE_NAME}-temp1-cooked.html || exit 1
+  rm ${FILE_NAME}-temp1-baked.html || exit 1
 done
 
 
@@ -80,8 +80,8 @@ done
 
 
 # Delete the temp files created above
->&2 echo "Step 4/4: Deleting the cooked example HTML files"
-for FILE_NAME in $(find ./books/rulesets/ -name "*-cooked.html")
+>&2 echo "Step 4/4: Deleting the baked example HTML files"
+for FILE_NAME in $(find ./books/rulesets/ -name "*-baked.html")
 do
   # echo "Removing temporary ${FILE_NAME}"
   rm ${FILE_NAME} || exit 1


### PR DESCRIPTION
also had to rename “cooked” to “baked” and “cooking” to “baking” while
preserving case
# TODO

I might also clean up the scripts so:
- [x] virtualenv is installed in `/venv/` instead of `.` (makes it easier to remove it since the `/bin`, `/lib/`, `/pip-selfcheck.json`, and `/src/` dirs will all be in the `./venv` dir.
- [ ] clean up the bash scripts so they follow dennis' conventions in #61
