### PR TITLE
describe which features should go in the styleguide

### DIFF
--- a/books.txt
+++ b/books.txt
@@ -1,20 +1,28 @@
 #!/bin/bash
 
+
+# These columns are:
+# - bookName
+# - rulesetName
+# - uuid : The uuid to use for ./scripts/fetch-book
+# - hostName : The hostName to use when running ./scripts/fetch-book and ./scripts/bake-book-remote
+# - additionalStyleguideDirs : These specify which additional directories should be included when generating the styleguide
+
 BOOK_CONFIGS=(
-  "statistics         statistics        30189442-6998-4686-ac05-ed152b91b9de    tea.cnx.org"
-  "TEAhsstats         statistics        ace2ec2d-778e-44aa-82c2-57a4e5c3de69    cte-cnx-dev.cnx.org"
-  "econ               economics         69619d2b-68f0-44b0-b074-a9b2bf90b2c6    tea.cnx.org"
-  "macroecon          economics         4061c832-098e-4b3c-a1d9-7eb593a2cb31    tea.cnx.org"
-  "macroeconap        economics         33076054-ec1d-4417-8824-ce354efe42d0    tea.cnx.org"
-  "microecon          economics         ea2f225e-6063-41ca-bcd8-36482e15ef65    tea.cnx.org"
-  "microeconap        economics         ca344e2d-6731-43cd-b851-a7b3aa0b37aa    tea.cnx.org"
-  "TEAmacroeconap     economics         3353a691-0c52-4691-8f36-65490cd3d962    cte-cnx-dev.cnx.org"
-  "TEAmicroeconap     economics         7f6fbc5b-6f3b-40a8-87ac-b14adc941e5e    cte-cnx-dev.cnx.org"
-  "physics            physics           031da8d3-b525-429c-80cf-6c8ed997733a    tea.cnx.org"
-  "TEAapphysics       ap-physics        21f9700a-d0ca-406d-9598-9af463d62c7c    tea.cnx.org"
-  "TEAapphysics2      ap-physics        4db6028f-8ca1-4a47-a1d3-9510baad7f9b    tea.cnx.org"
-  "TEAhsphysics       hs-physics        dbfdc541-752c-4a79-9e83-d32b1ca2c176    tea.cnx.org"
-  "biology            biology           185cbf87-c72e-48f5-b51e-f14f21b5eabd    tea.cnx.org"
+  "statistics         statistics        30189442-6998-4686-ac05-ed152b91b9de    tea.cnx.org          common/"
+  "TEAhsstats         statistics        ace2ec2d-778e-44aa-82c2-57a4e5c3de69    cte-cnx-dev.cnx.org  common/"
+  "econ               economics         69619d2b-68f0-44b0-b074-a9b2bf90b2c6    tea.cnx.org          common/"
+  "macroecon          economics         4061c832-098e-4b3c-a1d9-7eb593a2cb31    tea.cnx.org          common/"
+  "macroeconap        economics         33076054-ec1d-4417-8824-ce354efe42d0    tea.cnx.org          common/"
+  "microecon          economics         ea2f225e-6063-41ca-bcd8-36482e15ef65    tea.cnx.org          common/"
+  "microeconap        economics         ca344e2d-6731-43cd-b851-a7b3aa0b37aa    tea.cnx.org          common/"
+  "TEAmacroeconap     economics         3353a691-0c52-4691-8f36-65490cd3d962    cte-cnx-dev.cnx.org  common/"
+  "TEAmicroeconap     economics         7f6fbc5b-6f3b-40a8-87ac-b14adc941e5e    cte-cnx-dev.cnx.org  common/"
+  "physics            physics           031da8d3-b525-429c-80cf-6c8ed997733a    tea.cnx.org          common/"
+  "TEAapphysics       ap-physics        21f9700a-d0ca-406d-9598-9af463d62c7c    tea.cnx.org          common/,books/physics/"
+  "TEAapphysics2      ap-physics        4db6028f-8ca1-4a47-a1d3-9510baad7f9b    tea.cnx.org          common/,books/physics/"
+  "TEAhsphysics       hs-physics        dbfdc541-752c-4a79-9e83-d32b1ca2c176    tea.cnx.org          common/"
+  "biology            biology           185cbf87-c72e-48f5-b51e-f14f21b5eabd    tea.cnx.org          common/"
 )
 
 BOOK_NAMES=()

--- a/books.txt
+++ b/books.txt
@@ -9,20 +9,20 @@
 # - additionalStyleguideDirs : These specify which additional directories should be included when generating the styleguide
 
 BOOK_CONFIGS=(
-  "statistics         statistics        30189442-6998-4686-ac05-ed152b91b9de    tea.cnx.org          common/"
-  "TEAhsstats         statistics        ace2ec2d-778e-44aa-82c2-57a4e5c3de69    cte-cnx-dev.cnx.org  common/"
-  "econ               economics         69619d2b-68f0-44b0-b074-a9b2bf90b2c6    tea.cnx.org          common/"
-  "macroecon          economics         4061c832-098e-4b3c-a1d9-7eb593a2cb31    tea.cnx.org          common/"
-  "macroeconap        economics         33076054-ec1d-4417-8824-ce354efe42d0    tea.cnx.org          common/"
-  "microecon          economics         ea2f225e-6063-41ca-bcd8-36482e15ef65    tea.cnx.org          common/"
-  "microeconap        economics         ca344e2d-6731-43cd-b851-a7b3aa0b37aa    tea.cnx.org          common/"
-  "TEAmacroeconap     economics         3353a691-0c52-4691-8f36-65490cd3d962    cte-cnx-dev.cnx.org  common/"
-  "TEAmicroeconap     economics         7f6fbc5b-6f3b-40a8-87ac-b14adc941e5e    cte-cnx-dev.cnx.org  common/"
-  "physics            physics           031da8d3-b525-429c-80cf-6c8ed997733a    tea.cnx.org          common/"
-  "TEAapphysics       ap-physics        21f9700a-d0ca-406d-9598-9af463d62c7c    tea.cnx.org          common/,books/physics/"
-  "TEAapphysics2      ap-physics        4db6028f-8ca1-4a47-a1d3-9510baad7f9b    tea.cnx.org          common/,books/physics/"
-  "TEAhsphysics       hs-physics        dbfdc541-752c-4a79-9e83-d32b1ca2c176    tea.cnx.org          common/"
-  "biology            biology           185cbf87-c72e-48f5-b51e-f14f21b5eabd    tea.cnx.org          common/"
+  "statistics         statistics        30189442-6998-4686-ac05-ed152b91b9de    tea.cnx.org          mixins/"
+  "TEAhsstats         statistics        ace2ec2d-778e-44aa-82c2-57a4e5c3de69    cte-cnx-dev.cnx.org  mixins/"
+  "econ               economics         69619d2b-68f0-44b0-b074-a9b2bf90b2c6    tea.cnx.org          mixins/"
+  "macroecon          economics         4061c832-098e-4b3c-a1d9-7eb593a2cb31    tea.cnx.org          mixins/"
+  "macroeconap        economics         33076054-ec1d-4417-8824-ce354efe42d0    tea.cnx.org          mixins/"
+  "microecon          economics         ea2f225e-6063-41ca-bcd8-36482e15ef65    tea.cnx.org          mixins/"
+  "microeconap        economics         ca344e2d-6731-43cd-b851-a7b3aa0b37aa    tea.cnx.org          mixins/"
+  "TEAmacroeconap     economics         3353a691-0c52-4691-8f36-65490cd3d962    cte-cnx-dev.cnx.org  mixins/"
+  "TEAmicroeconap     economics         7f6fbc5b-6f3b-40a8-87ac-b14adc941e5e    cte-cnx-dev.cnx.org  mixins/"
+  "physics            physics           031da8d3-b525-429c-80cf-6c8ed997733a    tea.cnx.org          mixins/"
+  "TEAapphysics       ap-physics        21f9700a-d0ca-406d-9598-9af463d62c7c    tea.cnx.org          mixins/,books/physics/"
+  "TEAapphysics2      ap-physics        4db6028f-8ca1-4a47-a1d3-9510baad7f9b    tea.cnx.org          mixins/,books/physics/"
+  "TEAhsphysics       hs-physics        dbfdc541-752c-4a79-9e83-d32b1ca2c176    tea.cnx.org          mixins/"
+  "biology            biology           185cbf87-c72e-48f5-b51e-f14f21b5eabd    tea.cnx.org          mixins/"
 )
 
 BOOK_NAMES=()

--- a/scripts/generate-guide
+++ b/scripts/generate-guide
@@ -11,7 +11,6 @@ guideHomepageFile="./guide-homepage.md" # Relative to ${sassDir}/rulesets/
 
 tempDir="./tmp/"
 tempRulesetDir="${tempDir}/${rulesetName}/"
-commonDocumentationDir="./rulesets/mixins"
 bookDocumentationDir="./rulesets/books/${rulesetName}"
 kssOutputFile="${tempDir}/kss-output.txt"
 
@@ -56,9 +55,40 @@ then
 fi
 mkdir "${tempRulesetDir}" || exit 1
 
-cp -R "${commonDocumentationDir}" "${tempRulesetDir}" || exit 1
+# Copy over all the dirs containing the styleguide comments that need to be included
+
+# Pull in the BOOK_CONFIGS
+source ./books.txt || exit 1
+
+# Filter BOOK_CONFIGS to only contain the book you want to fetch
+for bookConfig in "${BOOK_CONFIGS[@]}"
+do
+  read -r bookConfigName rulesetConfigName uuid hostName basedOns <<< "${bookConfig}"
+
+  if [[ "${rulesetName}" = "${rulesetConfigName}" ]]
+  then
+    # Actually copy the directories over (like common/,books/physics/)
+    IFS=',' read -ra basedOnDirs <<< "$basedOns"
+    for basedOnDirName in "${basedOnDirs[@]}"; do
+      echo "==> Including ${sassDir}/${basedOnDirName}"
+      cp -R "${sassDir}/${basedOnDirName}" "${tempRulesetDir}/$(basename ${basedOnDirName})" || exit 1
+    done
+    foundConfig=1
+    break
+  fi
+done
+
+if [[ ! 1 -eq "${foundConfig}" ]]
+then
+  >&2 echo "ERROR: Could not find Book info for book named ${rulesetName}"
+  >&2 echo "check ./books.txt"
+  exit 1
+fi
+
 cp -R "${bookDocumentationDir}" "${tempRulesetDir}" || exit 1
 
+
+# Find all the styleguide html files and convert them
 for snippetFileName in $(find "${tempRulesetDir}" -name "*.html")
 do
   >&2 echo "Generating temporary ${snippetFileName}-baked.html"


### PR DESCRIPTION
This allows each book to decide which style guides to include.

For example, with the old codebase, _every_ book would always get the common styleguide sections (Lists, Paragraphs, Tables) and there was no way to generate a guide that _only_ contained book-specific features. 

Also, if a book (ie AP Physics) added more features to another book (ie Physics) there would be a bunch of copy/pasta to get all those features to show up in the guide; now, just add it to the book entry in `books.txt`.

Pulled from #107