### PR TITLE
Books.txt and server change

### DIFF
--- a/books.txt
+++ b/books.txt
@@ -1,20 +1,20 @@
 #!/bin/bash
 
 BOOK_CONFIGS=(
-  "statistics         statistics        30189442-6998-4686-ac05-ed152b91b9de"
-  "statshigh          statistics        ace2ec2d-778e-44aa-82c2-57a4e5c3de69"
-  "econ               economics         69619d2b-68f0-44b0-b074-a9b2bf90b2c6"
-  "econap             economics         69619d2b-68f0-44b0-b074-a9b2bf90b2c6"
-  "macroecon          economics         4061c832-098e-4b3c-a1d9-7eb593a2cb31"
-  "macroeconap        economics         33076054-ec1d-4417-8824-ce354efe42d0"
-  "microecon          economics         ea2f225e-6063-41ca-bcd8-36482e15ef65"
-  "microeconap        economics         ca344e2d-6731-43cd-b851-a7b3aa0b37aa"
-  "TEAmacroeconap     economics         3353a691-0c52-4691-8f36-65490cd3d962"
-  "TEAmicroeconap     economics         7f6fbc5b-6f3b-40a8-87ac-b14adc941e5e"
-  "physics            physics           031da8d3-b525-429c-80cf-6c8ed997733a"
-  "apphysics          ap-physics        8d04a686-d5e8-4798-a27d-c608e4d0e187"
-  "hsphysics          hs-physics        dbfdc541-752c-4a79-9e83-d32b1ca2c176"
-  "biology            biology           185cbf87-c72e-48f5-b51e-f14f21b5eabd"
+  "statistics         statistics        30189442-6998-4686-ac05-ed152b91b9de    cte-cnx-dev.cnx.org"
+  "statshigh          statistics        ace2ec2d-778e-44aa-82c2-57a4e5c3de69    cte-cnx-dev.cnx.org"
+  "econ               economics         69619d2b-68f0-44b0-b074-a9b2bf90b2c6    cte-cnx-dev.cnx.org"
+  "econap             economics         69619d2b-68f0-44b0-b074-a9b2bf90b2c6    cte-cnx-dev.cnx.org"
+  "macroecon          economics         4061c832-098e-4b3c-a1d9-7eb593a2cb31    cte-cnx-dev.cnx.org"
+  "macroeconap        economics         33076054-ec1d-4417-8824-ce354efe42d0    cte-cnx-dev.cnx.org"
+  "microecon          economics         ea2f225e-6063-41ca-bcd8-36482e15ef65    cte-cnx-dev.cnx.org"
+  "microeconap        economics         ca344e2d-6731-43cd-b851-a7b3aa0b37aa    cte-cnx-dev.cnx.org"
+  "TEAmacroeconap     economics         3353a691-0c52-4691-8f36-65490cd3d962    cte-cnx-dev.cnx.org"
+  "TEAmicroeconap     economics         7f6fbc5b-6f3b-40a8-87ac-b14adc941e5e    cte-cnx-dev.cnx.org"
+  "physics            physics           031da8d3-b525-429c-80cf-6c8ed997733a    cte-cnx-dev.cnx.org"
+  "apphysics          ap-physics        8d04a686-d5e8-4798-a27d-c608e4d0e187    cte-cnx-dev.cnx.org"
+  "hsphysics          hs-physics        dbfdc541-752c-4a79-9e83-d32b1ca2c176    dev00.cnx.org"
+  "biology            biology           185cbf87-c72e-48f5-b51e-f14f21b5eabd    dev00.cnx.org"
 )
 
 BOOK_NAMES=()

--- a/books.txt
+++ b/books.txt
@@ -14,7 +14,7 @@ BOOK_CONFIGS=(
   "physics            physics           031da8d3-b525-429c-80cf-6c8ed997733a    cte-cnx-dev.cnx.org"
   "apphysics          ap-physics        8d04a686-d5e8-4798-a27d-c608e4d0e187    cte-cnx-dev.cnx.org"
   "hsphysics          hs-physics        dbfdc541-752c-4a79-9e83-d32b1ca2c176    dev00.cnx.org"
-  "biology            biology           185cbf87-c72e-48f5-b51e-f14f21b5eabd    dev00.cnx.org"
+  # "biology            biology           185cbf87-c72e-48f5-b51e-f14f21b5eabd    dev00.cnx.org"
 )
 
 BOOK_NAMES=()

--- a/books.txt
+++ b/books.txt
@@ -13,7 +13,8 @@ BOOK_CONFIGS=(
   "TEAmicroeconap     economics         7f6fbc5b-6f3b-40a8-87ac-b14adc941e5e"
   "physics            physics           031da8d3-b525-429c-80cf-6c8ed997733a"
   "apphysics          ap-physics        8d04a686-d5e8-4798-a27d-c608e4d0e187"
-  "hsphysics          hs-physics        051ff00c-34b9-4547-ab03-fe5b1b95cf62"
+  "hsphysics          hs-physics        dbfdc541-752c-4a79-9e83-d32b1ca2c176"
+  "biology            biology           185cbf87-c72e-48f5-b51e-f14f21b5eabd"
 )
 
 BOOK_NAMES=()

--- a/scripts/bake-book-remote
+++ b/scripts/bake-book-remote
@@ -12,8 +12,6 @@ set -e
 # - Invoke the collation via a the python interpreter `import requests; resp = requests.post('http://dev00.cnx.org.cnx.org:6543/contents/031da8d3-b525-429c-80cf-6c8ed997733a/collate-content', headers={'x-api-key': 'b07'}); print(resp)`
 # Originally from: https://gist.github.com/pumazi/93f5ed32cb9e094e5a97415ced480a16
 
-HOST=${HOST:-'dev00.cnx.org'}
-
 arg1=$1
 bookVersion=$2
 
@@ -36,11 +34,12 @@ else
   # Filter BOOK_CONFIGS to only contain the book you want to fetch
   for bookConfig in "${BOOK_CONFIGS[@]}"
   do
-    read -r bookConfigName rulesetName uuid _ <<< "${bookConfig}"
+    read -r bookConfigName rulesetName uuid hostName _ <<< "${bookConfig}"
 
     if [[ "${arg1}" = "${bookConfigName}" ]]
     then
       BOOK_CONFIGS=("${bookConfigName} ${rulesetName} ${uuid}")
+      hostName=${HOST:-${hostName}}
       foundConfig=1
       break
     fi
@@ -58,10 +57,12 @@ if [ -z "${bookVersion}" ]
 then
 
   # The first entry is always the book info because "--all" is not a valid commandline arg
-  read -r bookName rulesetName uuid _ <<< "${BOOK_CONFIGS[0]}"
+  read -r bookName rulesetName uuid hostName _ <<< "${BOOK_CONFIGS[0]}"
+  hostName=${HOST:-${hostName}}
+
   >&2 echo 'ERROR: Argument Missing. You must specify the book version as the 2nd argument for what you want to cook (I know, it is annoying)'
   >&2 echo 'The version is the @#.## in the target collection URL'
-  >&2 echo "You can visit http://${HOST}/contents/${uuid} to get the version number"
+  >&2 echo "You can visit http://${hostName}/contents/${uuid} to get the version number"
   exit 1
 fi
 
@@ -76,7 +77,9 @@ fi
 
 for bookConfig in "${BOOK_CONFIGS[@]}"
 do
-  read -r bookName rulesetName uuid _ <<< "${bookConfig}"
+  read -r bookName rulesetName uuid hostName _ <<< "${bookConfig}"
+
+  hostName=${HOST:-${hostName}}
 
   cssFile="./books/rulesets/output/${rulesetName}.css"
 
@@ -86,25 +89,25 @@ do
     exit 1
   fi
 
-  >&2 echo "==> Baking book ${bookName} ${uuid} on ${HOST} ..."
+  >&2 echo "==> Baking book ${bookName} ${uuid} on ${hostName} ..."
 
   tempCssFile="~/temp.css"
 
   >&2 echo "==> Copying CSS file from local machine to server"
-  scp ${cssFile} ${USER}@${HOST}:${tempCssFile} || exit 1
+  scp ${cssFile} ${USER}@${hostName}:${tempCssFile} || exit 1
 
   >&2 echo "==> Injecting the css file into the book as ruleset.css"
 
   buildBookCmd="/var/cnx/venvs/archive/bin/cnx-archive-inject_resource --resource-filename \"ruleset.css\" --media-type \"text/css\" /etc/cnx/archive/app.ini \"${uuid}@${bookVersion}\" ${tempCssFile}"
-  ssh ${USER}@${HOST} ${buildBookCmd} || exit 1
+  ssh ${USER}@${hostName} ${buildBookCmd} || exit 1
 
   >&2 echo "==> Re-baking the book (may take up to 12 minutes)"
-  python -c "import requests; resp = requests.post('http://${HOST}:6543/contents/${uuid}@${bookVersion}/collate-content',  headers={'x-api-key': 'b07'}); print(resp)" || exit 1
+  python -c "import requests; resp = requests.post('http://${hostName}:6543/contents/${uuid}@${bookVersion}/collate-content',  headers={'x-api-key': 'b07'}); print(resp)" || exit 1
 
   >&2 echo "==> restarting varnish because the HTML files may be cached"
   restartVarnishCmd="varnishadm ban req.url '~' ."
-  ssh ${USER}@${HOST} ${restartVarnishCmd} || exit 1
+  ssh ${USER}@${hostName} ${restartVarnishCmd} || exit 1
 
-  >&2 echo "Build complete. See the changes by going to http://${HOST}/contents/${uuid}@${bookVersion}"
+  >&2 echo "Build complete. See the changes by going to http://${hostName}/contents/${uuid}@${bookVersion}"
 
 done

--- a/scripts/bake-book-remote
+++ b/scripts/bake-book-remote
@@ -9,10 +9,10 @@ set -e
 # - Inject a ruleset into the archive in association with the book to be collated.
 # `wget https://raw.githubusercontent.com/Connexions/cte/rulesets/books/rulesets/output/physics.css`
 # `/var/cnx/venvs/archive/bin/cnx-archive-inject_resource --resource-filename "ruleset.css" --media-type "text/css" /etc/cnx/archive/app.ini 031da8d3-b525-429c-80cf-6c8ed997733a@9.30 physics.css`
-# - Invoke the collation via a the python interpreter `import requests; resp = requests.post('http://cte-cnx-dev.cnx.org:6543/contents/031da8d3-b525-429c-80cf-6c8ed997733a/collate-content', headers={'x-api-key': 'cte-dev--sprint-6.7'}); print(resp)`
+# - Invoke the collation via a the python interpreter `import requests; resp = requests.post('http://dev00.cnx.org.cnx.org:6543/contents/031da8d3-b525-429c-80cf-6c8ed997733a/collate-content', headers={'x-api-key': 'b07'}); print(resp)`
 # Originally from: https://gist.github.com/pumazi/93f5ed32cb9e094e5a97415ced480a16
 
-HOST=${HOST:-'cte-cnx-dev.cnx.org'}
+HOST=${HOST:-'dev00.cnx.org'}
 
 arg1=$1
 bookVersion=$2
@@ -99,7 +99,7 @@ do
   ssh ${USER}@${HOST} ${buildBookCmd} || exit 1
 
   >&2 echo "==> Re-baking the book (may take up to 12 minutes)"
-  python -c "import requests; resp = requests.post('http://${HOST}:6543/contents/${uuid}@${bookVersion}/collate-content', headers={'x-api-key': 'cte-dev--sprint-6.7'}); print(resp)" || exit 1
+  python -c "import requests; resp = requests.post('http://${HOST}:6543/contents/${uuid}@${bookVersion}/collate-content',  headers={'x-api-key': 'b07'}); print(resp)" || exit 1
 
   >&2 echo "==> restarting varnish because the HTML files may be cached"
   restartVarnishCmd="varnishadm ban req.url '~' ."

--- a/scripts/bake-book-remote
+++ b/scripts/bake-book-remote
@@ -102,7 +102,7 @@ do
   ssh ${USER}@${hostName} ${buildBookCmd} || exit 1
 
   >&2 echo "==> Re-baking the book (may take up to 12 minutes)"
-  python -c "import requests; resp = requests.post('http://${hostName}:6543/contents/${uuid}@${bookVersion}/collate-content',  headers={'x-api-key': 'b07'}); print(resp)" || exit 1
+  python -c "import requests; resp = requests.post('http://${hostName}:6543/contents/${uuid}@${bookVersion}/collate-content', headers={'x-api-key': 'b07'}); print(resp)" || exit 1
 
   >&2 echo "==> restarting varnish because the HTML files may be cached"
   restartVarnishCmd="varnishadm ban req.url '~' ."

--- a/scripts/fetch-book
+++ b/scripts/fetch-book
@@ -1,9 +1,7 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
-# This fetches the raw HTML for a book (or all books if using the --all argument) from ${HOST}
-
-HOST=${HOST:-'dev00.cnx.org'}
+# This fetches the raw HTML for a book (or all books if using the --all argument) from ${hostName}
 
 arg1=$1
 
@@ -24,11 +22,13 @@ then
   # Filter BOOK_CONFIGS to only contain the book you want to fetch
   for bookConfig in "${BOOK_CONFIGS[@]}"
   do
-    read -r bookConfigName rulesetName uuid _ <<< "${bookConfig}"
+    read -r bookConfigName rulesetName uuid hostName _ <<< "${bookConfig}"
 
     if [[ "${arg1}" = "${bookConfigName}" ]]
     then
-      BOOK_CONFIGS=("${bookConfigName} ${rulesetName} ${uuid}")
+      BOOK_CONFIGS=("${bookConfigName} ${rulesetName} ${uuid} ${hostName} ${_}")
+      hostName=${HOST:-${hostName}}
+
       foundConfig=1
       break
     fi
@@ -44,10 +44,13 @@ fi
 
 for bookConfig in "${BOOK_CONFIGS[@]}"
 do
-  read -r bookName rulesetName uuid _ <<< "${bookConfig}"
+  read -r bookName rulesetName uuid hostName _ <<< "${bookConfig}"
+  # Allow user to override the hostname
+  hostName=${HOST:-${hostName}}
+
   rawFile="./data/${bookName}-raw.html"
 
-  >&2 echo "==> Fetching ${bookName}"
+  >&2 echo "==> Fetching ${bookName} from ${hostName}"
   >&2 echo "generating an EPUB from the database and converting to a single HTML file"
   >&2 echo "(may take a minute)..."
 
@@ -61,10 +64,10 @@ do
 
   commands="${rmTempEpubCmd}; ${rmTempHtmlCmd}; ${generateEpubCmd} && ${generateHtmlCmd}"
 
-  ssh ${USER}@${HOST} ${commands}
+  ssh ${USER}@${hostName} ${commands}
 
   >&2 echo "==> Copying HTML file from server to local machine"
-  scp ${USER}@${HOST}:${tempHtmlFile} ${rawFile}
+  scp ${USER}@${hostName}:${tempHtmlFile} ${rawFile}
 
   >&2 echo "Fetch is Done. File is available at ${rawFile}"
 

--- a/scripts/fetch-book
+++ b/scripts/fetch-book
@@ -3,7 +3,7 @@ set -e
 
 # This fetches the raw HTML for a book (or all books if using the --all argument) from ${HOST}
 
-HOST=${HOST:-'cte-cnx-dev.cnx.org'}
+HOST=${HOST:-'dev00.cnx.org'}
 
 arg1=$1
 


### PR DESCRIPTION
- added biology from production to `/books.txt`
- added proper collection to HS Physics. 
- added field in `/books.txt` to denote which hostname to use for downloading the book

# Questions

- [ ]  now that each book can specify a hostname, should we remove the option of specifying an environment-var-override option?
