### PR TITLE
Final tea.cnx.org UUID for books from CTE

### DIFF
--- a/books.txt
+++ b/books.txt
@@ -10,14 +10,14 @@
 
 BOOK_CONFIGS=(
   "statistics         statistics        30189442-6998-4686-ac05-ed152b91b9de    tea.cnx.org          mixins/"
-  "TEAhsstats         statistics        ace2ec2d-778e-44aa-82c2-57a4e5c3de69    cte-cnx-dev.cnx.org  mixins/"
+  "TEAhsstats         statistics        bed1f9d3-7472-4640-9947-7b87d81303ab    tea.cnx.org          mixins/"
   "econ               economics         69619d2b-68f0-44b0-b074-a9b2bf90b2c6    tea.cnx.org          mixins/"
   "macroecon          economics         4061c832-098e-4b3c-a1d9-7eb593a2cb31    tea.cnx.org          mixins/"
   "macroeconap        economics         33076054-ec1d-4417-8824-ce354efe42d0    tea.cnx.org          mixins/"
   "microecon          economics         ea2f225e-6063-41ca-bcd8-36482e15ef65    tea.cnx.org          mixins/"
   "microeconap        economics         ca344e2d-6731-43cd-b851-a7b3aa0b37aa    tea.cnx.org          mixins/"
-  "TEAmacroeconap     economics         3353a691-0c52-4691-8f36-65490cd3d962    cte-cnx-dev.cnx.org  mixins/"
-  "TEAmicroeconap     economics         7f6fbc5b-6f3b-40a8-87ac-b14adc941e5e    cte-cnx-dev.cnx.org  mixins/"
+  "TEAmacroeconap     economics         e6bb2235-8b3e-4708-b101-55119bf9a9c8    tea.cnx.org          mixins/"
+  "TEAmicroeconap     economics         2b14408b-4da7-4a3d-9f13-5a5d3dd50e7b    tea.cnx.org          mixins/"
   "physics            physics           031da8d3-b525-429c-80cf-6c8ed997733a    tea.cnx.org          mixins/"
   "TEAapphysics       ap-physics        21f9700a-d0ca-406d-9598-9af463d62c7c    tea.cnx.org          mixins/,books/physics/"
   "TEAapphysics2      ap-physics        4db6028f-8ca1-4a47-a1d3-9510baad7f9b    tea.cnx.org          mixins/,books/physics/"


### PR DESCRIPTION
TEAhsstats (col10009 on legacy-tea.cnx.org), TEAmacroeconap (col10007), TEAmicroeconap (col10008 ) have been moved from cte-dev to tea.cnx.org