### PR TITLE
add script to retrigger baking a book remotely

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,21 @@ You can pass 3 additional arguments to `report-book-coverage` to change how it r
 For more details on the commandline options see the [css-coverage](https://www.npmjs.com/package/css-coverage#commandline-options) documentation.
 
 
-# Deploy
+## Deploy
 
 To update a development instance you need to rebake a book.
 To do that, you will need to upload a CSS ruleset file, trigger a rebake, and then clear the cache.
 
 1. run `./scripts/compile-books` to generate the rulesets CSS file
 1. run `./scripts/bake-book-remote ${BOOK_NAME} ${VERSION}` to upload, trigger, and clear the cache
+
+### Example
+
+For example, you want to rebake the "cooking" book:
+
+1. you can run `./scripts/bake-book-remote cooking` and it will tell you to go to `http://foo.cnx.org/contents/${UUID}`
+1. find the version (ie `7.16`) by looking at the URL or by clicking “More Information” at the bottom of the page
+1. run `./scripts/bake-book-remote cooking 7.16` (using that version you found)
 
 
 ## Regression Testing

--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ To do that, you will need to upload a CSS ruleset file, trigger a rebake, and th
 1. run `./scripts/compile-books` to generate the rulesets CSS file
 1. run `./scripts/bake-book-remote ${BOOK_NAME} ${VERSION}` to upload, trigger, and clear the cache
 
+  - `${BOOK_NAME]` is the book’s name in the book list of `/books.txt`
+  - `${VERSION]` is the `@#.##` in the target collection URL
+
 ### Example
 
 For example, you want to rebake the "cooking" book:

--- a/README.md
+++ b/README.md
@@ -53,6 +53,16 @@ You can pass 3 additional arguments to `report-book-coverage` to change how it r
 
 For more details on the commandline options see the [css-coverage](https://www.npmjs.com/package/css-coverage#commandline-options) documentation.
 
+
+# Deploy
+
+To update a development instance you need to rebake a book.
+To do that, you will need to upload a CSS ruleset file, trigger a rebake, and then clear the cache.
+
+1. run `./scripts/compile-books` to generate the rulesets CSS file
+1. run `./scripts/bake-book-remote ${BOOK_NAME} ${VERSION}` to upload, trigger, and clear the cache
+
+
 ## Regression Testing
 
 To check that there were no regressions in a book what the following process does is:

--- a/scripts/bake-book-remote
+++ b/scripts/bake-book-remote
@@ -39,10 +39,12 @@ else
   BOOK_LIST="${ARG1}"
 fi
 
-. ./bin/activate
+# Activate the venv if not running Travis or already in a virtualenv
+if [[ ! "${CI}" = "true" && -z "${VIRTUAL_ENV}" ]]
+then
+  . ./venv/bin/activate
+fi
 
-
->&2 echo "Preparing to fetch book(s): ${BOOK_LIST}"
 
 for BOOK_NAME in ${BOOK_LIST}
 do
@@ -67,22 +69,22 @@ do
     exit 1
   fi
 
-  >&2 echo "Baking book ${BOOK_NAME} ${BOOK_UUID_AND_VER} on ${HOST}"
+  >&2 echo "==> Baking book ${BOOK_NAME} ${BOOK_UUID_AND_VER} on ${HOST} ..."
 
   TEMP_CSS_PATH="~/temp.css"
 
-  >&2 echo "Step 1/4: Copying CSS file from local machine to server"
+  >&2 echo "==> Copying CSS file from local machine to server"
   scp ${CSS_PATH} ${USER}@${HOST}:${TEMP_CSS_PATH}
 
-  >&2 echo "Step 2/4: Injecting the css file into the book as ruleset.css"
+  >&2 echo "==> Injecting the css file into the book as ruleset.css"
 
   BUILD_BOOK_CMD="/var/cnx/venvs/archive/bin/cnx-archive-inject_resource --resource-filename \"ruleset.css\" --media-type \"text/css\" /etc/cnx/archive/app.ini \"${BOOK_UUID_AND_VER}@${BOOK_VERSION}\" ${TEMP_CSS_PATH}"
   ssh ${USER}@${HOST} ${BUILD_BOOK_CMD}
 
-  >&2 echo "Step 3/4: Re-baking the book (may take up to 12 minutes)"
+  >&2 echo "==> Re-baking the book (may take up to 12 minutes)"
   python -c "import requests; resp = requests.post('http://${HOST}:6543/contents/${BOOK_UUID_AND_VER}@${BOOK_VERSION}/collate-content', headers={'x-api-key': 'cte-dev--sprint-6.7'}); print(resp)"
 
-  >&2 echo "Step 4/4: restarting varnish because the HTML files may be cached"
+  >&2 echo "==> restarting varnish because the HTML files may be cached"
   RESTART_VARNISH_CMD="varnishadm ban req.url '~' ."
   ssh ${USER}@${HOST} ${RESTART_VARNISH_CMD}
 

--- a/scripts/bake-book-remote
+++ b/scripts/bake-book-remote
@@ -79,12 +79,13 @@ do
   ssh ${USER}@${HOST} ${BUILD_BOOK_CMD}
 
   >&2 echo "Step 3/4: Re-baking the book (may take up to 12 minutes)"
+  >&2 echo "          Afterwards, it will prompt you for a password to reset the server cache"
   python -c "import requests; resp = requests.post('http://${HOST}:6543/contents/${BOOK_UUID_AND_VER}@${BOOK_VERSION}/collate-content', headers={'x-api-key': 'cte-dev--sprint-6.7'}); print(resp)"
 
   >&2 echo "Step 4/4: restarting varnish (optional) because the HTML files may be cached"
   RESTART_VARNISH_CMD="sudo service varnish restart"
   ssh -t ${USER}@${HOST} ${RESTART_VARNISH_CMD}
 
-  >&2 echo "Build complete."
+  >&2 echo "Build complete. See the changes by going to http://${HOST}/contents/${BOOK_UUID_AND_VER}@${BOOK_VERSION}"
 
 done

--- a/scripts/bake-book-remote
+++ b/scripts/bake-book-remote
@@ -1,0 +1,81 @@
+#!/bin/sh
+set -e
+
+# This re-bakes a book on ${HOST} (or all books if using the --all argument)
+
+# Snippet that inspired this script:
+#
+# To "re-bake” a book is something like:
+# - Inject a ruleset into the archive in association with the book to be collated.
+# `wget https://raw.githubusercontent.com/Connexions/cte/rulesets/books/rulesets/output/physics.css`
+# `/var/cnx/venvs/archive/bin/cnx-archive-inject_resource --resource-filename "ruleset.css" --media-type "text/css" /etc/cnx/archive/app.ini 031da8d3-b525-429c-80cf-6c8ed997733a@9.30 physics.css`
+# - Invoke the collation via a the python interpreter `import requests; resp = requests.post('http://cte-cnx-dev.cnx.org:6543/contents/031da8d3-b525-429c-80cf-6c8ed997733a/collate-content', headers={'x-api-key': 'cte-dev--sprint-6.7'}); print(resp)`
+# Originally from: https://gist.github.com/pumazi/93f5ed32cb9e094e5a97415ced480a16
+
+HOST='cte-cnx-dev.cnx.org'
+
+ARG1=$1
+BOOK_VERSION=$2
+
+# Check command line args
+
+if [ -z "${ARG1}" ]
+then
+  >&2 echo 'ERROR: Argument Missing. You must specify the name of the book as the 1st argument or --all for all books. For example: physics'
+  exit 1
+fi
+
+# if [ "${ARG1}" == "--all" ]
+# then
+#   source ./books.txt
+# else
+#   BOOK_LIST="${ARG1}"
+# fi
+if [ "${ARG1}" == "--all" ]
+then
+  >&2 echo "--all is not a valid option because you have to specify a version for the book you want to rebake"
+  exit 1
+fi
+
+if [ -z "${BOOK_VERSION}" ]
+then
+  >&2 echo 'ERROR: Argument Missing. You must specify the book version as the 2nd argument for what you want to cook (I know, it is annoying)'
+  exit 1
+fi
+
+
+>&2 echo "Preparing to fetch book(s): ${BOOK_LIST}"
+
+for BOOK_NAME in ${BOOK_LIST}
+do
+
+  RULESET_NAME_AND_UUID=($(./scripts/_convert-bookname-to-ruleset-name-and-uuid ${BOOK_NAME}))
+  RULESET_NAME=${RULESET_NAME_AND_UUID[0]}
+  BOOK_UUID_AND_VER=${RULESET_NAME_AND_UUID[1]}
+
+  CSS_PATH="./books/rulesets/output/${RULESET_NAME}.css"
+
+  if [ -z "${BOOK_UUID_AND_VER}" ]
+  then
+    >&2 echo "ERROR: Could not find Book UUID for book named ${BOOK_NAME}"
+    exit 1
+  fi
+
+  >&2 echo "Baking book ${BOOK_NAME} ${BOOK_UUID_AND_VER} on ${HOST}"
+
+  TEMP_CSS_PATH="~/temp.css"
+
+  >&2 echo "Step 1/3: Copying CSS file from local machine to server"
+  scp ${CSS_PATH} ${USER}@${HOST}:${TEMP_CSS_PATH}
+
+  >&2 echo "Step 2/3: Baking the book (may take a minute)"
+
+  BUILD_BOOK_CMD="/var/cnx/venvs/archive/bin/cnx-archive-inject_resource --resource-filename \"ruleset.css\" --media-type \"text/css\" /etc/cnx/archive/app.ini \"${BOOK_UUID_AND_VER}\" ${TEMP_CSS_PATH}"
+  INVOKE_COLLATION_CMD="python -c 'import requests; resp = requests.post(\"http://${HOST}:6543/contents/${BOOK_UUID_AND_VER}@${BOOK_VERSION}/collate-content\", headers={\"x-api-key\": \"cte-dev--sprint-6.7\"}); print(resp)'"
+  CMD="${BUILD_BOOK_CMD} && ${INVOKE_COLLATION_CMD}"
+
+  ssh ${USER}@${HOST} ${CMD}
+
+  >&2 echo "Build has hopefully been triggered."
+
+done

--- a/scripts/bake-book-remote
+++ b/scripts/bake-book-remote
@@ -83,7 +83,7 @@ do
 
   >&2 echo "Step 4/4: restarting varnish (optional) because the HTML files may be cached"
   RESTART_VARNISH_CMD="sudo service varnish restart"
-  ssh ${USER}@${HOST} ${RESTART_VARNISH_CMD}
+  ssh -t ${USER}@${HOST} ${RESTART_VARNISH_CMD}
 
   >&2 echo "Build complete."
 

--- a/scripts/bake-book-remote
+++ b/scripts/bake-book-remote
@@ -70,17 +70,21 @@ do
 
   TEMP_CSS_PATH="~/temp.css"
 
-  >&2 echo "Step 1/3: Copying CSS file from local machine to server"
+  >&2 echo "Step 1/4: Copying CSS file from local machine to server"
   scp ${CSS_PATH} ${USER}@${HOST}:${TEMP_CSS_PATH}
 
-  >&2 echo "Step 2/3: Injecting the css file into the book as ruleset.css"
+  >&2 echo "Step 2/4: Injecting the css file into the book as ruleset.css"
 
   BUILD_BOOK_CMD="/var/cnx/venvs/archive/bin/cnx-archive-inject_resource --resource-filename \"ruleset.css\" --media-type \"text/css\" /etc/cnx/archive/app.ini \"${BOOK_UUID_AND_VER}@${BOOK_VERSION}\" ${TEMP_CSS_PATH}"
   ssh ${USER}@${HOST} ${BUILD_BOOK_CMD}
 
-  >&2 echo "Step 3/3: Re-baking the book (may take a couple minutes)"
+  >&2 echo "Step 3/4: Re-baking the book (may take up to 12 minutes)"
   python -c "import requests; resp = requests.post('http://${HOST}:6543/contents/${BOOK_UUID_AND_VER}@${BOOK_VERSION}/collate-content', headers={'x-api-key': 'cte-dev--sprint-6.7'}); print(resp)"
 
-  >&2 echo "Build has hopefully been triggered."
+  >&2 echo "Step 4/4: restarting varnish (optional) because the HTML files may be cached"
+  RESTART_VARNISH_CMD="sudo service varnish restart"
+  ssh ${USER}@${HOST} ${RESTART_VARNISH_CMD}
+
+  >&2 echo "Build complete."
 
 done

--- a/scripts/bake-book-remote
+++ b/scripts/bake-book-remote
@@ -21,7 +21,7 @@ BOOK_VERSION=$2
 
 if [ -z "${ARG1}" ]
 then
-  >&2 echo 'ERROR: Argument Missing. You must specify the name of the book as the 1st argument or --all for all books. For example: physics'
+  >&2 echo 'ERROR: Argument Missing. You must specify the name of the book as the 1st argument or --all for all books (see books.txt). For example: physics'
   exit 1
 fi
 
@@ -62,6 +62,7 @@ do
   if [ -z "${BOOK_VERSION}" ]
   then
     >&2 echo 'ERROR: Argument Missing. You must specify the book version as the 2nd argument for what you want to cook (I know, it is annoying)'
+    >&2 echo 'The version is the @#.## in the target collection URL'
     >&2 echo "You can visit http://${HOST}/contents/${BOOK_UUID_AND_VER} to get the version number"
     exit 1
   fi
@@ -79,7 +80,9 @@ do
   ssh ${USER}@${HOST} ${BUILD_BOOK_CMD}
 
   >&2 echo "Step 3/4: Re-baking the book (may take up to 12 minutes)"
-  >&2 echo "          Afterwards, it will prompt you for a password to reset the server cache"
+  >&2 echo ""
+  >&2 echo "In a few minutes (~7) you will be prompted"
+  >&2 echo "for a password to reset the server cache"
   python -c "import requests; resp = requests.post('http://${HOST}:6543/contents/${BOOK_UUID_AND_VER}@${BOOK_VERSION}/collate-content', headers={'x-api-key': 'cte-dev--sprint-6.7'}); print(resp)"
 
   >&2 echo "Step 4/4: restarting varnish (optional) because the HTML files may be cached"

--- a/scripts/bake-book-remote
+++ b/scripts/bake-book-remote
@@ -80,14 +80,11 @@ do
   ssh ${USER}@${HOST} ${BUILD_BOOK_CMD}
 
   >&2 echo "Step 3/4: Re-baking the book (may take up to 12 minutes)"
-  >&2 echo ""
-  >&2 echo "In a few minutes (~7) you will be prompted"
-  >&2 echo "for a password to reset the server cache"
   python -c "import requests; resp = requests.post('http://${HOST}:6543/contents/${BOOK_UUID_AND_VER}@${BOOK_VERSION}/collate-content', headers={'x-api-key': 'cte-dev--sprint-6.7'}); print(resp)"
 
-  >&2 echo "Step 4/4: restarting varnish (optional) because the HTML files may be cached"
-  RESTART_VARNISH_CMD="sudo service varnish restart"
-  ssh -t ${USER}@${HOST} ${RESTART_VARNISH_CMD}
+  >&2 echo "Step 4/4: restarting varnish because the HTML files may be cached"
+  RESTART_VARNISH_CMD="varnishadm ban req.url '~' ."
+  ssh ${USER}@${HOST} ${RESTART_VARNISH_CMD}
 
   >&2 echo "Build complete. See the changes by going to http://${HOST}/contents/${BOOK_UUID_AND_VER}@${BOOK_VERSION}"
 

--- a/scripts/bake-book-remote
+++ b/scripts/bake-book-remote
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 # This re-bakes a book on ${HOST} (or all books if using the --all argument)
@@ -35,13 +35,11 @@ if [ "${ARG1}" == "--all" ]
 then
   >&2 echo "--all is not a valid option because you have to specify a version for the book you want to rebake"
   exit 1
+else
+  BOOK_LIST="${ARG1}"
 fi
 
-if [ -z "${BOOK_VERSION}" ]
-then
-  >&2 echo 'ERROR: Argument Missing. You must specify the book version as the 2nd argument for what you want to cook (I know, it is annoying)'
-  exit 1
-fi
+. ./bin/activate
 
 
 >&2 echo "Preparing to fetch book(s): ${BOOK_LIST}"
@@ -61,6 +59,13 @@ do
     exit 1
   fi
 
+  if [ -z "${BOOK_VERSION}" ]
+  then
+    >&2 echo 'ERROR: Argument Missing. You must specify the book version as the 2nd argument for what you want to cook (I know, it is annoying)'
+    >&2 echo "You can visit http://${HOST}/contents/${BOOK_UUID_AND_VER} to get the version number"
+    exit 1
+  fi
+
   >&2 echo "Baking book ${BOOK_NAME} ${BOOK_UUID_AND_VER} on ${HOST}"
 
   TEMP_CSS_PATH="~/temp.css"
@@ -68,13 +73,13 @@ do
   >&2 echo "Step 1/3: Copying CSS file from local machine to server"
   scp ${CSS_PATH} ${USER}@${HOST}:${TEMP_CSS_PATH}
 
-  >&2 echo "Step 2/3: Baking the book (may take a minute)"
+  >&2 echo "Step 2/3: Injecting the css file into the book as ruleset.css"
 
-  BUILD_BOOK_CMD="/var/cnx/venvs/archive/bin/cnx-archive-inject_resource --resource-filename \"ruleset.css\" --media-type \"text/css\" /etc/cnx/archive/app.ini \"${BOOK_UUID_AND_VER}\" ${TEMP_CSS_PATH}"
-  INVOKE_COLLATION_CMD="python -c 'import requests; resp = requests.post(\"http://${HOST}:6543/contents/${BOOK_UUID_AND_VER}@${BOOK_VERSION}/collate-content\", headers={\"x-api-key\": \"cte-dev--sprint-6.7\"}); print(resp)'"
-  CMD="${BUILD_BOOK_CMD} && ${INVOKE_COLLATION_CMD}"
+  BUILD_BOOK_CMD="/var/cnx/venvs/archive/bin/cnx-archive-inject_resource --resource-filename \"ruleset.css\" --media-type \"text/css\" /etc/cnx/archive/app.ini \"${BOOK_UUID_AND_VER}@${BOOK_VERSION}\" ${TEMP_CSS_PATH}"
+  ssh ${USER}@${HOST} ${BUILD_BOOK_CMD}
 
-  ssh ${USER}@${HOST} ${CMD}
+  >&2 echo "Step 3/3: Re-baking the book (may take a couple minutes)"
+  python -c "import requests; resp = requests.post('http://${HOST}:6543/contents/${BOOK_UUID_AND_VER}@${BOOK_VERSION}/collate-content', headers={'x-api-key': 'cte-dev--sprint-6.7'}); print(resp)"
 
   >&2 echo "Build has hopefully been triggered."
 

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -8,18 +8,18 @@ set -e
 cd "$(dirname "$0")/.."
 
 if [ -f "Brewfile" ] && [ "$(uname -s)" = "Darwin" ]; then
-  echo "==> Updating Homebrew…"
+  >&2 echo "==> Updating Homebrew…"
   brew update
 
   brew bundle check >/dev/null 2>&1  || {
-    echo "==> Installing Homebrew dependencies…"
+    >&2 echo "==> Installing Homebrew dependencies…"
     brew bundle
   }
 fi
 
 # Note: Skip rbenv for Travis because it already has ruby
 if [ ! "${CI}" = "true" ] && [ -f ".ruby-version" ] && [ -z "$(rbenv version-name 2>/dev/null)" ]; then
-  echo "==> Installing Ruby…"
+  >&2 echo "==> Installing Ruby…"
   rbenv install --skip-existing
   which bundle >/dev/null 2>&1  || {
     gem install bundler
@@ -28,7 +28,7 @@ if [ ! "${CI}" = "true" ] && [ -f ".ruby-version" ] && [ -z "$(rbenv version-nam
 fi
 
 if [ -f "Gemfile" ]; then
-  echo "==> Installing gem dependencies…"
+  >&2 echo "==> Installing gem dependencies…"
   bundle check --path vendor/gems >/dev/null 2>&1  || {
     bundle install --path vendor/gems --quiet --without production
   }

--- a/scripts/setup
+++ b/scripts/setup
@@ -9,11 +9,11 @@ then
   # Only activate the virtualenv if not already in one
   if [[ -z "${VIRTUAL_ENV}" ]]
   then
-    echo "==> Setting up a python virtualenv"
+    >&2 echo "==> Setting up a python virtualenv"
     virtualenv ./venv/
     . ./venv/bin/activate
   else
-    echo "==> Skipping virtualenv because already in one"
+    >&2 echo "==> Skipping virtualenv because already in one"
   fi
 fi
 
@@ -21,7 +21,7 @@ fi
 if [[ ( "${CI}" = "true" ) || ( -n "${VIRTUAL_ENV}" ) ]]
 then
 
-  echo "==> Installing python packages"
+  >&2 echo "==> Installing python packages"
   pip install -r ./requirements.txt
 
 else
@@ -29,5 +29,5 @@ else
   exit 1
 fi
 
-echo "==> Installing sassdoc (depends on NodeJS)"
+>&2 echo "==> Installing sassdoc (depends on NodeJS)"
 npm install

--- a/scripts/update
+++ b/scripts/update
@@ -11,10 +11,10 @@ fi
 
 if [[ ( "${CI}" = "true" ) || ( -n "${VIRTUAL_ENV}" ) ]]
 then
-  echo '==> Uninstalling python packages'
+  >&2 echo '==> Uninstalling python packages'
   pip uninstall --yes -r requirements.txt
 
-  echo '==> Reinstalling python packages'
+  >&2 echo '==> Reinstalling python packages'
   pip install -r requirements.txt
 
 else
@@ -22,5 +22,5 @@ else
   exit 1
 fi
 
-echo "==> Updating sassdoc to the version listed in package.json"
+>&2 echo "==> Updating sassdoc to the version listed in package.json"
 npm install


### PR DESCRIPTION
This adds `./scripts/bake-book-remote ${BOOK_NAME} ${VERSION}` which retriggers a bake using the css file in `./books/rulesets/output/`

# Rebake

To update a development instance you need to rebake a book.
To do that, you will need to upload a CSS ruleset file, trigger a rebake, and then clear the cache.

1. run `./scripts/compile-books` to generate the rulesets CSS file
1. run `./scripts/bake-book-remote ${BOOK_NAME} ${VERSION}` to upload, trigger rebake, and clear the cache


# TODO
- [x] update `README.md`

/cc @Stackblocks for feedback