### PR TITLE
:art: move utils mixins to be private

### DIFF
--- a/rulesets/mixins/_count.scss
+++ b/rulesets/mixins/_count.scss
@@ -1,9 +1,22 @@
-@import "./utils";
+/// Base counting mixin - creates a counter with the given name, increment location, and reset location
+/// @arg {Text} $name - The unquoted name of the counter that will be created
+/// @arg {String} $selector - A string of the selector at which the counter will increment
+/// @arg {String} $resetSelector - A string of the selector at which the counter will reset
+/// @group count
+@mixin _count($name, $selector, $resetSelector) {
+  //Improvement: Resetting isn't dry, recreates selector if more than one counter resets on one element
+  #{$resetSelector} {
+    counter-reset: $name;
+  }
+  #{$selector} {
+    counter-increment: $name;
+  }
+}
 
 
 //TODO: call arguments explicity? Is this possible? Ex:
 // @mixin count_countChapter($name) {
-//   @include utils_count(
+//   @include _count(
 //     $name: $name,
 //     $selector: 'div[data-type="chapter"]',
 //     $resetSelector: 'body'
@@ -14,7 +27,7 @@
 /// @arg {Text} $name - Name of the css counter that will control chapter numbering
 /// @group count
 @mixin count_countChapters($name) {
-  @include utils_count(
+  @include _count(
     $name,
     'div[data-type="chapter"]',
     'body'
@@ -25,7 +38,7 @@
 /// @arg {Text} $name - Name of the css counter that will control appendix numbering`
 /// @group count
 @mixin count_countAppendices($name) {
-  @include utils_count(
+  @include _count(
     $name,
     'div.appendix',
     'body'
@@ -37,7 +50,7 @@
 /// @arg {Text} $name - Name of the css counter that will control section numbering
 /// @group count
 @mixin count_countSections($name) {
-  @include utils_count(
+  @include _count(
     $name,
     'div[data-type="chapter"] > div[data-type="page"]:not(.introduction)',
     '[data-type="chapter"], .appendix'
@@ -50,7 +63,7 @@
 /// @group count
 
 @mixin count_countEOCExercises($name, $resetSelector) {
-  @include utils_count(
+  @include _count(
     $name,
     '.os-eoc [data-type="exercise"]',
     '#{$resetSelector}, .appendix'
@@ -62,7 +75,7 @@
 /// @arg {Text} $name - Name of the css counter that will control all exercise numbering
 /// @group count
 @mixin count_countExercises($name) {
-  @include utils_count(
+  @include _count(
     $name,
     '.os-eoc [data-type="exercise"]',
     'body'
@@ -73,7 +86,7 @@
 /// @arg {Text} $name - Name of the css counter that will control example numbering
 /// @group count
 @mixin count_countExamples($name) {
-  @include utils_count(
+  @include _count(
     $name,
     'div[data-type="chapter"] [data-type="example"]',
     '[data-type="chapter"], .appendix'
@@ -84,7 +97,7 @@
 /// @arg {Text} $name - Name of the css counter that will control term numbering
 /// @group count
 @mixin count_countTerms($name) {
-  @include utils_count(
+  @include _count(
     $name,
     'div[data-type="page"] span[data-type="term"], div[data-type="composite-page"] span[data-type="term"]',
     'body'
@@ -95,7 +108,7 @@
 /// @arg {Text} $name - Name of the css counter that will control table numbering
 /// @group count
 @mixin count_countTables($name) {
-  @include utils_count(
+  @include _count(
     $name,
     ':not(table) > table',
     '[data-type="chapter"], .appendix'
@@ -106,7 +119,7 @@
 /// @arg {Text} $name - Name of the css counter that will control figure numbering
 /// @group count
 @mixin count_countFigures($name) {
-  @include utils_count(
+  @include _count(
     $name,
     ':not(figure) > figure',
     '[data-type="chapter"], .appendix'
@@ -118,7 +131,7 @@
 /// @arg {String} $type - A string of the selector of the note type you want to count
 /// @group count
 @mixin count_countNote($name, $type) {
-  @include utils_count(
+  @include _count(
     $name,
     '[data-type="note"].#{$type}',
     '[data-type="chapter"], .appendix'
@@ -129,7 +142,7 @@
 /// @arg {Text} $name - Name of the css counter that will control equation numbering
 /// @group count
 @mixin count_countEquations($name) {
-  @include utils_count(
+  @include _count(
     $name,
     '[data-type="equation"]',
     '[data-type="chapter"], .appendix'

--- a/rulesets/mixins/_reference.scss
+++ b/rulesets/mixins/_reference.scss
@@ -1,10 +1,24 @@
-@import "./utils";
+/// Simply base mixin to reference a string
+/// @arg {Text} $name - The unquoted name of the string that will be referenced
+/// @arg {String} $string - The referenced string. Often, this will be to an element's content() or an attr()
+/// @group reference
+@mixin _refStringAs($name, $string) {
+  string-set: $name $string;
+}
+
+/// Simply base mixin to reference a node
+/// @arg {Text} $name - The unquoted name of the node that will be referenced
+/// @group reference
+@mixin _refNodeAs($name) {
+  node-set: $name;
+}
+
 
 @mixin reference_refSectionHeaderNodeAs($name) {
   div[data-type="page"],
   div[data-type="composite-page"] {
     > [data-type="document-title"] {
-      @include utils_refNodeAs($name);
+      @include _refNodeAs($name);
     }
   }
 }
@@ -12,32 +26,32 @@
   div[data-type="page"],
   div[data-type="composite-page"] {
     > [data-type="document-title"] {
-      @include utils_refStringAs($name, content());
+      @include _refStringAs($name, content());
     }
   }
 }
 
 @mixin reference_refChapterHeaderNodeAs($name) {
   div[data-type="chapter"] {
-    @include utils_refNodeAs($name);
+    @include _refNodeAs($name);
   }
 }
 
 @mixin reference_refChapterHeaderStringAs($name) {
   div[data-type="chapter"] {
-    @include utils_refStringAs($name, content());
+    @include _refStringAs($name, content());
   }
 }
 
 @mixin reference_refPageIDStringAs($name) {
   div[data-type="page"],
   div[data-type="composite-page"] {
-    @include utils_refStringAs($name, attr(id))
+    @include _refStringAs($name, attr(id))
   }
 }
 
 @mixin reference_refBookMetadataNodeAs($name) {
   body > [data-type="metadata"] {
-    @include utils_refNodeAs($name);
+    @include _refNodeAs($name);
   }
 }

--- a/rulesets/mixins/_utils.scss
+++ b/rulesets/mixins/_utils.scss
@@ -1,19 +1,3 @@
-/// Base counting mixin - creates a counter with the given name, increment location, and reset location
-/// @arg {Text} $name - The unquoted name of the counter that will be created
-/// @arg {String} $selector - A string of the selector at which the counter will increment
-/// @arg {String} $resetSelector - A string of the selector at which the counter will reset
-/// @group utils
-@mixin utils_count($name, $selector, $resetSelector) {
-  //Improvement: Resetting isn't dry, recreates selector if more than one counter resets on one element
-  #{$resetSelector} {
-    counter-reset: $name;
-  }
-  #{$selector} {
-    counter-increment: $name;
-  }
-}
-
-
 /// Base titling and numbering mixin - Creates <span> elements before an element defined by the content passed. These <span> elements can be automatically wrapped and/or sent to a specified bucket
 /// @arg {Map} $content - A content map containing key and value pairs. Each key, value pair creates a <span> of class="key" with a text node of "value"
 /// @arg {Text} $bucket [null] - The unquoted name of the bucket to send the resulting object(s) to. If null, resulting object(s) will remain in place, before the element the mixin was called within
@@ -69,21 +53,6 @@
       class: attr(class) string(isSolution, " ") ;
     }
   }
-}
-
-/// Simply base mixin to reference a node
-/// @arg {Text} $name - The unquoted name of the node that will be referenced
-/// @group utils
-@mixin utils_refNodeAs($name) {
-  node-set: $name;
-}
-
-/// Simply base mixin to reference a string
-/// @arg {Text} $name - The unquoted name of the string that will be referenced
-/// @arg {String} $string - The referenced string. Often, this will be to an element's content() or an attr()
-/// @group utils
-@mixin utils_refStringAs($name, $string) {
-  string-set: $name $string;
 }
 
 /// A simple call to clear the trash at the end of a pass/step


### PR DESCRIPTION
While reading through to understand the mixins I kept having to refer to the utils file even though a particular mixin was only used in one file (ie `utils_count`).

This moves the `utils_*` mixin (if it is only used in 1 file) to be a private mixin at the top of the file instead.