### PR TITLE
:bug: fix the `.unnumberedtable` selector to be `table.unnumbered`

### DIFF
--- a/rulesets/mixins/_number.scss
+++ b/rulesets/mixins/_number.scss
@@ -151,7 +151,7 @@
           @include setCaptionsHelper($type, $defaultContainer, $hasCaption, $hasTitle);
         }
       }
-      .unnumbered#{$notAnExceptionSelector} {
+      #{$notAnExceptionSelector}.unnumbered {
         @include setCaptionsHelper($type, $defaultContainer, $hasCaption, $hasTitle);
       }
     }
@@ -177,7 +177,7 @@
           @include setCaptionsHelper($type, $defaultContainer, $hasCaption, $hasTitle);
         }
       }
-      .unnumbered#{$notAnExceptionSelector} {
+      #{$notAnExceptionSelector}.unnumbered {
         @include setCaptionsHelper($type, $defaultContainer, $hasCaption, $hasTitle);
       }
     }

--- a/rulesets/output/ap-physics.css
+++ b/rulesets/output/ap-physics.css
@@ -808,19 +808,19 @@ Usage Note: key: class of the containing span, value: text that will go inside s
   class: os-table;
   container: div;
   content: content() pending(bCaptionContainer); }
-:pass(5) [data-type="chapter"] > .unnumberedtable caption [data-type="title"],
-:pass(5) [data-type="chapter"] :not(table) > .unnumberedtable caption [data-type="title"] {
+:pass(5) [data-type="chapter"] > table.unnumbered caption [data-type="title"],
+:pass(5) [data-type="chapter"] :not(table) > table.unnumbered caption [data-type="title"] {
   container: span;
   class: "os-title";
   move-to: bCaption; }
-:pass(5) [data-type="chapter"] > .unnumberedtable::after,
-:pass(5) [data-type="chapter"] :not(table) > .unnumberedtable::after {
+:pass(5) [data-type="chapter"] > table.unnumbered::after,
+:pass(5) [data-type="chapter"] :not(table) > table.unnumbered::after {
   container: div;
   class: "os-caption-container";
   content: pending(bCaption);
   move-to: bCaptionContainer; }
-:pass(5) [data-type="chapter"] > .unnumberedtable::outside,
-:pass(5) [data-type="chapter"] :not(table) > .unnumberedtable::outside {
+:pass(5) [data-type="chapter"] > table.unnumbered::outside,
+:pass(5) [data-type="chapter"] :not(table) > table.unnumbered::outside {
   class: os-table;
   container: div;
   content: content() pending(bCaptionContainer); }
@@ -855,19 +855,19 @@ Usage Note: key: class of the containing span, value: text that will go inside s
   class: os-table;
   container: div;
   content: content() pending(bCaptionContainer); }
-:pass(5) .appendix > .unnumberedtable caption [data-type="title"],
-:pass(5) .appendix :not(table) > .unnumberedtable caption [data-type="title"] {
+:pass(5) .appendix > table.unnumbered caption [data-type="title"],
+:pass(5) .appendix :not(table) > table.unnumbered caption [data-type="title"] {
   container: span;
   class: "os-title";
   move-to: bCaption; }
-:pass(5) .appendix > .unnumberedtable::after,
-:pass(5) .appendix :not(table) > .unnumberedtable::after {
+:pass(5) .appendix > table.unnumbered::after,
+:pass(5) .appendix :not(table) > table.unnumbered::after {
   container: div;
   class: "os-caption-container";
   content: pending(bCaption);
   move-to: bCaptionContainer; }
-:pass(5) .appendix > .unnumberedtable::outside,
-:pass(5) .appendix :not(table) > .unnumberedtable::outside {
+:pass(5) .appendix > table.unnumbered::outside,
+:pass(5) .appendix :not(table) > table.unnumbered::outside {
   class: os-table;
   container: div;
   content: content() pending(bCaptionContainer); }
@@ -902,19 +902,19 @@ Usage Note: key: class of the containing span, value: text that will go inside s
   class: os-figure;
   container: div;
   content: content() pending(bCaptionContainer); }
-:pass(5) [data-type="chapter"] > .unnumberedfigure figcaption,
-:pass(5) [data-type="chapter"] :not(figure) > .unnumberedfigure figcaption {
+:pass(5) [data-type="chapter"] > figure.unnumbered figcaption,
+:pass(5) [data-type="chapter"] :not(figure) > figure.unnumbered figcaption {
   container: span;
   class: "os-caption";
   move-to: bCaption; }
-:pass(5) [data-type="chapter"] > .unnumberedfigure::after,
-:pass(5) [data-type="chapter"] :not(figure) > .unnumberedfigure::after {
+:pass(5) [data-type="chapter"] > figure.unnumbered::after,
+:pass(5) [data-type="chapter"] :not(figure) > figure.unnumbered::after {
   container: div;
   class: "os-caption-container";
   content: pending(bCaption);
   move-to: bCaptionContainer; }
-:pass(5) [data-type="chapter"] > .unnumberedfigure::outside,
-:pass(5) [data-type="chapter"] :not(figure) > .unnumberedfigure::outside {
+:pass(5) [data-type="chapter"] > figure.unnumbered::outside,
+:pass(5) [data-type="chapter"] :not(figure) > figure.unnumbered::outside {
   class: os-figure;
   container: div;
   content: content() pending(bCaptionContainer); }
@@ -949,19 +949,19 @@ Usage Note: key: class of the containing span, value: text that will go inside s
   class: os-figure;
   container: div;
   content: content() pending(bCaptionContainer); }
-:pass(5) .appendix > .unnumberedfigure figcaption,
-:pass(5) .appendix :not(figure) > .unnumberedfigure figcaption {
+:pass(5) .appendix > figure.unnumbered figcaption,
+:pass(5) .appendix :not(figure) > figure.unnumbered figcaption {
   container: span;
   class: "os-caption";
   move-to: bCaption; }
-:pass(5) .appendix > .unnumberedfigure::after,
-:pass(5) .appendix :not(figure) > .unnumberedfigure::after {
+:pass(5) .appendix > figure.unnumbered::after,
+:pass(5) .appendix :not(figure) > figure.unnumbered::after {
   container: div;
   class: "os-caption-container";
   content: pending(bCaption);
   move-to: bCaptionContainer; }
-:pass(5) .appendix > .unnumberedfigure::outside,
-:pass(5) .appendix :not(figure) > .unnumberedfigure::outside {
+:pass(5) .appendix > figure.unnumbered::outside,
+:pass(5) .appendix :not(figure) > figure.unnumbered::outside {
   class: os-figure;
   container: div;
   content: content() pending(bCaptionContainer); }

--- a/rulesets/output/biology.css
+++ b/rulesets/output/biology.css
@@ -873,24 +873,24 @@
   class: os-table;
   container: div;
   content: content() pending(bCaptionContainer); }
-:pass(5) [data-type="chapter"] > .unnumberedtable caption,
-:pass(5) [data-type="chapter"] :not(table) > .unnumberedtable caption {
+:pass(5) [data-type="chapter"] > table.unnumbered caption,
+:pass(5) [data-type="chapter"] :not(table) > table.unnumbered caption {
   container: span;
   class: "os-caption";
   move-to: bCaption; }
-:pass(5) [data-type="chapter"] > .unnumberedtable caption [data-type="title"],
-:pass(5) [data-type="chapter"] :not(table) > .unnumberedtable caption [data-type="title"] {
+:pass(5) [data-type="chapter"] > table.unnumbered caption [data-type="title"],
+:pass(5) [data-type="chapter"] :not(table) > table.unnumbered caption [data-type="title"] {
   container: span;
   class: "os-title";
   move-to: bCaption; }
-:pass(5) [data-type="chapter"] > .unnumberedtable::after,
-:pass(5) [data-type="chapter"] :not(table) > .unnumberedtable::after {
+:pass(5) [data-type="chapter"] > table.unnumbered::after,
+:pass(5) [data-type="chapter"] :not(table) > table.unnumbered::after {
   container: div;
   class: "os-caption-container";
   content: pending(bCaption);
   move-to: bCaptionContainer; }
-:pass(5) [data-type="chapter"] > .unnumberedtable::outside,
-:pass(5) [data-type="chapter"] :not(table) > .unnumberedtable::outside {
+:pass(5) [data-type="chapter"] > table.unnumbered::outside,
+:pass(5) [data-type="chapter"] :not(table) > table.unnumbered::outside {
   class: os-table;
   container: div;
   content: content() pending(bCaptionContainer); }
@@ -930,24 +930,24 @@
   class: os-table;
   container: div;
   content: content() pending(bCaptionContainer); }
-:pass(5) .appendix > .unnumberedtable caption,
-:pass(5) .appendix :not(table) > .unnumberedtable caption {
+:pass(5) .appendix > table.unnumbered caption,
+:pass(5) .appendix :not(table) > table.unnumbered caption {
   container: span;
   class: "os-caption";
   move-to: bCaption; }
-:pass(5) .appendix > .unnumberedtable caption [data-type="title"],
-:pass(5) .appendix :not(table) > .unnumberedtable caption [data-type="title"] {
+:pass(5) .appendix > table.unnumbered caption [data-type="title"],
+:pass(5) .appendix :not(table) > table.unnumbered caption [data-type="title"] {
   container: span;
   class: "os-title";
   move-to: bCaption; }
-:pass(5) .appendix > .unnumberedtable::after,
-:pass(5) .appendix :not(table) > .unnumberedtable::after {
+:pass(5) .appendix > table.unnumbered::after,
+:pass(5) .appendix :not(table) > table.unnumbered::after {
   container: div;
   class: "os-caption-container";
   content: pending(bCaption);
   move-to: bCaptionContainer; }
-:pass(5) .appendix > .unnumberedtable::outside,
-:pass(5) .appendix :not(table) > .unnumberedtable::outside {
+:pass(5) .appendix > table.unnumbered::outside,
+:pass(5) .appendix :not(table) > table.unnumbered::outside {
   class: os-table;
   container: div;
   content: content() pending(bCaptionContainer); }
@@ -987,24 +987,24 @@
   class: os-figure;
   container: div;
   content: content() pending(bCaptionContainer); }
-:pass(5) [data-type="chapter"] > .unnumberedfigure figcaption,
-:pass(5) [data-type="chapter"] :not(figure) > .unnumberedfigure figcaption {
+:pass(5) [data-type="chapter"] > figure.unnumbered figcaption,
+:pass(5) [data-type="chapter"] :not(figure) > figure.unnumbered figcaption {
   container: span;
   class: "os-caption";
   move-to: bCaption; }
-:pass(5) [data-type="chapter"] > .unnumberedfigure [data-type="title"],
-:pass(5) [data-type="chapter"] :not(figure) > .unnumberedfigure [data-type="title"] {
+:pass(5) [data-type="chapter"] > figure.unnumbered [data-type="title"],
+:pass(5) [data-type="chapter"] :not(figure) > figure.unnumbered [data-type="title"] {
   container: span;
   class: "os-title";
   move-to: bCaption; }
-:pass(5) [data-type="chapter"] > .unnumberedfigure::after,
-:pass(5) [data-type="chapter"] :not(figure) > .unnumberedfigure::after {
+:pass(5) [data-type="chapter"] > figure.unnumbered::after,
+:pass(5) [data-type="chapter"] :not(figure) > figure.unnumbered::after {
   container: div;
   class: "os-caption-container";
   content: pending(bCaption);
   move-to: bCaptionContainer; }
-:pass(5) [data-type="chapter"] > .unnumberedfigure::outside,
-:pass(5) [data-type="chapter"] :not(figure) > .unnumberedfigure::outside {
+:pass(5) [data-type="chapter"] > figure.unnumbered::outside,
+:pass(5) [data-type="chapter"] :not(figure) > figure.unnumbered::outside {
   class: os-figure;
   container: div;
   content: content() pending(bCaptionContainer); }
@@ -1044,24 +1044,24 @@
   class: os-figure;
   container: div;
   content: content() pending(bCaptionContainer); }
-:pass(5) .appendix > .unnumberedfigure figcaption,
-:pass(5) .appendix :not(figure) > .unnumberedfigure figcaption {
+:pass(5) .appendix > figure.unnumbered figcaption,
+:pass(5) .appendix :not(figure) > figure.unnumbered figcaption {
   container: span;
   class: "os-caption";
   move-to: bCaption; }
-:pass(5) .appendix > .unnumberedfigure [data-type="title"],
-:pass(5) .appendix :not(figure) > .unnumberedfigure [data-type="title"] {
+:pass(5) .appendix > figure.unnumbered [data-type="title"],
+:pass(5) .appendix :not(figure) > figure.unnumbered [data-type="title"] {
   container: span;
   class: "os-title";
   move-to: bCaption; }
-:pass(5) .appendix > .unnumberedfigure::after,
-:pass(5) .appendix :not(figure) > .unnumberedfigure::after {
+:pass(5) .appendix > figure.unnumbered::after,
+:pass(5) .appendix :not(figure) > figure.unnumbered::after {
   container: div;
   class: "os-caption-container";
   content: pending(bCaption);
   move-to: bCaptionContainer; }
-:pass(5) .appendix > .unnumberedfigure::outside,
-:pass(5) .appendix :not(figure) > .unnumberedfigure::outside {
+:pass(5) .appendix > figure.unnumbered::outside,
+:pass(5) .appendix :not(figure) > figure.unnumbered::outside {
   class: os-figure;
   container: div;
   content: content() pending(bCaptionContainer); }

--- a/rulesets/output/economics.css
+++ b/rulesets/output/economics.css
@@ -933,24 +933,24 @@
   class: os-table;
   container: div;
   content: content() pending(bCaptionContainer); }
-:pass(5) [data-type="chapter"] > .unnumberedtable caption,
-:pass(5) [data-type="chapter"] :not(table) > .unnumberedtable caption {
+:pass(5) [data-type="chapter"] > table.unnumbered caption,
+:pass(5) [data-type="chapter"] :not(table) > table.unnumbered caption {
   container: span;
   class: "os-caption";
   move-to: bCaption; }
-:pass(5) [data-type="chapter"] > .unnumberedtable caption [data-type="title"],
-:pass(5) [data-type="chapter"] :not(table) > .unnumberedtable caption [data-type="title"] {
+:pass(5) [data-type="chapter"] > table.unnumbered caption [data-type="title"],
+:pass(5) [data-type="chapter"] :not(table) > table.unnumbered caption [data-type="title"] {
   container: span;
   class: "os-title";
   move-to: bCaption; }
-:pass(5) [data-type="chapter"] > .unnumberedtable::after,
-:pass(5) [data-type="chapter"] :not(table) > .unnumberedtable::after {
+:pass(5) [data-type="chapter"] > table.unnumbered::after,
+:pass(5) [data-type="chapter"] :not(table) > table.unnumbered::after {
   container: div;
   class: "os-caption-container";
   content: pending(bCaption);
   move-to: bCaptionContainer; }
-:pass(5) [data-type="chapter"] > .unnumberedtable::outside,
-:pass(5) [data-type="chapter"] :not(table) > .unnumberedtable::outside {
+:pass(5) [data-type="chapter"] > table.unnumbered::outside,
+:pass(5) [data-type="chapter"] :not(table) > table.unnumbered::outside {
   class: os-table;
   container: div;
   content: content() pending(bCaptionContainer); }
@@ -990,24 +990,24 @@
   class: os-table;
   container: div;
   content: content() pending(bCaptionContainer); }
-:pass(5) .appendix > .unnumberedtable caption,
-:pass(5) .appendix :not(table) > .unnumberedtable caption {
+:pass(5) .appendix > table.unnumbered caption,
+:pass(5) .appendix :not(table) > table.unnumbered caption {
   container: span;
   class: "os-caption";
   move-to: bCaption; }
-:pass(5) .appendix > .unnumberedtable caption [data-type="title"],
-:pass(5) .appendix :not(table) > .unnumberedtable caption [data-type="title"] {
+:pass(5) .appendix > table.unnumbered caption [data-type="title"],
+:pass(5) .appendix :not(table) > table.unnumbered caption [data-type="title"] {
   container: span;
   class: "os-title";
   move-to: bCaption; }
-:pass(5) .appendix > .unnumberedtable::after,
-:pass(5) .appendix :not(table) > .unnumberedtable::after {
+:pass(5) .appendix > table.unnumbered::after,
+:pass(5) .appendix :not(table) > table.unnumbered::after {
   container: div;
   class: "os-caption-container";
   content: pending(bCaption);
   move-to: bCaptionContainer; }
-:pass(5) .appendix > .unnumberedtable::outside,
-:pass(5) .appendix :not(table) > .unnumberedtable::outside {
+:pass(5) .appendix > table.unnumbered::outside,
+:pass(5) .appendix :not(table) > table.unnumbered::outside {
   class: os-table;
   container: div;
   content: content() pending(bCaptionContainer); }
@@ -1047,24 +1047,24 @@
   class: os-figure;
   container: div;
   content: content() pending(bCaptionContainer); }
-:pass(5) [data-type="chapter"] > .unnumberedfigure figcaption,
-:pass(5) [data-type="chapter"] :not(figure) > .unnumberedfigure figcaption {
+:pass(5) [data-type="chapter"] > figure.unnumbered figcaption,
+:pass(5) [data-type="chapter"] :not(figure) > figure.unnumbered figcaption {
   container: span;
   class: "os-caption";
   move-to: bCaption; }
-:pass(5) [data-type="chapter"] > .unnumberedfigure [data-type="title"],
-:pass(5) [data-type="chapter"] :not(figure) > .unnumberedfigure [data-type="title"] {
+:pass(5) [data-type="chapter"] > figure.unnumbered [data-type="title"],
+:pass(5) [data-type="chapter"] :not(figure) > figure.unnumbered [data-type="title"] {
   container: span;
   class: "os-title";
   move-to: bCaption; }
-:pass(5) [data-type="chapter"] > .unnumberedfigure::after,
-:pass(5) [data-type="chapter"] :not(figure) > .unnumberedfigure::after {
+:pass(5) [data-type="chapter"] > figure.unnumbered::after,
+:pass(5) [data-type="chapter"] :not(figure) > figure.unnumbered::after {
   container: div;
   class: "os-caption-container";
   content: pending(bCaption);
   move-to: bCaptionContainer; }
-:pass(5) [data-type="chapter"] > .unnumberedfigure::outside,
-:pass(5) [data-type="chapter"] :not(figure) > .unnumberedfigure::outside {
+:pass(5) [data-type="chapter"] > figure.unnumbered::outside,
+:pass(5) [data-type="chapter"] :not(figure) > figure.unnumbered::outside {
   class: os-figure;
   container: div;
   content: content() pending(bCaptionContainer); }
@@ -1104,24 +1104,24 @@
   class: os-figure;
   container: div;
   content: content() pending(bCaptionContainer); }
-:pass(5) .appendix > .unnumberedfigure figcaption,
-:pass(5) .appendix :not(figure) > .unnumberedfigure figcaption {
+:pass(5) .appendix > figure.unnumbered figcaption,
+:pass(5) .appendix :not(figure) > figure.unnumbered figcaption {
   container: span;
   class: "os-caption";
   move-to: bCaption; }
-:pass(5) .appendix > .unnumberedfigure [data-type="title"],
-:pass(5) .appendix :not(figure) > .unnumberedfigure [data-type="title"] {
+:pass(5) .appendix > figure.unnumbered [data-type="title"],
+:pass(5) .appendix :not(figure) > figure.unnumbered [data-type="title"] {
   container: span;
   class: "os-title";
   move-to: bCaption; }
-:pass(5) .appendix > .unnumberedfigure::after,
-:pass(5) .appendix :not(figure) > .unnumberedfigure::after {
+:pass(5) .appendix > figure.unnumbered::after,
+:pass(5) .appendix :not(figure) > figure.unnumbered::after {
   container: div;
   class: "os-caption-container";
   content: pending(bCaption);
   move-to: bCaptionContainer; }
-:pass(5) .appendix > .unnumberedfigure::outside,
-:pass(5) .appendix :not(figure) > .unnumberedfigure::outside {
+:pass(5) .appendix > figure.unnumbered::outside,
+:pass(5) .appendix :not(figure) > figure.unnumbered::outside {
   class: os-figure;
   container: div;
   content: content() pending(bCaptionContainer); }

--- a/rulesets/output/hs-physics.css
+++ b/rulesets/output/hs-physics.css
@@ -1205,24 +1205,24 @@
   class: os-table;
   container: div;
   content: content() pending(bCaptionContainer); }
-:pass(5) [data-type="chapter"] > .unnumberedtable:not(.key-terms) caption,
-:pass(5) [data-type="chapter"] :not(table) > .unnumberedtable:not(.key-terms) caption {
+:pass(5) [data-type="chapter"] > table:not(.key-terms).unnumbered caption,
+:pass(5) [data-type="chapter"] :not(table) > table:not(.key-terms).unnumbered caption {
   container: span;
   class: "os-caption";
   move-to: bCaption; }
-:pass(5) [data-type="chapter"] > .unnumberedtable:not(.key-terms) caption [data-type="title"],
-:pass(5) [data-type="chapter"] :not(table) > .unnumberedtable:not(.key-terms) caption [data-type="title"] {
+:pass(5) [data-type="chapter"] > table:not(.key-terms).unnumbered caption [data-type="title"],
+:pass(5) [data-type="chapter"] :not(table) > table:not(.key-terms).unnumbered caption [data-type="title"] {
   container: span;
   class: "os-title";
   move-to: bCaption; }
-:pass(5) [data-type="chapter"] > .unnumberedtable:not(.key-terms)::after,
-:pass(5) [data-type="chapter"] :not(table) > .unnumberedtable:not(.key-terms)::after {
+:pass(5) [data-type="chapter"] > table:not(.key-terms).unnumbered::after,
+:pass(5) [data-type="chapter"] :not(table) > table:not(.key-terms).unnumbered::after {
   container: div;
   class: "os-caption-container";
   content: pending(bCaption);
   move-to: bCaptionContainer; }
-:pass(5) [data-type="chapter"] > .unnumberedtable:not(.key-terms)::outside,
-:pass(5) [data-type="chapter"] :not(table) > .unnumberedtable:not(.key-terms)::outside {
+:pass(5) [data-type="chapter"] > table:not(.key-terms).unnumbered::outside,
+:pass(5) [data-type="chapter"] :not(table) > table:not(.key-terms).unnumbered::outside {
   class: os-table;
   container: div;
   content: content() pending(bCaptionContainer); }
@@ -1283,24 +1283,24 @@
   class: os-table;
   container: div;
   content: content() pending(bCaptionContainer); }
-:pass(5) .appendix > .unnumberedtable:not(.key-terms) caption,
-:pass(5) .appendix :not(table) > .unnumberedtable:not(.key-terms) caption {
+:pass(5) .appendix > table:not(.key-terms).unnumbered caption,
+:pass(5) .appendix :not(table) > table:not(.key-terms).unnumbered caption {
   container: span;
   class: "os-caption";
   move-to: bCaption; }
-:pass(5) .appendix > .unnumberedtable:not(.key-terms) caption [data-type="title"],
-:pass(5) .appendix :not(table) > .unnumberedtable:not(.key-terms) caption [data-type="title"] {
+:pass(5) .appendix > table:not(.key-terms).unnumbered caption [data-type="title"],
+:pass(5) .appendix :not(table) > table:not(.key-terms).unnumbered caption [data-type="title"] {
   container: span;
   class: "os-title";
   move-to: bCaption; }
-:pass(5) .appendix > .unnumberedtable:not(.key-terms)::after,
-:pass(5) .appendix :not(table) > .unnumberedtable:not(.key-terms)::after {
+:pass(5) .appendix > table:not(.key-terms).unnumbered::after,
+:pass(5) .appendix :not(table) > table:not(.key-terms).unnumbered::after {
   container: div;
   class: "os-caption-container";
   content: pending(bCaption);
   move-to: bCaptionContainer; }
-:pass(5) .appendix > .unnumberedtable:not(.key-terms)::outside,
-:pass(5) .appendix :not(table) > .unnumberedtable:not(.key-terms)::outside {
+:pass(5) .appendix > table:not(.key-terms).unnumbered::outside,
+:pass(5) .appendix :not(table) > table:not(.key-terms).unnumbered::outside {
   class: os-table;
   container: div;
   content: content() pending(bCaptionContainer); }
@@ -1340,24 +1340,24 @@
   class: os-figure;
   container: div;
   content: content() pending(bCaptionContainer); }
-:pass(5) [data-type="chapter"] > .unnumberedfigure figcaption,
-:pass(5) [data-type="chapter"] :not(figure) > .unnumberedfigure figcaption {
+:pass(5) [data-type="chapter"] > figure.unnumbered figcaption,
+:pass(5) [data-type="chapter"] :not(figure) > figure.unnumbered figcaption {
   container: span;
   class: "os-caption";
   move-to: bCaption; }
-:pass(5) [data-type="chapter"] > .unnumberedfigure [data-type="title"],
-:pass(5) [data-type="chapter"] :not(figure) > .unnumberedfigure [data-type="title"] {
+:pass(5) [data-type="chapter"] > figure.unnumbered [data-type="title"],
+:pass(5) [data-type="chapter"] :not(figure) > figure.unnumbered [data-type="title"] {
   container: span;
   class: "os-title";
   move-to: bCaption; }
-:pass(5) [data-type="chapter"] > .unnumberedfigure::after,
-:pass(5) [data-type="chapter"] :not(figure) > .unnumberedfigure::after {
+:pass(5) [data-type="chapter"] > figure.unnumbered::after,
+:pass(5) [data-type="chapter"] :not(figure) > figure.unnumbered::after {
   container: div;
   class: "os-caption-container";
   content: pending(bCaption);
   move-to: bCaptionContainer; }
-:pass(5) [data-type="chapter"] > .unnumberedfigure::outside,
-:pass(5) [data-type="chapter"] :not(figure) > .unnumberedfigure::outside {
+:pass(5) [data-type="chapter"] > figure.unnumbered::outside,
+:pass(5) [data-type="chapter"] :not(figure) > figure.unnumbered::outside {
   class: os-figure;
   container: div;
   content: content() pending(bCaptionContainer); }
@@ -1397,24 +1397,24 @@
   class: os-figure;
   container: div;
   content: content() pending(bCaptionContainer); }
-:pass(5) .appendix > .unnumberedfigure figcaption,
-:pass(5) .appendix :not(figure) > .unnumberedfigure figcaption {
+:pass(5) .appendix > figure.unnumbered figcaption,
+:pass(5) .appendix :not(figure) > figure.unnumbered figcaption {
   container: span;
   class: "os-caption";
   move-to: bCaption; }
-:pass(5) .appendix > .unnumberedfigure [data-type="title"],
-:pass(5) .appendix :not(figure) > .unnumberedfigure [data-type="title"] {
+:pass(5) .appendix > figure.unnumbered [data-type="title"],
+:pass(5) .appendix :not(figure) > figure.unnumbered [data-type="title"] {
   container: span;
   class: "os-title";
   move-to: bCaption; }
-:pass(5) .appendix > .unnumberedfigure::after,
-:pass(5) .appendix :not(figure) > .unnumberedfigure::after {
+:pass(5) .appendix > figure.unnumbered::after,
+:pass(5) .appendix :not(figure) > figure.unnumbered::after {
   container: div;
   class: "os-caption-container";
   content: pending(bCaption);
   move-to: bCaptionContainer; }
-:pass(5) .appendix > .unnumberedfigure::outside,
-:pass(5) .appendix :not(figure) > .unnumberedfigure::outside {
+:pass(5) .appendix > figure.unnumbered::outside,
+:pass(5) .appendix :not(figure) > figure.unnumbered::outside {
   class: os-figure;
   container: div;
   content: content() pending(bCaptionContainer); }

--- a/rulesets/output/physics.css
+++ b/rulesets/output/physics.css
@@ -714,19 +714,19 @@
   class: os-table;
   container: div;
   content: content() pending(bCaptionContainer); }
-:pass(5) [data-type="chapter"] > .unnumberedtable caption [data-type="title"],
-:pass(5) [data-type="chapter"] :not(table) > .unnumberedtable caption [data-type="title"] {
+:pass(5) [data-type="chapter"] > table.unnumbered caption [data-type="title"],
+:pass(5) [data-type="chapter"] :not(table) > table.unnumbered caption [data-type="title"] {
   container: span;
   class: "os-title";
   move-to: bCaption; }
-:pass(5) [data-type="chapter"] > .unnumberedtable::after,
-:pass(5) [data-type="chapter"] :not(table) > .unnumberedtable::after {
+:pass(5) [data-type="chapter"] > table.unnumbered::after,
+:pass(5) [data-type="chapter"] :not(table) > table.unnumbered::after {
   container: div;
   class: "os-caption-container";
   content: pending(bCaption);
   move-to: bCaptionContainer; }
-:pass(5) [data-type="chapter"] > .unnumberedtable::outside,
-:pass(5) [data-type="chapter"] :not(table) > .unnumberedtable::outside {
+:pass(5) [data-type="chapter"] > table.unnumbered::outside,
+:pass(5) [data-type="chapter"] :not(table) > table.unnumbered::outside {
   class: os-table;
   container: div;
   content: content() pending(bCaptionContainer); }
@@ -761,19 +761,19 @@
   class: os-table;
   container: div;
   content: content() pending(bCaptionContainer); }
-:pass(5) .appendix > .unnumberedtable caption [data-type="title"],
-:pass(5) .appendix :not(table) > .unnumberedtable caption [data-type="title"] {
+:pass(5) .appendix > table.unnumbered caption [data-type="title"],
+:pass(5) .appendix :not(table) > table.unnumbered caption [data-type="title"] {
   container: span;
   class: "os-title";
   move-to: bCaption; }
-:pass(5) .appendix > .unnumberedtable::after,
-:pass(5) .appendix :not(table) > .unnumberedtable::after {
+:pass(5) .appendix > table.unnumbered::after,
+:pass(5) .appendix :not(table) > table.unnumbered::after {
   container: div;
   class: "os-caption-container";
   content: pending(bCaption);
   move-to: bCaptionContainer; }
-:pass(5) .appendix > .unnumberedtable::outside,
-:pass(5) .appendix :not(table) > .unnumberedtable::outside {
+:pass(5) .appendix > table.unnumbered::outside,
+:pass(5) .appendix :not(table) > table.unnumbered::outside {
   class: os-table;
   container: div;
   content: content() pending(bCaptionContainer); }
@@ -808,19 +808,19 @@
   class: os-figure;
   container: div;
   content: content() pending(bCaptionContainer); }
-:pass(5) [data-type="chapter"] > .unnumberedfigure figcaption,
-:pass(5) [data-type="chapter"] :not(figure) > .unnumberedfigure figcaption {
+:pass(5) [data-type="chapter"] > figure.unnumbered figcaption,
+:pass(5) [data-type="chapter"] :not(figure) > figure.unnumbered figcaption {
   container: span;
   class: "os-caption";
   move-to: bCaption; }
-:pass(5) [data-type="chapter"] > .unnumberedfigure::after,
-:pass(5) [data-type="chapter"] :not(figure) > .unnumberedfigure::after {
+:pass(5) [data-type="chapter"] > figure.unnumbered::after,
+:pass(5) [data-type="chapter"] :not(figure) > figure.unnumbered::after {
   container: div;
   class: "os-caption-container";
   content: pending(bCaption);
   move-to: bCaptionContainer; }
-:pass(5) [data-type="chapter"] > .unnumberedfigure::outside,
-:pass(5) [data-type="chapter"] :not(figure) > .unnumberedfigure::outside {
+:pass(5) [data-type="chapter"] > figure.unnumbered::outside,
+:pass(5) [data-type="chapter"] :not(figure) > figure.unnumbered::outside {
   class: os-figure;
   container: div;
   content: content() pending(bCaptionContainer); }
@@ -855,19 +855,19 @@
   class: os-figure;
   container: div;
   content: content() pending(bCaptionContainer); }
-:pass(5) .appendix > .unnumberedfigure figcaption,
-:pass(5) .appendix :not(figure) > .unnumberedfigure figcaption {
+:pass(5) .appendix > figure.unnumbered figcaption,
+:pass(5) .appendix :not(figure) > figure.unnumbered figcaption {
   container: span;
   class: "os-caption";
   move-to: bCaption; }
-:pass(5) .appendix > .unnumberedfigure::after,
-:pass(5) .appendix :not(figure) > .unnumberedfigure::after {
+:pass(5) .appendix > figure.unnumbered::after,
+:pass(5) .appendix :not(figure) > figure.unnumbered::after {
   container: div;
   class: "os-caption-container";
   content: pending(bCaption);
   move-to: bCaptionContainer; }
-:pass(5) .appendix > .unnumberedfigure::outside,
-:pass(5) .appendix :not(figure) > .unnumberedfigure::outside {
+:pass(5) .appendix > figure.unnumbered::outside,
+:pass(5) .appendix :not(figure) > figure.unnumbered::outside {
   class: os-figure;
   container: div;
   content: content() pending(bCaptionContainer); }

--- a/rulesets/output/statistics.css
+++ b/rulesets/output/statistics.css
@@ -851,19 +851,19 @@
   class: os-table;
   container: div;
   content: content() pending(bCaptionContainer); }
-:pass(5) [data-type="chapter"] > .unnumberedtable caption [data-type="title"],
-:pass(5) [data-type="chapter"] :not(table) > .unnumberedtable caption [data-type="title"] {
+:pass(5) [data-type="chapter"] > table.unnumbered caption [data-type="title"],
+:pass(5) [data-type="chapter"] :not(table) > table.unnumbered caption [data-type="title"] {
   container: span;
   class: "os-title";
   move-to: bCaption; }
-:pass(5) [data-type="chapter"] > .unnumberedtable::after,
-:pass(5) [data-type="chapter"] :not(table) > .unnumberedtable::after {
+:pass(5) [data-type="chapter"] > table.unnumbered::after,
+:pass(5) [data-type="chapter"] :not(table) > table.unnumbered::after {
   container: div;
   class: "os-caption-container";
   content: pending(bCaption);
   move-to: bCaptionContainer; }
-:pass(5) [data-type="chapter"] > .unnumberedtable::outside,
-:pass(5) [data-type="chapter"] :not(table) > .unnumberedtable::outside {
+:pass(5) [data-type="chapter"] > table.unnumbered::outside,
+:pass(5) [data-type="chapter"] :not(table) > table.unnumbered::outside {
   class: os-table;
   container: div;
   content: content() pending(bCaptionContainer); }
@@ -898,19 +898,19 @@
   class: os-table;
   container: div;
   content: content() pending(bCaptionContainer); }
-:pass(5) .appendix > .unnumberedtable caption [data-type="title"],
-:pass(5) .appendix :not(table) > .unnumberedtable caption [data-type="title"] {
+:pass(5) .appendix > table.unnumbered caption [data-type="title"],
+:pass(5) .appendix :not(table) > table.unnumbered caption [data-type="title"] {
   container: span;
   class: "os-title";
   move-to: bCaption; }
-:pass(5) .appendix > .unnumberedtable::after,
-:pass(5) .appendix :not(table) > .unnumberedtable::after {
+:pass(5) .appendix > table.unnumbered::after,
+:pass(5) .appendix :not(table) > table.unnumbered::after {
   container: div;
   class: "os-caption-container";
   content: pending(bCaption);
   move-to: bCaptionContainer; }
-:pass(5) .appendix > .unnumberedtable::outside,
-:pass(5) .appendix :not(table) > .unnumberedtable::outside {
+:pass(5) .appendix > table.unnumbered::outside,
+:pass(5) .appendix :not(table) > table.unnumbered::outside {
   class: os-table;
   container: div;
   content: content() pending(bCaptionContainer); }
@@ -945,19 +945,19 @@
   class: os-figure;
   container: div;
   content: content() pending(bCaptionContainer); }
-:pass(5) [data-type="chapter"] > .unnumberedfigure figcaption,
-:pass(5) [data-type="chapter"] :not(figure) > .unnumberedfigure figcaption {
+:pass(5) [data-type="chapter"] > figure.unnumbered figcaption,
+:pass(5) [data-type="chapter"] :not(figure) > figure.unnumbered figcaption {
   container: span;
   class: "os-caption";
   move-to: bCaption; }
-:pass(5) [data-type="chapter"] > .unnumberedfigure::after,
-:pass(5) [data-type="chapter"] :not(figure) > .unnumberedfigure::after {
+:pass(5) [data-type="chapter"] > figure.unnumbered::after,
+:pass(5) [data-type="chapter"] :not(figure) > figure.unnumbered::after {
   container: div;
   class: "os-caption-container";
   content: pending(bCaption);
   move-to: bCaptionContainer; }
-:pass(5) [data-type="chapter"] > .unnumberedfigure::outside,
-:pass(5) [data-type="chapter"] :not(figure) > .unnumberedfigure::outside {
+:pass(5) [data-type="chapter"] > figure.unnumbered::outside,
+:pass(5) [data-type="chapter"] :not(figure) > figure.unnumbered::outside {
   class: os-figure;
   container: div;
   content: content() pending(bCaptionContainer); }
@@ -992,19 +992,19 @@
   class: os-figure;
   container: div;
   content: content() pending(bCaptionContainer); }
-:pass(5) .appendix > .unnumberedfigure figcaption,
-:pass(5) .appendix :not(figure) > .unnumberedfigure figcaption {
+:pass(5) .appendix > figure.unnumbered figcaption,
+:pass(5) .appendix :not(figure) > figure.unnumbered figcaption {
   container: span;
   class: "os-caption";
   move-to: bCaption; }
-:pass(5) .appendix > .unnumberedfigure::after,
-:pass(5) .appendix :not(figure) > .unnumberedfigure::after {
+:pass(5) .appendix > figure.unnumbered::after,
+:pass(5) .appendix :not(figure) > figure.unnumbered::after {
   container: div;
   class: "os-caption-container";
   content: pending(bCaption);
   move-to: bCaptionContainer; }
-:pass(5) .appendix > .unnumberedfigure::outside,
-:pass(5) .appendix :not(figure) > .unnumberedfigure::outside {
+:pass(5) .appendix > figure.unnumbered::outside,
+:pass(5) .appendix :not(figure) > figure.unnumbered::outside {
   class: os-figure;
   container: div;
   content: content() pending(bCaptionContainer); }


### PR DESCRIPTION
The CSS contained selectors containing `... > .unnumberedtable > ...` which was never being matched. This changes the selectors to be `... > table.unnumbered > ...`

It causes easybake to crash so I am looking into that.