### PR TITLE
add python3 as a dependency

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,2 +1,3 @@
+brew "python3"
 brew "rbenv"
 brew "lcov"


### PR DESCRIPTION
It seems that over the holidays something changed that ended up with this message when running `./scripts/setup` on OSX:

```
==> Installing Homebrew dependencies…
Error: No such file or directory - /usr/local/Cellar/python3/3.6.0/Frameworks/Python.framework/Versions
```