### PR TITLE
moves validation mixins into a separate file

### DIFF
--- a/rulesets/common/_all.scss
+++ b/rulesets/common/_all.scss
@@ -6,5 +6,6 @@
 @import './_reference';
 @import './_toc';
 @import './_utils';
+@import './_validate';
 // Incude the "common" style guide
 @import './styleguide/_all';

--- a/rulesets/common/_compose.scss
+++ b/rulesets/common/_compose.scss
@@ -9,8 +9,8 @@
     $source: map-get($page, source);
 
     // Validate
-    @include utils_checkType($name, string);
-    @include utils_checkType($source, string);
+    @include validate_type($name, string);
+    @include validate_type($source, string);
 
     [data-type="composite-page"].os-eoc.os-#{$source}-container {
       $titleContent: (
@@ -30,8 +30,8 @@
     $source: map-get($page, source);
 
     // Validate
-    @include utils_checkType($name, string);
-    @include utils_checkType($source, string);
+    @include validate_type($name, string);
+    @include validate_type($source, string);
 
     [data-type="composite-page"].os-eob.os-#{$source}-container {
       $titleContent: (
@@ -49,7 +49,7 @@
 /// @group compose
 @mixin compose_createChapterComposites($compositePages, $sectionHeaderNode) {
   // Validate
-  @include utils_checkType($compositePages, list);
+  @include validate_type($compositePages, list);
 
   @each $page in $compositePages {
     @include _createChapterComposite($page, $sectionHeaderNode);
@@ -68,11 +68,11 @@
   $compoundComposite: map-get($page, compoundComposite);
 
   // Validate
-  @include utils_checkType($name, string);
-  @include utils_checkType($source, string);
-  @include utils_checkTypeOptional($sortBy, string);
-  @include utils_checkTypeOptional($compoundComposite, bool);
-  @include utils_checkType($sectionHeaderNode, string);
+  @include validate_type($name, string);
+  @include validate_type($source, string);
+  @include validate_typeOptional($sortBy, string);
+  @include validate_typeOptional($compoundComposite, bool);
+  @include validate_type($sectionHeaderNode, string);
 
   div[data-type="chapter"] {
     @if (not $compoundComposite) {
@@ -208,11 +208,11 @@
   $isIndex: map-get($page, isIndex);
 
   // Validate
-  @include utils_checkType($name, string);
-  @include utils_checkType($source, string);
-  @include utils_checkTypeOptional($isIndex, bool);
-  @include utils_checkTypeOptional($compoundComposite, bool);
-  @include utils_checkType($sectionHeaderString, string);
+  @include validate_type($name, string);
+  @include validate_type($source, string);
+  @include validate_typeOptional($isIndex, bool);
+  @include validate_typeOptional($compoundComposite, bool);
+  @include validate_type($sectionHeaderString, string);
 
   @if (not $compoundComposite) {
     $sourceSelector: if($isIndex, 'div[data-type="page"] span[data-type="term"], div[data-type="composite-page"] span[data-type="term"]', 'section.#{$source}');
@@ -260,9 +260,9 @@
       $chapterPages: map-get($page, chapterPages);
 
       // Validate
-      @include utils_checkType($chapterSeparated, bool);
-      @include utils_checkType($sectionSeparated, bool);
-      @include utils_checkTypeOptional($chapterPages, bool);
+      @include validate_type($chapterSeparated, bool);
+      @include validate_type($sectionSeparated, bool);
+      @include validate_typeOptional($chapterPages, bool);
 
       [data-type="chapter"] {
         #{$sourceSelector} {
@@ -310,8 +310,8 @@
     $isIndex: map-get($page, isIndex);
 
     // Validate
-    @include utils_checkType($source, string);
-    @include utils_checkTypeOptional($isIndex, bool);
+    @include validate_type($source, string);
+    @include validate_typeOptional($isIndex, bool);
 
     &::after {
       container: div;
@@ -334,13 +334,13 @@
 /// @group compose
 @mixin compose_prepChapterAreas($compositePages, $chapterHeaderNode) {
   // Validate
-  @include utils_checkType($chapterHeaderNode, string);
+  @include validate_type($chapterHeaderNode, string);
 
   @each $page in $compositePages {
     $source: map-get($page, source);
 
     // Validate
-    @include utils_checkType($source, string);
+    @include validate_type($source, string);
 
     [data-type="chapter"] {
       .os-#{$source}-chapter-area {
@@ -361,16 +361,16 @@
   $sectionSeparated: map-get($solutionPage, sectionSeparated);
 
   // Validate
-  @include utils_checkType($solutionSource, string);
-  @include utils_checkTypeOptional($sectionSeparated, bool);
+  @include validate_type($solutionSource, string);
+  @include validate_typeOptional($sectionSeparated, bool);
 
   @each $page in $compositePages {
     $hasSolutions: map-get($page, hasSolutions);
     $source: map-get($page, source);
 
     // Validate
-    @include utils_checkType($source, string);
-    @include utils_checkTypeOptional($hasSolutions, bool);
+    @include validate_type($source, string);
+    @include validate_typeOptional($hasSolutions, bool);
 
     @if ($hasSolutions) {
       [data-type="chapter"] {
@@ -424,17 +424,17 @@
   $chapterSeparated: map-get($solutionPage,chapterSeparated);
 
   // Validate
-  @include utils_checkType($solutionSource, string);
-  @include utils_checkTypeOptional($sectionSeparated, bool);
-  @include utils_checkType($chapterSeparated, bool);
+  @include validate_type($solutionSource, string);
+  @include validate_typeOptional($sectionSeparated, bool);
+  @include validate_type($chapterSeparated, bool);
 
   @each $page in $compositePages {
     $hasSolutions: map-get($page, hasSolutions);
     $source: map-get($page, source);
 
     // Validate
-    @include utils_checkTypeOptional($hasSolutions, bool);
-    @include utils_checkType($source, string);
+    @include validate_typeOptional($hasSolutions, bool);
+    @include validate_type($source, string);
 
     @if ($hasSolutions) {
       [data-type="chapter"] {

--- a/rulesets/common/_number.scss
+++ b/rulesets/common/_number.scss
@@ -107,7 +107,7 @@
 
   // $noTitleContent: (); // For the exceptions, this is the "titleContent" that will be used
 
-  @include utils_checkTypeOptional($exceptionClassNames, list);
+  @include validate_typeOptional($exceptionClassNames, list);
   // These selectors are of the form:
   // `table:not(.unnumbered):not(.custom1):not(.custom2)` (everything that is not an exception)
   // `table.unnumbered, table.custom1, table.custom2`     (everything that is an exception)
@@ -115,7 +115,7 @@
   $exceptionsSelector: "";
   @if $exceptionClassNames {
     @each $item in $exceptionClassNames {
-      @include utils_checkType($item, string);
+      @include validate_type($item, string);
       $notAnExceptionSelector: unquote("#{$notAnExceptionSelector}:not(.#{$item})");
       // Only add a comma if there is already an $exceptionsSelector
       @if $exceptionsSelector == "" {

--- a/rulesets/common/_utils.scss
+++ b/rulesets/common/_utils.scss
@@ -93,22 +93,3 @@
     content: clear(trash);
   }
 }
-
-/// Utility mixin that validates the type of a variable.
-/// useful for erroring early. For example, If the developer was expecting an
-/// argument to a mixin to be a `list` but the mixin that uses it several levels
-/// deep actually expected it to be a `bool`
-/// @group utils
-@mixin utils_checkType($var, $expectedType) {
-  @if (type-of($var) != $expectedType) {
-    @error "The argument is of the wrong type. Expected: #{$expectedType} but got #{type-of($var)}";
-  }
-}
-
-/// @see {mixin} utils_checkTypeOptional
-/// @group utils
-@mixin utils_checkTypeOptional($var, $expectedType) {
-  @if ($var and type-of($var) != $expectedType) {
-    @error "The optional argument is of the wrong type. Expected: #{$expectedType} but got #{type-of($var)}";
-  }
-}

--- a/rulesets/common/_validate.scss
+++ b/rulesets/common/_validate.scss
@@ -1,0 +1,49 @@
+/// Utility mixin that validates the type of a variable.
+/// useful for erroring early. For example, If the developer was expecting an
+/// argument to a mixin to be a `list` but the mixin that uses it several levels
+/// deep actually expected it to be a `bool`
+/// @group validate
+@mixin validate_type($var, $expectedType) {
+  @if (type-of($var) != $expectedType) {
+    @error "BUG: The argument is of the wrong type. Expected: #{$expectedType} but got #{type-of($var)}";
+  }
+}
+
+/// @see {mixin} validate_type
+/// @group validate
+@mixin validate_typeOptional($var, $expectedType) {
+  @if ($var and type-of($var) != $expectedType) {
+    @error "BUG: The optional argument is of the wrong type. Expected: #{$expectedType} but got #{type-of($var)}";
+  }
+}
+
+/// Utility mixin that checks that the argument is an Enum (like `$MOVE_TO_###` or `$RESET_###`)
+/// by checking that the value of the enum begins with `$startsWithStr`.
+/// This is sort of a hack because SASS does not have Enums (or typed Enums).
+/// @group validate
+@mixin validate_enum($val, $startsWithStr) {
+  @include validate_type($val, string);
+  @include validate_type($startsWithStr, string);
+
+  @if str-index($val, $startsWithStr) >= 1 {
+  } @else {
+    @error "BUG: Invalid enum used. You must pass in a string that begins with '#{$startsWithStr}' but got '#{$val}'";
+  }
+}
+
+/// @see {mixin} validate_enum
+/// @group validate
+@mixin validate_enumOptional($val, $startsWithStr) {
+  @if $val {
+    @include validate_enum($val, $startsWithStr);
+  }
+}
+
+/// Checks that the value exists (is not null)
+/// @group validate
+@mixin validate_exists($val) {
+  @if $val { }
+  @else {
+    @error "BUG: A value is required for this field";
+  }
+}


### PR DESCRIPTION
Currently, the validation mixins are organized in the `utils_` namespace and are rather long & difficult to remember. This shortens the name and moves them into a separate section.

Pulled from #107 as a separate PR so it can get merged sooner