### PR TITLE
:bug: somehow missed in the merge, this CSS file needed to be updated

### DIFF
--- a/rulesets/output/biology.css
+++ b/rulesets/output/biology.css
@@ -532,7 +532,7 @@
   move-to: trash; }
 :pass(1) div[data-type="chapter"] div[data-type="glossary"] dl {
   move-to: glossary-TOCOMPOSITE; }
-  :pass(1) div[data-type="chapter"] div[data-type="glossary"] dl > h3[data-type="title"] {
+  :pass(1) div[data-type="chapter"] div[data-type="glossary"] dl > [data-type="title"] {
     /* Discard this Page-specific title because a chapter title is added when collated */
     move-to: trash; }
 :pass(1) div[data-type="chapter"]::after {
@@ -545,7 +545,7 @@
   /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
   content: nodes(sectionHeaderNode) content();
   move-to: summary-TOCOMPOSITE; }
-  :pass(1) div[data-type="chapter"] section.summary > h3[data-type="title"] {
+  :pass(1) div[data-type="chapter"] section.summary > [data-type="title"] {
     /* Discard this Page-specific title because a chapter title is added when collated */
     move-to: trash; }
 :pass(1) div[data-type="chapter"]::after {
@@ -555,7 +555,7 @@
   data-type: "composite-page"; }
 :pass(1) div[data-type="chapter"] section.art-exercise {
   move-to: art-exercise-TOCOMPOSITE; }
-  :pass(1) div[data-type="chapter"] section.art-exercise > h3[data-type="title"] {
+  :pass(1) div[data-type="chapter"] section.art-exercise > [data-type="title"] {
     /* Discard this Page-specific title because a chapter title is added when collated */
     move-to: trash; }
 :pass(1) div[data-type="chapter"]::after {
@@ -565,7 +565,7 @@
   data-type: "composite-page"; }
 :pass(1) div[data-type="chapter"] section.multiple-choice {
   move-to: multiple-choice-TOCOMPOSITE; }
-  :pass(1) div[data-type="chapter"] section.multiple-choice > h3[data-type="title"] {
+  :pass(1) div[data-type="chapter"] section.multiple-choice > [data-type="title"] {
     /* Discard this Page-specific title because a chapter title is added when collated */
     move-to: trash; }
 :pass(1) div[data-type="chapter"]::after {
@@ -575,7 +575,7 @@
   data-type: "composite-page"; }
 :pass(1) div[data-type="chapter"] section.free-response {
   move-to: free-response-TOCOMPOSITE; }
-  :pass(1) div[data-type="chapter"] section.free-response > h3[data-type="title"] {
+  :pass(1) div[data-type="chapter"] section.free-response > [data-type="title"] {
     /* Discard this Page-specific title because a chapter title is added when collated */
     move-to: trash; }
 :pass(1) div[data-type="chapter"]::after {


### PR DESCRIPTION
Looks like #126 was created before biology was added so this CSS file was forgotten/missed. As a result, `master` has a big travis "X" on it and any new PR's with master would have to fix this problem (unless this PR is merged first)