### PR TITLE
add space divider for chapters and sections

### DIFF
--- a/books/rulesets/economics/_config.scss
+++ b/books/rulesets/economics/_config.scss
@@ -170,15 +170,18 @@ $bookCompositePages: (
 //Usage Note: key: class of the containing span, value: text that will go inside span
 $chapterTitleContent: (
   number: counter(chapter),
+  divider: ' '
 );
 
 $appendixTitleContent: (
   title-label: "Appendix ",
   number: counter(appendix, upper-alpha),
+  divider: ' '
 );
 
 $sectionTitleContent: (
   number: counter(chapter) "." counter(section),
+  divider: ' '
 );
 
 $exerciseTitleContent: (

--- a/books/rulesets/output/economics.css
+++ b/books/rulesets/output/economics.css
@@ -441,6 +441,11 @@
   content: counter(chapter);
   class: os-number;
   move-to: bChapterLabel; }
+:pass(1) div[data-type="chapter"]::before {
+  container: span;
+  content: " ";
+  class: os-divider;
+  move-to: bChapterLabel; }
 :pass(1) div[data-type="chapter"] > [data-type="document-title"] {
   container: h1;
   content: pending(bChapterLabel) content(); }
@@ -458,6 +463,11 @@
   content: counter(appendix,upper-alpha);
   class: os-number;
   move-to: bAppendixLabel; }
+:pass(1) div.appendix::before {
+  container: span;
+  content: " ";
+  class: os-divider;
+  move-to: bAppendixLabel; }
 :pass(1) div.appendix > [data-type="document-title"] {
   container: h1;
   content: pending(bAppendixLabel) content(); }
@@ -469,6 +479,11 @@
   container: span;
   content: counter(chapter) "." counter(section);
   class: os-number;
+  move-to: bSectionLabel; }
+:pass(1) div[data-type="chapter"] > div[data-type="page"]:not(.introduction)::before {
+  container: span;
+  content: " ";
+  class: os-divider;
   move-to: bSectionLabel; }
 :pass(1) div[data-type="chapter"] > div[data-type="page"]:not(.introduction) > [data-type="document-title"] {
   container: h2;

--- a/books/rulesets/output/statistics.css
+++ b/books/rulesets/output/statistics.css
@@ -286,6 +286,11 @@
   content: counter(chapter);
   class: os-number;
   move-to: bChapterLabel; }
+:pass(1) div[data-type="chapter"]::before {
+  container: span;
+  content: " ";
+  class: os-divider;
+  move-to: bChapterLabel; }
 :pass(1) div[data-type="chapter"] > [data-type="document-title"] {
   container: h1;
   content: pending(bChapterLabel) content(); }
@@ -303,6 +308,11 @@
   content: counter(appendix,upper-alpha);
   class: os-number;
   move-to: bAppendixLabel; }
+:pass(1) div.appendix::before {
+  container: span;
+  content: " ";
+  class: os-divider;
+  move-to: bAppendixLabel; }
 :pass(1) div.appendix > [data-type="document-title"] {
   container: h1;
   content: pending(bAppendixLabel) content(); }
@@ -314,6 +324,11 @@
   container: span;
   content: counter(chapter) "." counter(section);
   class: os-number;
+  move-to: bSectionLabel; }
+:pass(1) div[data-type="chapter"] > div[data-type="page"]:not(.introduction)::before {
+  container: span;
+  content: " ";
+  class: os-divider;
   move-to: bSectionLabel; }
 :pass(1) div[data-type="chapter"] > div[data-type="page"]:not(.introduction) > [data-type="document-title"] {
   container: h2;

--- a/books/rulesets/statistics/_config.scss
+++ b/books/rulesets/statistics/_config.scss
@@ -102,15 +102,18 @@ $bookCompositePages: (
 //Usage Note: key: class of the containing span, value: text that will go inside span
 $chapterTitleContent: (
   number: counter(chapter),
+  divider: ' '
 );
 
 $appendixTitleContent: (
   title-label: "Appendix ",
   number: counter(appendix, upper-alpha),
+  divider: ' '
 );
 
 $sectionTitleContent: (
   number: counter(chapter) "." counter(section),
+  divider: ' '
 );
 
 $exerciseTitleContent: (


### PR DESCRIPTION
This partially undoes the changes in #91 to add better spacing between the chapter number and the title.

![image](https://cloud.githubusercontent.com/assets/253202/19832332/6a766850-9def-11e6-9781-2c64a1b12c0e.png)

# Test Criteria

- re-bake the economics book and the statistics books on the dev machine and verify the spacing in the screenshot is correct

**Note:** This depends on #94 being merged (so @Stackblocks can rebake the dev machine and verify)