### PR TITLE
travis: instal the correct version of node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,17 @@
 sudo: false
+# Travis actually needs to have python, ruby, and nodejs installed.
+# It _seems_ virtualenv is only available when the language is set to python
+# When language=python it seems Travis runs this command:
+# source ~/virtualenv/python2.7/bin/activate
 language: python
 python:
   - "2.7"
+
+env:
+- NODE_VERSION="6.9.1"
+
 before_install:
+  - nvm install $NODE_VERSION
   - rvm default
 install:
   - ./scripts/setup

--- a/scripts/bake-file
+++ b/scripts/bake-file
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 BOOK_NAME=$1


### PR DESCRIPTION
Travis was using the default version of node 0.10 (like 4 years old) and over the weekend one of `sass-lint`'s dependencies updated (I think it was `eslint`) which seems to have dropped support for old versions of node.

This installs a new version of node so the linter will continue to work.

/cc @helenemccarron 