### PR TITLE
small fix so sassdoc runs again

### DIFF
--- a/scripts/generate-docs
+++ b/scripts/generate-docs
@@ -1,7 +1,6 @@
-#!/bin/sh
-set -e
+#!/bin/bash
 
 >&2 echo "==> Generating SASSdocs"
-$(npm bin)/sassdoc --verbose --dest=./sassdoc/ ./rulesets/
+$(npm bin)/sassdoc --verbose --dest=./sassdoc/ ./rulesets/ || exit 1
 
 >&2 echo "Docs are available at ./sassdoc/index.html . You can open them in a browser"


### PR DESCRIPTION
Sassdoc was not running because it was pointing to the wrong directory

**Note:** there are still warnings in `_compose.scss` that should be fixed

Pulled from #107, This also handles the error case: If the `sassdoc` command returns a non-zero exit status then this script will also return a non-zero exit status and will not continue executing