### PR TITLE
when baking a book, compile only the ruleset needed

### DIFF
--- a/scripts/bake-book
+++ b/scripts/bake-book
@@ -45,11 +45,11 @@ then
 fi
 
 
-./scripts/compile-books || exit 1
-
 for bookConfig in "${BOOK_CONFIGS[@]}"
 do
   read -r bookName rulesetName uuid _ <<< "${bookConfig}"
+
+  ./scripts/compile-books ${rulesetName} || exit 1
 
   rawFile="./data/${bookName}-raw.html"
   bakedFile="./data/${bookName}-baked.html"

--- a/scripts/compile-books
+++ b/scripts/compile-books
@@ -1,10 +1,19 @@
 #!/bin/bash
 
+arg1=$1
+
 # Pull in the BOOK_CONFIGS and RULESET_NAMES
 source ./books.txt || exit 1
 
 # Initialize rbenv (if installed)
 [[ -n $(which rbenv) ]] && eval "$(rbenv init -)"
+
+
+if [ ! "${arg1}" == "" ]
+then
+  RULESET_NAMES=(${arg1})
+fi
+
 
 for rulesetName in "${RULESET_NAMES[@]}"
 do


### PR DESCRIPTION
Previously, `./scripts/bake-book ${BOOK_NAME}` would compile all the rulesets instead of just compiling the ruleset needed to make the book.