### PR TITLE
removes the lingering glossary title when they are collated

### DIFF
--- a/rulesets/common/_compose.scss
+++ b/rulesets/common/_compose.scss
@@ -81,7 +81,7 @@
       $sourceSelector: if($isGlossary, 'div[data-type="#{$source}"] dl', 'section.#{$source}');
       @if ($isGlossary) {
         div[data-type="#{$source}"] {
-          > h3[data-type="glossary-title"] {
+          > [data-type="glossary-title"] {
             /* Discard this Page-specific title because a chapter title is added when collated */
             move-to: trash;
           }

--- a/rulesets/output/ap-physics.css
+++ b/rulesets/output/ap-physics.css
@@ -398,7 +398,7 @@ Style guide  :page.note.chapter-objectives
 :pass(1) div[data-type="page"] > [data-type="document-title"],
 :pass(1) div[data-type="composite-page"] > [data-type="document-title"] {
   node-set: sectionHeaderNode; }
-:pass(1) div[data-type="chapter"] div[data-type="glossary"] > h3[data-type="glossary-title"] {
+:pass(1) div[data-type="chapter"] div[data-type="glossary"] > [data-type="glossary-title"] {
   /* Discard this Page-specific title because a chapter title is added when collated */
   move-to: trash; }
 :pass(1) div[data-type="chapter"] div[data-type="glossary"] dl {

--- a/rulesets/output/economics.css
+++ b/rulesets/output/economics.css
@@ -472,7 +472,7 @@
 :pass(1) div[data-type="page"] > [data-type="document-title"],
 :pass(1) div[data-type="composite-page"] > [data-type="document-title"] {
   node-set: sectionHeaderNode; }
-:pass(1) div[data-type="chapter"] div[data-type="glossary"] > h3[data-type="glossary-title"] {
+:pass(1) div[data-type="chapter"] div[data-type="glossary"] > [data-type="glossary-title"] {
   /* Discard this Page-specific title because a chapter title is added when collated */
   move-to: trash; }
 :pass(1) div[data-type="chapter"] div[data-type="glossary"] dl {

--- a/rulesets/output/hs-physics.css
+++ b/rulesets/output/hs-physics.css
@@ -663,7 +663,7 @@
 :pass(1) div[data-type="page"] > [data-type="document-title"],
 :pass(1) div[data-type="composite-page"] > [data-type="document-title"] {
   node-set: sectionHeaderNode; }
-:pass(1) div[data-type="chapter"] div[data-type="glossary"] > h3[data-type="glossary-title"] {
+:pass(1) div[data-type="chapter"] div[data-type="glossary"] > [data-type="glossary-title"] {
   /* Discard this Page-specific title because a chapter title is added when collated */
   move-to: trash; }
 :pass(1) div[data-type="chapter"] div[data-type="glossary"] dl {

--- a/rulesets/output/physics.css
+++ b/rulesets/output/physics.css
@@ -388,7 +388,7 @@
 :pass(1) div[data-type="page"] > [data-type="document-title"],
 :pass(1) div[data-type="composite-page"] > [data-type="document-title"] {
   node-set: sectionHeaderNode; }
-:pass(1) div[data-type="chapter"] div[data-type="glossary"] > h3[data-type="glossary-title"] {
+:pass(1) div[data-type="chapter"] div[data-type="glossary"] > [data-type="glossary-title"] {
   /* Discard this Page-specific title because a chapter title is added when collated */
   move-to: trash; }
 :pass(1) div[data-type="chapter"] div[data-type="glossary"] dl {

--- a/rulesets/output/statistics.css
+++ b/rulesets/output/statistics.css
@@ -428,7 +428,7 @@
 :pass(1) div[data-type="page"] > [data-type="document-title"],
 :pass(1) div[data-type="composite-page"] > [data-type="document-title"] {
   node-set: sectionHeaderNode; }
-:pass(1) div[data-type="chapter"] div[data-type="glossary"] > h3[data-type="glossary-title"] {
+:pass(1) div[data-type="chapter"] div[data-type="glossary"] > [data-type="glossary-title"] {
   /* Discard this Page-specific title because a chapter title is added when collated */
   move-to: trash; }
 :pass(1) div[data-type="chapter"] div[data-type="glossary"] dl {


### PR DESCRIPTION
In books the glossary items are collated at the end of the Chapter/Book. This problem was noticed while working on the biology book.

# New Screenshot:

![image](https://cloud.githubusercontent.com/assets/253202/21032782/dcee0ca4-bd79-11e6-89a2-405510da2f94.png)

---

# Old Screenshot:
![image](https://cloud.githubusercontent.com/assets/253202/21032765/b6ad1bf2-bd79-11e6-9757-97c0c75868c7.png)

---
/cc @zroehr 