### PR TITLE
fix trashing of duplicate glossary title

### DIFF
--- a/rulesets/common/_compose.scss
+++ b/rulesets/common/_compose.scss
@@ -81,7 +81,7 @@
       $sourceSelector: if($isGlossary, 'div[data-type="#{$source}"] dl', 'section.#{$source}');
       @if ($isGlossary) {
         div[data-type="#{$source}"] {
-          /* Discard this Page-specific title because a chapter title is added when collated */
+          /* Discard this Page-specific glossary because it is collated later and the title is added when this is collated */
           move-to: trash;
         }
       }

--- a/rulesets/common/_compose.scss
+++ b/rulesets/common/_compose.scss
@@ -81,10 +81,8 @@
       $sourceSelector: if($isGlossary, 'div[data-type="#{$source}"] dl', 'section.#{$source}');
       @if ($isGlossary) {
         div[data-type="#{$source}"] {
-          > h3[data-type="glossary-title"] {
-            /* Discard this Page-specific title because a chapter title is added when collated */
-            move-to: trash;
-          }
+          /* Discard this Page-specific title because a chapter title is added when collated */
+          move-to: trash;
         }
       }
       #{$sourceSelector} {

--- a/rulesets/output/ap-physics.css
+++ b/rulesets/output/ap-physics.css
@@ -399,7 +399,7 @@ Style guide  :page.note.chapter-objectives
 :pass(1) div[data-type="composite-page"] > [data-type="document-title"] {
   node-set: sectionHeaderNode; }
 :pass(1) div[data-type="chapter"] div[data-type="glossary"] {
-  /* Discard this Page-specific title because a chapter title is added when collated */
+  /* Discard this Page-specific glossary because it is collated later and the title is added when this is collated */
   move-to: trash; }
 :pass(1) div[data-type="chapter"] div[data-type="glossary"] dl {
   move-to: glossary-TOCOMPOSITE; }

--- a/rulesets/output/ap-physics.css
+++ b/rulesets/output/ap-physics.css
@@ -398,7 +398,7 @@ Style guide  :page.note.chapter-objectives
 :pass(1) div[data-type="page"] > [data-type="document-title"],
 :pass(1) div[data-type="composite-page"] > [data-type="document-title"] {
   node-set: sectionHeaderNode; }
-:pass(1) div[data-type="chapter"] div[data-type="glossary"] > h3[data-type="glossary-title"] {
+:pass(1) div[data-type="chapter"] div[data-type="glossary"] {
   /* Discard this Page-specific title because a chapter title is added when collated */
   move-to: trash; }
 :pass(1) div[data-type="chapter"] div[data-type="glossary"] dl {

--- a/rulesets/output/economics.css
+++ b/rulesets/output/economics.css
@@ -473,7 +473,7 @@
 :pass(1) div[data-type="composite-page"] > [data-type="document-title"] {
   node-set: sectionHeaderNode; }
 :pass(1) div[data-type="chapter"] div[data-type="glossary"] {
-  /* Discard this Page-specific title because a chapter title is added when collated */
+  /* Discard this Page-specific glossary because it is collated later and the title is added when this is collated */
   move-to: trash; }
 :pass(1) div[data-type="chapter"] div[data-type="glossary"] dl {
   move-to: glossary-TOCOMPOSITE; }

--- a/rulesets/output/economics.css
+++ b/rulesets/output/economics.css
@@ -472,7 +472,7 @@
 :pass(1) div[data-type="page"] > [data-type="document-title"],
 :pass(1) div[data-type="composite-page"] > [data-type="document-title"] {
   node-set: sectionHeaderNode; }
-:pass(1) div[data-type="chapter"] div[data-type="glossary"] > h3[data-type="glossary-title"] {
+:pass(1) div[data-type="chapter"] div[data-type="glossary"] {
   /* Discard this Page-specific title because a chapter title is added when collated */
   move-to: trash; }
 :pass(1) div[data-type="chapter"] div[data-type="glossary"] dl {

--- a/rulesets/output/hs-physics.css
+++ b/rulesets/output/hs-physics.css
@@ -663,7 +663,7 @@
 :pass(1) div[data-type="page"] > [data-type="document-title"],
 :pass(1) div[data-type="composite-page"] > [data-type="document-title"] {
   node-set: sectionHeaderNode; }
-:pass(1) div[data-type="chapter"] div[data-type="glossary"] > h3[data-type="glossary-title"] {
+:pass(1) div[data-type="chapter"] div[data-type="glossary"] {
   /* Discard this Page-specific title because a chapter title is added when collated */
   move-to: trash; }
 :pass(1) div[data-type="chapter"] div[data-type="glossary"] dl {

--- a/rulesets/output/hs-physics.css
+++ b/rulesets/output/hs-physics.css
@@ -664,7 +664,7 @@
 :pass(1) div[data-type="composite-page"] > [data-type="document-title"] {
   node-set: sectionHeaderNode; }
 :pass(1) div[data-type="chapter"] div[data-type="glossary"] {
-  /* Discard this Page-specific title because a chapter title is added when collated */
+  /* Discard this Page-specific glossary because it is collated later and the title is added when this is collated */
   move-to: trash; }
 :pass(1) div[data-type="chapter"] div[data-type="glossary"] dl {
   move-to: glossary-TOCOMPOSITE; }

--- a/rulesets/output/physics.css
+++ b/rulesets/output/physics.css
@@ -388,7 +388,7 @@
 :pass(1) div[data-type="page"] > [data-type="document-title"],
 :pass(1) div[data-type="composite-page"] > [data-type="document-title"] {
   node-set: sectionHeaderNode; }
-:pass(1) div[data-type="chapter"] div[data-type="glossary"] > h3[data-type="glossary-title"] {
+:pass(1) div[data-type="chapter"] div[data-type="glossary"] {
   /* Discard this Page-specific title because a chapter title is added when collated */
   move-to: trash; }
 :pass(1) div[data-type="chapter"] div[data-type="glossary"] dl {

--- a/rulesets/output/physics.css
+++ b/rulesets/output/physics.css
@@ -389,7 +389,7 @@
 :pass(1) div[data-type="composite-page"] > [data-type="document-title"] {
   node-set: sectionHeaderNode; }
 :pass(1) div[data-type="chapter"] div[data-type="glossary"] {
-  /* Discard this Page-specific title because a chapter title is added when collated */
+  /* Discard this Page-specific glossary because it is collated later and the title is added when this is collated */
   move-to: trash; }
 :pass(1) div[data-type="chapter"] div[data-type="glossary"] dl {
   move-to: glossary-TOCOMPOSITE; }

--- a/rulesets/output/statistics.css
+++ b/rulesets/output/statistics.css
@@ -429,7 +429,7 @@
 :pass(1) div[data-type="composite-page"] > [data-type="document-title"] {
   node-set: sectionHeaderNode; }
 :pass(1) div[data-type="chapter"] div[data-type="glossary"] {
-  /* Discard this Page-specific title because a chapter title is added when collated */
+  /* Discard this Page-specific glossary because it is collated later and the title is added when this is collated */
   move-to: trash; }
 :pass(1) div[data-type="chapter"] div[data-type="glossary"] dl {
   move-to: glossary-TOCOMPOSITE; }

--- a/rulesets/output/statistics.css
+++ b/rulesets/output/statistics.css
@@ -428,7 +428,7 @@
 :pass(1) div[data-type="page"] > [data-type="document-title"],
 :pass(1) div[data-type="composite-page"] > [data-type="document-title"] {
   node-set: sectionHeaderNode; }
-:pass(1) div[data-type="chapter"] div[data-type="glossary"] > h3[data-type="glossary-title"] {
+:pass(1) div[data-type="chapter"] div[data-type="glossary"] {
   /* Discard this Page-specific title because a chapter title is added when collated */
   move-to: trash; }
 :pass(1) div[data-type="chapter"] div[data-type="glossary"] dl {


### PR DESCRIPTION
There was an extra glossary title that wasn't getting trashed due to the glossary title selector changing. Fixed selector in `rulesets/common/_compose.scss` to trash the extra title.