### PR TITLE
Fix ruby bundler

### DIFF
--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -21,11 +21,17 @@ fi
 if [ ! "${CI}" = "true" ] && [ -f ".ruby-version" ] && [ -z "$(rbenv version-name 2>/dev/null)" ]; then
   >&2 echo "==> Installing Ruby…"
   rbenv install --skip-existing
-  which bundle >/dev/null 2>&1  || {
-    gem install bundler
-    rbenv rehash
-  }
 fi
+
+>&2 echo "Using ruby via rbenv:"
+rbenv version
+
+which bundle >/dev/null 2>&1  || {
+  >&2 echo "==> Installing Ruby Bundler gem…"
+  rbenv version
+  gem install bundler
+  rbenv rehash
+}
 
 if [ -f "Gemfile" ]; then
   >&2 echo "==> Installing gem dependencies…"

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -23,18 +23,28 @@ if [ ! "${CI}" = "true" ] && [ -f ".ruby-version" ] && [ -z "$(rbenv version-nam
   rbenv install --skip-existing
 fi
 
->&2 echo "Using ruby via rbenv:"
-rbenv version
-
 which bundle >/dev/null 2>&1  || {
   >&2 echo "==> Installing Ruby Bundler gem…"
   rbenv version
-  gem install bundler
+  gem install bundler || {
+    >&2 echo ''
+    >&2 echo ''
+    >&2 echo '--------------- Error -------------'
+    >&2 echo 'Unable to install the bundler.'
+    >&2 echo 'You may need to add the following to ~/.bash_profile :'
+    >&2 echo ''
+    >&2 echo 'eval "$(rbenv init -)"'
+    >&2 echo ''
+    >&2 echo 'Doing this will require restarting your terminal'
+    >&2 echo 'or running "source ~/.bash_profile"'
+    exit 1
+  }
   rbenv rehash
 }
 
 if [ -f "Gemfile" ]; then
   >&2 echo "==> Installing gem dependencies…"
+  which bundle
   bundle check --path vendor/gems >/dev/null 2>&1  || {
     bundle install --path vendor/gems --quiet --without production
   }

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -18,29 +18,31 @@ if [ -f "Brewfile" ] && [ "$(uname -s)" = "Darwin" ]; then
 fi
 
 # Note: Skip rbenv for Travis because it already has ruby
-if [ ! "${CI}" = "true" ] && [ -f ".ruby-version" ] && [ -z "$(rbenv version-name 2>/dev/null)" ]; then
-  >&2 echo "==> Installing Ruby…"
-  rbenv install --skip-existing
-fi
+if [ ! "${CI}" = "true" ] && [ -f ".ruby-version" ]; then
+  if [ -z "$(rbenv version-name 2>/dev/null)" ]; then
+    >&2 echo "==> Installing Ruby…"
+    rbenv install --skip-existing
+  fi
 
-which bundle >/dev/null 2>&1  || {
-  >&2 echo "==> Installing Ruby Bundler gem…"
-  rbenv version
-  gem install bundler || {
-    >&2 echo ''
-    >&2 echo ''
-    >&2 echo '--------------- Error -------------'
-    >&2 echo 'Unable to install the bundler.'
-    >&2 echo 'You may need to add the following to ~/.bash_profile :'
-    >&2 echo ''
-    >&2 echo 'eval "$(rbenv init -)"'
-    >&2 echo ''
-    >&2 echo 'Doing this will require restarting your terminal'
-    >&2 echo 'or running "source ~/.bash_profile"'
-    exit 1
+  which bundle >/dev/null 2>&1  || {
+    >&2 echo "==> Installing Ruby Bundler gem…"
+    rbenv version
+    gem install bundler || {
+      >&2 echo ''
+      >&2 echo ''
+      >&2 echo '--------------- Error -------------'
+      >&2 echo 'Unable to install the bundler.'
+      >&2 echo 'You may need to add the following to ~/.bash_profile :'
+      >&2 echo ''
+      >&2 echo 'eval "$(rbenv init -)"'
+      >&2 echo ''
+      >&2 echo 'Doing this will require restarting your terminal'
+      >&2 echo 'or running "source ~/.bash_profile"'
+      exit 1
+    }
+    rbenv rehash
   }
-  rbenv rehash
-}
+fi
 
 if [ -f "Gemfile" ]; then
   >&2 echo "==> Installing gem dependencies…"

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -19,28 +19,31 @@ fi
 
 # Note: Skip rbenv for Travis because it already has ruby
 if [ ! "${CI}" = "true" ] && [ -f ".ruby-version" ]; then
-  if [ -z "$(rbenv version-name 2>/dev/null)" ]; then
-    >&2 echo "==> Installing Ruby…"
-    rbenv install --skip-existing
+  if [[ -n $(which rbenv) ]]; then
+
+    if [ -z "$(rbenv version-name 2>/dev/null)" ]; then
+      >&2 echo "==> Installing Ruby…"
+      rbenv install --skip-existing
+    fi
+  else
+    >&2 echo "WARNING: Skipping rbenv. Using local ruby"
   fi
+
+  # Initialize rbenv (if installed)
+  [[ -n $(which rbenv) ]] && eval "$(rbenv init -)"
 
   which bundle >/dev/null 2>&1  || {
     >&2 echo "==> Installing Ruby Bundler gem…"
-    rbenv version
     gem install bundler || {
       >&2 echo ''
       >&2 echo ''
       >&2 echo '--------------- Error -------------'
-      >&2 echo 'Unable to install the bundler.'
-      >&2 echo 'You may need to add the following to ~/.bash_profile :'
-      >&2 echo ''
-      >&2 echo 'eval "$(rbenv init -)"'
-      >&2 echo ''
-      >&2 echo 'Doing this will require restarting your terminal'
-      >&2 echo 'or running "source ~/.bash_profile"'
+      >&2 echo 'Problem installing ruby bundler.'
       exit 1
     }
-    rbenv rehash
+
+    [[ -n $(which rbenv) ]] && rbenv rehash
+
   }
 fi
 

--- a/scripts/compile-books
+++ b/scripts/compile-books
@@ -3,6 +3,9 @@
 # Pull in the BOOK_CONFIGS and RULESET_NAMES
 source ./books.txt || exit 1
 
+# Initialize rbenv (if installed)
+[[ -n $(which rbenv) ]] && eval "$(rbenv init -)"
+
 for rulesetName in "${RULESET_NAMES[@]}"
 do
 

--- a/scripts/generate-guide
+++ b/scripts/generate-guide
@@ -23,6 +23,8 @@ then
   exit 1
 fi
 
+# Initialize rbenv (if installed)
+[[ -n $(which rbenv) ]] && eval "$(rbenv init -)"
 
 
 >&2 echo "==> Compiling the guide.scss file for ${rulesetName}"


### PR DESCRIPTION
People used to get the following error:

```
$: ./scripts/setup

==> Updating Homebrew…
Already up-to-date.
==> Installing Ruby Bundler gem…
2.3.1 (set by /path/to/cnx-recipes/.ruby-version)
ERROR:  While executing gem ... (Gem::FilePermissionError)
    You don't have write permissions for the /Library/Ruby/Gems/2.0.0 directory.

$:
```

Now they get a message with how to fix the problem:

```
$: ./scripts/setup

==> Updating Homebrew…
Already up-to-date.
==> Installing Ruby Bundler gem…
2.3.1 (set by /Users/phil/github/cnx/cnx-recipes/.ruby-version)
ERROR:  While executing gem ... (Gem::FilePermissionError)
    You don't have write permissions for the /Library/Ruby/Gems/2.0.0 directory.


--------------- Error -------------
Unable to install the bundler.
You may need to add the following to ~/.bash_profile :

eval "$(rbenv init -)"

Doing this will require restarting your terminal
or running "source ~/.bash_profile"

$:
```

/cc @kerwinso @Stackblocks 