### PR TITLE
make dependencies more pythonic

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+requests
+git+https://github.com/Connexions/cssselect2.git#egg=cssselect2
+git+https://github.com/Connexions/cnx-easybake.git
+git+https://github.com/Connexions/cnx-epub.git

--- a/scripts/setup
+++ b/scripts/setup
@@ -22,11 +22,7 @@ if [[ ( "${CI}" = "true" ) || ( -n "${VIRTUAL_ENV}" ) ]]
 then
 
   echo "==> Installing python packages"
-
-  pip install --quiet requests # Used for rebaking a book
-  pip install --quiet git+https://github.com/Connexions/cssselect2.git
-  pip install --quiet git+https://github.com/Connexions/cnx-easybake.git
-  pip install --quiet git+https://github.com/Connexions/cnx-epub.git
+  pip install -r ./requirements.txt
 
 else
   echo "ERROR. Not in a virtualenv"

--- a/scripts/update
+++ b/scripts/update
@@ -12,19 +12,10 @@ fi
 if [[ ( "${CI}" = "true" ) || ( -n "${VIRTUAL_ENV}" ) ]]
 then
   echo '==> Uninstalling python packages'
-
-  pip uninstall --quiet --yes requests # Used for rebaking a book
-  pip uninstall --quiet --yes cssselect2
-  pip uninstall --quiet --yes cnx-easybake
-  pip uninstall --quiet --yes cnx-epub
-
+  pip uninstall --yes -r requirements.txt
 
   echo '==> Reinstalling python packages'
-
-  pip install requests # Used for rebaking a book
-  pip install --quiet git+https://github.com/Connexions/cssselect2.git
-  pip install --quiet git+https://github.com/Connexions/cnx-easybake.git
-  pip install --quiet git+https://github.com/Connexions/cnx-epub.git
+  pip install -r requirements.txt
 
 else
   echo "Error. Not in a virtualenv"


### PR DESCRIPTION
This moves the python dependencies into a separate file (`requirements.txt`) to be more pythonic.

So now we have the following files:

- `/requirements.txt` : python dependencies
- `/Gemfile` : ruby dependencies
- `/package.json` : JavaScript dependencies
- `/Brewfile` : OSX system dependencies
- `/.ruby-version` : Version of ruby
- `/.nvmrc` : Version of node

/cc @reedstrm Thanks!