### PR TITLE
update selector for trashing EOC section titles after collation

### DIFF
--- a/rulesets/common/_compose.scss
+++ b/rulesets/common/_compose.scss
@@ -86,7 +86,7 @@
         }
       }
       #{$sourceSelector} {
-        > h3[data-type="title"] {
+        > [data-type="title"] {
           /* Discard this Page-specific title because a chapter title is added when collated */
           move-to: trash;
         }

--- a/rulesets/output/ap-physics.css
+++ b/rulesets/output/ap-physics.css
@@ -448,7 +448,7 @@ Usage Note: key: class of the containing span, value: text that will go inside s
   move-to: trash; }
 :pass(1) div[data-type="chapter"] div[data-type="glossary"] dl {
   move-to: glossary-TOCOMPOSITE; }
-  :pass(1) div[data-type="chapter"] div[data-type="glossary"] dl > h3[data-type="title"] {
+  :pass(1) div[data-type="chapter"] div[data-type="glossary"] dl > [data-type="title"] {
     /* Discard this Page-specific title because a chapter title is added when collated */
     move-to: trash; }
 :pass(1) div[data-type="chapter"]::after {
@@ -461,7 +461,7 @@ Usage Note: key: class of the containing span, value: text that will go inside s
   /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
   content: nodes(sectionHeaderNode) content();
   move-to: section-summary-TOCOMPOSITE; }
-  :pass(1) div[data-type="chapter"] section.section-summary > h3[data-type="title"] {
+  :pass(1) div[data-type="chapter"] section.section-summary > [data-type="title"] {
     /* Discard this Page-specific title because a chapter title is added when collated */
     move-to: trash; }
 :pass(1) div[data-type="chapter"]::after {
@@ -473,7 +473,7 @@ Usage Note: key: class of the containing span, value: text that will go inside s
   /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
   content: nodes(sectionHeaderNode) content();
   move-to: conceptual-questions-TOCOMPOSITE; }
-  :pass(1) div[data-type="chapter"] section.conceptual-questions > h3[data-type="title"] {
+  :pass(1) div[data-type="chapter"] section.conceptual-questions > [data-type="title"] {
     /* Discard this Page-specific title because a chapter title is added when collated */
     move-to: trash; }
 :pass(1) div[data-type="chapter"]::after {
@@ -485,7 +485,7 @@ Usage Note: key: class of the containing span, value: text that will go inside s
   /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
   content: nodes(sectionHeaderNode) content();
   move-to: problems-exercises-TOCOMPOSITE; }
-  :pass(1) div[data-type="chapter"] section.problems-exercises > h3[data-type="title"] {
+  :pass(1) div[data-type="chapter"] section.problems-exercises > [data-type="title"] {
     /* Discard this Page-specific title because a chapter title is added when collated */
     move-to: trash; }
 :pass(1) div[data-type="chapter"]::after {
@@ -497,7 +497,7 @@ Usage Note: key: class of the containing span, value: text that will go inside s
   /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
   content: nodes(sectionHeaderNode) content();
   move-to: ap-test-prep-TOCOMPOSITE; }
-  :pass(1) div[data-type="chapter"] section.ap-test-prep > h3[data-type="title"] {
+  :pass(1) div[data-type="chapter"] section.ap-test-prep > [data-type="title"] {
     /* Discard this Page-specific title because a chapter title is added when collated */
     move-to: trash; }
 :pass(1) div[data-type="chapter"]::after {

--- a/rulesets/output/economics.css
+++ b/rulesets/output/economics.css
@@ -540,7 +540,7 @@
   move-to: trash; }
 :pass(1) div[data-type="chapter"] div[data-type="glossary"] dl {
   move-to: glossary-TOCOMPOSITE; }
-  :pass(1) div[data-type="chapter"] div[data-type="glossary"] dl > h3[data-type="title"] {
+  :pass(1) div[data-type="chapter"] div[data-type="glossary"] dl > [data-type="title"] {
     /* Discard this Page-specific title because a chapter title is added when collated */
     move-to: trash; }
 :pass(1) div[data-type="chapter"]::after {
@@ -553,7 +553,7 @@
   /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
   content: nodes(sectionHeaderNode) content();
   move-to: summary-TOCOMPOSITE; }
-  :pass(1) div[data-type="chapter"] section.summary > h3[data-type="title"] {
+  :pass(1) div[data-type="chapter"] section.summary > [data-type="title"] {
     /* Discard this Page-specific title because a chapter title is added when collated */
     move-to: trash; }
 :pass(1) div[data-type="chapter"]::after {
@@ -563,7 +563,7 @@
   data-type: "composite-page"; }
 :pass(1) div[data-type="chapter"] section.self-check-questions {
   move-to: self-check-questions-TOCOMPOSITE; }
-  :pass(1) div[data-type="chapter"] section.self-check-questions > h3[data-type="title"] {
+  :pass(1) div[data-type="chapter"] section.self-check-questions > [data-type="title"] {
     /* Discard this Page-specific title because a chapter title is added when collated */
     move-to: trash; }
 :pass(1) div[data-type="chapter"]::after {
@@ -573,7 +573,7 @@
   data-type: "composite-page"; }
 :pass(1) div[data-type="chapter"] section.review-questions {
   move-to: review-questions-TOCOMPOSITE; }
-  :pass(1) div[data-type="chapter"] section.review-questions > h3[data-type="title"] {
+  :pass(1) div[data-type="chapter"] section.review-questions > [data-type="title"] {
     /* Discard this Page-specific title because a chapter title is added when collated */
     move-to: trash; }
 :pass(1) div[data-type="chapter"]::after {
@@ -583,7 +583,7 @@
   data-type: "composite-page"; }
 :pass(1) div[data-type="chapter"] section.critical-thinking {
   move-to: critical-thinking-TOCOMPOSITE; }
-  :pass(1) div[data-type="chapter"] section.critical-thinking > h3[data-type="title"] {
+  :pass(1) div[data-type="chapter"] section.critical-thinking > [data-type="title"] {
     /* Discard this Page-specific title because a chapter title is added when collated */
     move-to: trash; }
 :pass(1) div[data-type="chapter"]::after {
@@ -593,7 +593,7 @@
   data-type: "composite-page"; }
 :pass(1) div[data-type="chapter"] section.problems {
   move-to: problems-TOCOMPOSITE; }
-  :pass(1) div[data-type="chapter"] section.problems > h3[data-type="title"] {
+  :pass(1) div[data-type="chapter"] section.problems > [data-type="title"] {
     /* Discard this Page-specific title because a chapter title is added when collated */
     move-to: trash; }
 :pass(1) div[data-type="chapter"]::after {
@@ -603,7 +603,7 @@
   data-type: "composite-page"; }
 :pass(1) div[data-type="chapter"] section.ap-test-prep {
   move-to: ap-test-prep-TOCOMPOSITE; }
-  :pass(1) div[data-type="chapter"] section.ap-test-prep > h3[data-type="title"] {
+  :pass(1) div[data-type="chapter"] section.ap-test-prep > [data-type="title"] {
     /* Discard this Page-specific title because a chapter title is added when collated */
     move-to: trash; }
 :pass(1) div[data-type="chapter"]::after {

--- a/rulesets/output/hs-physics.css
+++ b/rulesets/output/hs-physics.css
@@ -791,7 +791,7 @@
   move-to: trash; }
 :pass(1) div[data-type="chapter"] div[data-type="glossary"] dl {
   move-to: glossary-TOCOMPOSITE; }
-  :pass(1) div[data-type="chapter"] div[data-type="glossary"] dl > h3[data-type="title"] {
+  :pass(1) div[data-type="chapter"] div[data-type="glossary"] dl > [data-type="title"] {
     /* Discard this Page-specific title because a chapter title is added when collated */
     move-to: trash; }
 :pass(1) div[data-type="chapter"]::after {
@@ -804,7 +804,7 @@
   /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
   content: nodes(sectionHeaderNode) content();
   move-to: summary-TOCOMPOSITE; }
-  :pass(1) div[data-type="chapter"] section.summary > h3[data-type="title"] {
+  :pass(1) div[data-type="chapter"] section.summary > [data-type="title"] {
     /* Discard this Page-specific title because a chapter title is added when collated */
     move-to: trash; }
 :pass(1) div[data-type="chapter"]::after {
@@ -816,7 +816,7 @@
   /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
   content: nodes(sectionHeaderNode) content();
   move-to: key-equations-TOCOMPOSITE; }
-  :pass(1) div[data-type="chapter"] section.key-equations > h3[data-type="title"] {
+  :pass(1) div[data-type="chapter"] section.key-equations > [data-type="title"] {
     /* Discard this Page-specific title because a chapter title is added when collated */
     move-to: trash; }
 :pass(1) div[data-type="chapter"]::after {
@@ -826,7 +826,7 @@
   data-type: "composite-page"; }
 :pass(1) div[data-type="chapter"] section.chapter-review {
   move-to: chapter-review-TOCOMPOSITE; }
-  :pass(1) div[data-type="chapter"] section.chapter-review > h3[data-type="title"] {
+  :pass(1) div[data-type="chapter"] section.chapter-review > [data-type="title"] {
     /* Discard this Page-specific title because a chapter title is added when collated */
     move-to: trash; }
 :pass(1) div[data-type="chapter"]::after {
@@ -836,7 +836,7 @@
   data-type: "composite-page"; }
 :pass(1) div[data-type="chapter"] section.test-prep {
   move-to: test-prep-TOCOMPOSITE; }
-  :pass(1) div[data-type="chapter"] section.test-prep > h3[data-type="title"] {
+  :pass(1) div[data-type="chapter"] section.test-prep > [data-type="title"] {
     /* Discard this Page-specific title because a chapter title is added when collated */
     move-to: trash; }
 :pass(1) div[data-type="chapter"]::after {

--- a/rulesets/output/physics.css
+++ b/rulesets/output/physics.css
@@ -435,7 +435,7 @@
   move-to: trash; }
 :pass(1) div[data-type="chapter"] div[data-type="glossary"] dl {
   move-to: glossary-TOCOMPOSITE; }
-  :pass(1) div[data-type="chapter"] div[data-type="glossary"] dl > h3[data-type="title"] {
+  :pass(1) div[data-type="chapter"] div[data-type="glossary"] dl > [data-type="title"] {
     /* Discard this Page-specific title because a chapter title is added when collated */
     move-to: trash; }
 :pass(1) div[data-type="chapter"]::after {
@@ -448,7 +448,7 @@
   /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
   content: nodes(sectionHeaderNode) content();
   move-to: section-summary-TOCOMPOSITE; }
-  :pass(1) div[data-type="chapter"] section.section-summary > h3[data-type="title"] {
+  :pass(1) div[data-type="chapter"] section.section-summary > [data-type="title"] {
     /* Discard this Page-specific title because a chapter title is added when collated */
     move-to: trash; }
 :pass(1) div[data-type="chapter"]::after {
@@ -460,7 +460,7 @@
   /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
   content: nodes(sectionHeaderNode) content();
   move-to: conceptual-questions-TOCOMPOSITE; }
-  :pass(1) div[data-type="chapter"] section.conceptual-questions > h3[data-type="title"] {
+  :pass(1) div[data-type="chapter"] section.conceptual-questions > [data-type="title"] {
     /* Discard this Page-specific title because a chapter title is added when collated */
     move-to: trash; }
 :pass(1) div[data-type="chapter"]::after {
@@ -472,7 +472,7 @@
   /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
   content: nodes(sectionHeaderNode) content();
   move-to: problems-exercises-TOCOMPOSITE; }
-  :pass(1) div[data-type="chapter"] section.problems-exercises > h3[data-type="title"] {
+  :pass(1) div[data-type="chapter"] section.problems-exercises > [data-type="title"] {
     /* Discard this Page-specific title because a chapter title is added when collated */
     move-to: trash; }
 :pass(1) div[data-type="chapter"]::after {

--- a/rulesets/output/statistics.css
+++ b/rulesets/output/statistics.css
@@ -469,7 +469,7 @@
   move-to: trash; }
 :pass(1) div[data-type="chapter"] div[data-type="glossary"] dl {
   move-to: glossary-TOCOMPOSITE; }
-  :pass(1) div[data-type="chapter"] div[data-type="glossary"] dl > h3[data-type="title"] {
+  :pass(1) div[data-type="chapter"] div[data-type="glossary"] dl > [data-type="title"] {
     /* Discard this Page-specific title because a chapter title is added when collated */
     move-to: trash; }
 :pass(1) div[data-type="chapter"]::after {
@@ -482,7 +482,7 @@
   /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
   content: nodes(sectionHeaderNode) content();
   move-to: summary-TOCOMPOSITE; }
-  :pass(1) div[data-type="chapter"] section.summary > h3[data-type="title"] {
+  :pass(1) div[data-type="chapter"] section.summary > [data-type="title"] {
     /* Discard this Page-specific title because a chapter title is added when collated */
     move-to: trash; }
 :pass(1) div[data-type="chapter"]::after {
@@ -494,7 +494,7 @@
   /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
   content: nodes(sectionHeaderNode) content();
   move-to: formula-review-TOCOMPOSITE; }
-  :pass(1) div[data-type="chapter"] section.formula-review > h3[data-type="title"] {
+  :pass(1) div[data-type="chapter"] section.formula-review > [data-type="title"] {
     /* Discard this Page-specific title because a chapter title is added when collated */
     move-to: trash; }
 :pass(1) div[data-type="chapter"]::after {
@@ -506,7 +506,7 @@
   /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
   content: nodes(sectionHeaderNode) content();
   move-to: practice-TOCOMPOSITE; }
-  :pass(1) div[data-type="chapter"] section.practice > h3[data-type="title"] {
+  :pass(1) div[data-type="chapter"] section.practice > [data-type="title"] {
     /* Discard this Page-specific title because a chapter title is added when collated */
     move-to: trash; }
 :pass(1) div[data-type="chapter"]::after {
@@ -516,7 +516,7 @@
   data-type: "composite-page"; }
 :pass(1) div[data-type="chapter"] section.bring-together-exercises {
   move-to: bring-together-exercises-TOCOMPOSITE; }
-  :pass(1) div[data-type="chapter"] section.bring-together-exercises > h3[data-type="title"] {
+  :pass(1) div[data-type="chapter"] section.bring-together-exercises > [data-type="title"] {
     /* Discard this Page-specific title because a chapter title is added when collated */
     move-to: trash; }
 :pass(1) div[data-type="chapter"]::after {
@@ -528,7 +528,7 @@
   /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
   content: nodes(sectionHeaderNode) content();
   move-to: free-response-TOCOMPOSITE; }
-  :pass(1) div[data-type="chapter"] section.free-response > h3[data-type="title"] {
+  :pass(1) div[data-type="chapter"] section.free-response > [data-type="title"] {
     /* Discard this Page-specific title because a chapter title is added when collated */
     move-to: trash; }
 :pass(1) div[data-type="chapter"]::after {
@@ -538,7 +538,7 @@
   data-type: "composite-page"; }
 :pass(1) div[data-type="chapter"] section.bring-together-homework {
   move-to: bring-together-homework-TOCOMPOSITE; }
-  :pass(1) div[data-type="chapter"] section.bring-together-homework > h3[data-type="title"] {
+  :pass(1) div[data-type="chapter"] section.bring-together-homework > [data-type="title"] {
     /* Discard this Page-specific title because a chapter title is added when collated */
     move-to: trash; }
 :pass(1) div[data-type="chapter"]::after {
@@ -550,7 +550,7 @@
   /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
   content: nodes(sectionHeaderNode) content();
   move-to: references-TOCOMPOSITE; }
-  :pass(1) div[data-type="chapter"] section.references > h3[data-type="title"] {
+  :pass(1) div[data-type="chapter"] section.references > [data-type="title"] {
     /* Discard this Page-specific title because a chapter title is added when collated */
     move-to: trash; }
 :pass(1) div[data-type="chapter"]::after {


### PR DESCRIPTION
EOC section titles were not being trashed after move-to due to the incorrect selector. 