### PR TITLE
shows the list of books when cli arg is invalid

### DIFF
--- a/scripts/bake-book
+++ b/scripts/bake-book
@@ -39,7 +39,12 @@ then
   if [[ ! 1 -eq "${foundConfig}" ]]
   then
     >&2 echo "ERROR: Could not find Book info for book named ${arg1}"
-    >&2 echo "check ./books.txt"
+    >&2 echo "Valid books are (from ./books.txt):"
+    for bookConfig in "${BOOK_CONFIGS[@]}"
+    do
+      read -r bookName rulesetName uuid _ <<< "${bookConfig}"
+      >&2 echo "${bookName}"
+    done
     exit 1
   fi
 fi

--- a/scripts/bake-book-remote
+++ b/scripts/bake-book-remote
@@ -15,16 +15,23 @@ set -e
 arg1=$1
 bookVersion=$2
 
+# Pull in the BOOK_CONFIGS
+source ./books.txt || exit 1
+
 # Check command line args
 
 if [ -z "${arg1}" ]
 then
   >&2 echo 'ERROR: Argument Missing. You must specify the name of the book as the 1st argument or --all for all books (see books.txt). For example: physics'
+  >&2 echo ''
+  >&2 echo "Valid books are (from ./books.txt):"
+  for bookConfig in "${BOOK_CONFIGS[@]}"
+  do
+    read -r bookName rulesetName uuid _ <<< "${bookConfig}"
+    >&2 echo "${bookName}"
+  done
   exit 1
 fi
-
-# Pull in the BOOK_CONFIGS
-source ./books.txt || exit 1
 
 if [[ "${arg1}" == "--all" ]]
 then
@@ -47,7 +54,12 @@ else
   if [[ ! 1 -eq "${foundConfig}" ]]
   then
     >&2 echo "ERROR: Could not find Book info for book named ${arg1}"
-    >&2 echo "check ./books.txt"
+    >&2 echo "Valid books are (from ./books.txt):"
+    for bookConfig in "${BOOK_CONFIGS[@]}"
+    do
+      read -r bookName rulesetName uuid _ <<< "${bookConfig}"
+      >&2 echo "${bookName}"
+    done
     exit 1
   fi
 fi

--- a/scripts/diff-book
+++ b/scripts/diff-book
@@ -4,6 +4,9 @@
 arg1=$1
 debugFlag=$2
 
+# Pull in the BOOK_CONFIGS
+source ./books.txt || exit 1
+
 # Check command line args
 
 if [[ -z "${arg1}" ]]
@@ -13,12 +16,17 @@ then
   >&2 echo ''
   >&2 echo 'This script bakes the book and then compares to the prepared book'
   >&2 echo '(done earlier, usually in another branch)'
+  >&2 echo ''
+  >&2 echo "Valid books are (from ./books.txt):"
+  for bookConfig in "${BOOK_CONFIGS[@]}"
+  do
+    read -r bookName rulesetName uuid _ <<< "${bookConfig}"
+    >&2 echo "${bookName}"
+  done
+
   exit 1
 fi
 
-
-# Pull in the BOOK_CONFIGS
-source ./books.txt || exit 1
 
 if [[ ! "${arg1}" == "--all" ]]
 then
@@ -38,7 +46,12 @@ then
   if [[ ! 1 -eq "${foundConfig}" ]]
   then
     >&2 echo "ERROR: Could not find Book info for book named ${arg1}"
-    >&2 echo "check ./books.txt"
+    >&2 echo "Valid books are (from ./books.txt):"
+    for bookConfig in "${BOOK_CONFIGS[@]}"
+    do
+      read -r bookName rulesetName uuid _ <<< "${bookConfig}"
+      >&2 echo "${bookName}"
+    done
     exit 1
   fi
 fi

--- a/scripts/diff-book-prepare
+++ b/scripts/diff-book-prepare
@@ -4,6 +4,9 @@
 arg1=$1
 debugFlag=$2
 
+# Pull in the BOOK_CONFIGS
+source ./books.txt || exit 1
+
 # Check command line args
 
 if [[ -z "${arg1}" ]]
@@ -13,12 +16,16 @@ then
   >&2 echo 'This script prepares the book to compare against.'
   >&2 echo 'Typically this step is done in the master branch'
   >&2 echo 'and then in another branch diff-book is called to see how the HTML changed.'
+  >&2 echo ''
+  >&2 echo "Valid books are (from ./books.txt):"
+  for bookConfig in "${BOOK_CONFIGS[@]}"
+  do
+    read -r bookName rulesetName uuid _ <<< "${bookConfig}"
+    >&2 echo "${bookName}"
+  done
   exit 1
 fi
 
-
-# Pull in the BOOK_CONFIGS
-source ./books.txt || exit 1
 
 if [[ ! "${arg1}" == "--all" ]]
 then
@@ -38,7 +45,12 @@ then
   if [[ ! 1 -eq "${foundConfig}" ]]
   then
     >&2 echo "ERROR: Could not find Book info for book named ${arg1}"
-    >&2 echo "check ./books.txt"
+    >&2 echo "Valid books are (from ./books.txt):"
+    for bookConfig in "${BOOK_CONFIGS[@]}"
+    do
+      read -r bookName rulesetName uuid _ <<< "${bookConfig}"
+      >&2 echo "${bookName}"
+    done
     exit 1
   fi
 fi

--- a/scripts/fetch-html
+++ b/scripts/fetch-html
@@ -5,17 +5,24 @@ set -e
 
 arg1=$1
 
+# Pull in the BOOK_CONFIGS
+source ./books.txt || exit 1
+
 
 # Check command line args
 
 if [ -z "${arg1}" ]
 then
   >&2 echo 'ERROR: Argument Missing. You must specify the name of the book as the 1st argument or --all for all books. For example: physics'
+  >&2 echo ''
+  >&2 echo "Valid books are (from ./books.txt):"
+  for bookConfig in "${BOOK_CONFIGS[@]}"
+  do
+    read -r bookName rulesetName uuid _ <<< "${bookConfig}"
+    >&2 echo "${bookName}"
+  done
   exit 1
 fi
-
-# Pull in the BOOK_CONFIGS
-source ./books.txt || exit 1
 
 if [ ! "${arg1}" == "--all" ]
 then
@@ -37,7 +44,12 @@ then
   if [[ ! 1 -eq "${foundConfig}" ]]
   then
     >&2 echo "ERROR: Could not find Book info for book named ${arg1}"
-    >&2 echo "check ./books.txt"
+    >&2 echo "Valid books are (from ./books.txt):"
+    for bookConfig in "${BOOK_CONFIGS[@]}"
+    do
+      read -r bookName rulesetName uuid _ <<< "${bookConfig}"
+      >&2 echo "${bookName}"
+    done
     exit 1
   fi
 fi


### PR DESCRIPTION
Example command and output:

```
$ ./scripts/fetch-html foo
ERROR: Could not find Book info for book named foo
Valid books are (from ./books.txt):
statistics
TEAhsstats
econ
macroecon
macroeconap
microecon
microeconap
TEAmacroeconap
TEAmicroeconap
physics
TEAapphysics
TEAapphysics2
TEAhsphysics
biology
```