### PR TITLE
Use codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,6 @@
+comment:
+  layout: "header, diff, changes, uncovered, tree"
+  behavior: default
+
+# To Turn off comments completely:
+# comment: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,6 @@ before_install:
 install:
   - ./scripts/setup
 script: ./scripts/ci
+after_success:
+  # Report coverage to codecov
+  - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Coverage][coveralls-image]][coveralls-url]
+[![Coverage][codecov-image]][codecov-url]
 
 # Install
 
@@ -118,5 +118,7 @@ To update the Documentation in the gh-pages branch:
 **Note:** This will push changes if successful
 
 
+[codecov-image]: https://img.shields.io/codecov/c/github/connexions/cnx-recipes.svg
+[codecov-url]: https://codecov.io/gh/Connexions/cnx-recipes
 [coveralls-image]: https://img.shields.io/coveralls/connexions/cnx-recipes.svg
 [coveralls-url]: https://coveralls.io/github/Connexions/cnx-recipes


### PR DESCRIPTION
This adds https://codecov.io coverage reporting (without removing coveralls for now).

In addition to reporting normal coverage, it seems this will also show the coverage differences between `master` and the Pull Request/branch/commit.

Link to the coverage: https://codecov.io/gh/Connexions/cnx-recipes and [Coverage for a single commit](https://codecov.io/gh/Connexions/cnx-recipes/tree/05cac5d2c3db2d1a1f90aca1994e1c8a5fdbac77/rulesets/output)


# Screenshots

If you use the [Browser Extension]() then you can also see which new lines of code were not hit as part of the changes in the Pull Request (the big red/green boxes on the left of each line):

This screenshot is from `https://github.com/nextcloud/server/pull/2850/files`:

![image](https://cloud.githubusercontent.com/assets/253202/21554043/58b78700-cdda-11e6-82a7-4471babcf189.png)

refs openstax/napkin-notes#68