### PR TITLE
Diff multiple books

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,12 @@ Here are the steps to run it:
 ./scripts/diff-book statistics
 
 # Any differences would pop up here
+
+# Optional: Create a diff and give it to a GUI
+diff ./data/statistics-prepared.html ./data/statistics-baked.html > foo.diff
 ```
+
+**Note:** You can specify `--all` instead of `statistics` to diff all the books (assuming they have been fetched)
 
 ## Experimental
 

--- a/scripts/diff-book
+++ b/scripts/diff-book
@@ -1,31 +1,58 @@
-#!/bin/sh
-set -e
+#!/bin/bash
 
 
-bookName=$1
+arg1=$1
 debugFlag=$2
-
-bakedFile="./data/${bookName}-baked.html"
-preparedFile="./data/${bookName}-prepared.html"
 
 # Check command line args
 
-if [ -z "${bookName}" ]
+if [[ -z "${arg1}" ]]
 then
-  >&2 echo 'ERROR: Argument Missing. You must specify the name of the book as the 1st argument. For example: physics'
+  >&2 echo 'ERROR: Argument Missing. You must specify the name of the book as the 1st argument'
+  >&2 echo ' or --all for all books.'
+  >&2 echo ''
   >&2 echo 'This script bakes the book and then compares to the prepared book'
   >&2 echo '(done earlier, usually in another branch)'
   exit 1
 fi
 
-if [ ! -f "${preparedFile}" ]
+
+# Pull in the BOOK_CONFIGS
+source ./books.txt || exit 1
+
+if [[ ! "${arg1}" == "--all" ]]
 then
-  >&2 echo 'ERROR: This book was not prepared beforehand.'
-  >&2 echo 'Run diff-book-prepare before running this script'
-  >&2 echo 'so there is something to compare against'
-  exit 1
+  # Filter BOOK_CONFIGS to only contain the book you want to fetch
+  for bookConfig in "${BOOK_CONFIGS[@]}"
+  do
+    read -r bookConfigName rulesetName uuid _ <<< "${bookConfig}"
+
+    if [[ "${arg1}" = "${bookConfigName}" ]]
+    then
+      BOOK_CONFIGS=("${bookConfigName} ${rulesetName} ${uuid}")
+      foundConfig=1
+      break
+    fi
+  done
+
+  if [[ ! 1 -eq "${foundConfig}" ]]
+  then
+    >&2 echo "ERROR: Could not find Book info for book named ${arg1}"
+    >&2 echo "check ./books.txt"
+    exit 1
+  fi
 fi
 
-./scripts/bake-book ${bookName}
+for bookConfig in "${BOOK_CONFIGS[@]}"
+do
+  read -r bookName rulesetName uuid _ <<< "${bookConfig}"
+  rawFile="./data/${bookName}-raw.html"
 
-diff ${preparedFile} ${bakedFile}
+  bakedFile="./data/${bookName}-baked.html"
+  preparedFile="./data/${bookName}-prepared.html"
+
+  ./scripts/bake-book ${bookName} || exit 1
+
+  diff ${preparedFile} ${bakedFile} || exit 1
+
+done

--- a/scripts/diff-book
+++ b/scripts/diff-book
@@ -63,6 +63,7 @@ do
       >&2 echo "There were ${diffCount} differences found"
       >&2 echo "To see all of them run the following:"
       >&2 echo "diff ${preparedFile} ${bakedFile}"
+      exit 1
     fi
 
   else

--- a/scripts/diff-book
+++ b/scripts/diff-book
@@ -51,8 +51,25 @@ do
   bakedFile="./data/${bookName}-baked.html"
   preparedFile="./data/${bookName}-prepared.html"
 
-  ./scripts/bake-book ${bookName} || exit 1
+  if [[ -s "${preparedFile}" ]]
+  then
 
-  diff ${preparedFile} ${bakedFile} || exit 1
+    ./scripts/bake-book ${bookName} || exit 1
+
+    diffCount=$(diff ${preparedFile} ${bakedFile} | wc -l)
+
+    if [[ 0 -ne "${diffCount}" ]]
+    then
+      >&2 echo "There were ${diffCount} differences found"
+      >&2 echo "To see all of them run the following:"
+      >&2 echo "diff ${preparedFile} ${bakedFile}"
+    fi
+
+  else
+
+    >&2 echo "SKIPPING ${bookName} because the prepared file was not found."
+    >&2 echo "Did you run './scripts/diff-book-prepare ${bookName}' earlier?"
+  fi
+
 
 done

--- a/scripts/diff-book-prepare
+++ b/scripts/diff-book-prepare
@@ -1,5 +1,4 @@
-#!/bin/sh
-set -e
+#!/bin/bash
 
 
 arg1=$1
@@ -7,9 +6,10 @@ debugFlag=$2
 
 # Check command line args
 
-if [ -z "${arg1}" ]
+if [[ -z "${arg1}" ]]
 then
-  >&2 echo 'ERROR: Argument Missing. You must specify the name of the book as the 1st argument. For example: physics'
+  >&2 echo 'ERROR: Argument Missing. You must specify the name of the book as the 1st argument'
+  >&2 echo ' or --all for all books.'
   >&2 echo 'This script prepares the book to compare against.'
   >&2 echo 'Typically this step is done in the master branch'
   >&2 echo 'and then in another branch diff-book is called to see how the HTML changed.'
@@ -20,7 +20,7 @@ fi
 # Pull in the BOOK_CONFIGS
 source ./books.txt || exit 1
 
-if [ ! "${arg1}" == "--all" ]
+if [[ ! "${arg1}" == "--all" ]]
 then
   # Filter BOOK_CONFIGS to only contain the book you want to fetch
   for bookConfig in "${BOOK_CONFIGS[@]}"

--- a/scripts/diff-book-prepare
+++ b/scripts/diff-book-prepare
@@ -2,15 +2,12 @@
 set -e
 
 
-bookName=$1
+arg1=$1
 debugFlag=$2
-
-bakedFile="./data/${bookName}-baked.html"
-preparedFile="./data/${bookName}-prepared.html"
 
 # Check command line args
 
-if [ -z "${bookName}" ]
+if [ -z "${arg1}" ]
 then
   >&2 echo 'ERROR: Argument Missing. You must specify the name of the book as the 1st argument. For example: physics'
   >&2 echo 'This script prepares the book to compare against.'
@@ -19,6 +16,42 @@ then
   exit 1
 fi
 
-./scripts/bake-book ${bookName}
 
-mv ${bakedFile} ${preparedFile}
+# Pull in the BOOK_CONFIGS
+source ./books.txt || exit 1
+
+if [ ! "${arg1}" == "--all" ]
+then
+  # Filter BOOK_CONFIGS to only contain the book you want to fetch
+  for bookConfig in "${BOOK_CONFIGS[@]}"
+  do
+    read -r bookConfigName rulesetName uuid _ <<< "${bookConfig}"
+
+    if [[ "${arg1}" = "${bookConfigName}" ]]
+    then
+      BOOK_CONFIGS=("${bookConfigName} ${rulesetName} ${uuid}")
+      foundConfig=1
+      break
+    fi
+  done
+
+  if [[ ! 1 -eq "${foundConfig}" ]]
+  then
+    >&2 echo "ERROR: Could not find Book info for book named ${arg1}"
+    >&2 echo "check ./books.txt"
+    exit 1
+  fi
+fi
+
+for bookConfig in "${BOOK_CONFIGS[@]}"
+do
+  read -r bookName rulesetName uuid _ <<< "${bookConfig}"
+  rawFile="./data/${bookName}-raw.html"
+
+  bakedFile="./data/${bookName}-baked.html"
+  preparedFile="./data/${bookName}-prepared.html"
+
+  ./scripts/bake-book ${bookName}
+
+  mv ${bakedFile} ${preparedFile}
+done


### PR DESCRIPTION
Adds support for `./scripts/diff-book-prepare --all` and `./scripts/diff-book --all` to make regression-testing easier.

Unfortunately, autogenerated `id=""` attributes are still different so not sure how useful the diffs are but you can run the files through a GUI and visually ignore the mismatched uuid's