### PR TITLE
Allow remote host to be overridden by local var

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
   - **Note:** To see the list of books available see `./books.txt`
   - **Note:** This will require you to log in via ssh.
   - **Note:** You can set the ssh username by running `USER=myusername ./scripts/fetch-book ...`
+  - **Note:** You can set the remote server to pull from by running `HOST=dev.cnx.org ./scripts/fetch-book ...`
   - **Note:** You can run `./scripts/fetch-book --all` to fetch all the books
 1. run `./scripts/bake-book statistics`
 

--- a/scripts/bake-book-remote
+++ b/scripts/bake-book-remote
@@ -12,7 +12,7 @@ set -e
 # - Invoke the collation via a the python interpreter `import requests; resp = requests.post('http://cte-cnx-dev.cnx.org:6543/contents/031da8d3-b525-429c-80cf-6c8ed997733a/collate-content', headers={'x-api-key': 'cte-dev--sprint-6.7'}); print(resp)`
 # Originally from: https://gist.github.com/pumazi/93f5ed32cb9e094e5a97415ced480a16
 
-HOST='cte-cnx-dev.cnx.org'
+HOST=${HOST:-'cte-cnx-dev.cnx.org'}
 
 arg1=$1
 bookVersion=$2

--- a/scripts/fetch-book
+++ b/scripts/fetch-book
@@ -3,7 +3,7 @@ set -e
 
 # This fetches the raw HTML for a book (or all books if using the --all argument) from ${HOST}
 
-HOST='cte-cnx-dev.cnx.org'
+HOST=${HOST:-'cte-cnx-dev.cnx.org'}
 
 arg1=$1
 


### PR DESCRIPTION
Examples:
 $ HOST=dev00.cnx.org scripts/fetch-book econ
  or
 $ export HOST=dev00.cnx.org
 $ scripts/bake-book-remote econ