### PR TITLE
adds support for diffing styleguides

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,13 @@ diff ./data/statistics-prepared.html ./data/statistics-baked.html > foo.diff
 
 **Note:** You can specify `--all` instead of `statistics` to diff all the books (after fetching them earlier)
 
+### Finding differences in the styleguide
+
+Instead of diffing the whole book, you can find differences in the styleguide for a ruleset (faster and easier to find errors because the HTML files are much smaller than an entire book).
+
+To do this, just replace every occurrence of `./scripts/diff-book ${BOOK_NAME}` (and `./scripts/diff-book-prepare`) with `diff-guide ${RULESET_NAME}`.
+
+
 ## Experimental
 
 To update the Documentation in the gh-pages branch:

--- a/scripts/diff-guide
+++ b/scripts/diff-guide
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+
+arg1=$1
+debugFlag=$2
+
+# Pull in the BOOK_CONFIGS
+source ./books.txt || exit 1
+
+# Check command line args
+
+./scripts/diff-guide-prepare "${arg1}" "baked"
+
+
+if [[ ! "${arg1}" == "--all" ]]
+then
+  # Filter BOOK_CONFIGS to only contain the book you want to fetch
+  for rulesetName in "${RULESET_NAMES[@]}"
+  do
+
+    if [[ "${arg1}" = "${rulesetName}" ]]
+    then
+      RULESET_NAMES=("${rulesetName}")
+      foundConfig=1
+      break
+    fi
+  done
+
+  if [[ ! 1 -eq "${foundConfig}" ]]
+  then
+    >&2 echo "ERROR: Could not find Book info for ruleset named ${arg1}"
+    >&2 echo "Valid books are (from ./books.txt):"
+    for rulesetName in "${RULESET_NAMES[@]}"
+    do
+      >&2 echo "${rulesetName}"
+    done
+    exit 1
+  fi
+fi
+
+diffFound=0
+for rulesetName in "${RULESET_NAMES[@]}"
+do
+
+  >&2 echo "==> Checking for differences in '${rulesetName}'"
+
+  for bakedFile in $(find ./tmp/${rulesetName} -name "*-baked.html")
+  do
+
+    preparedFile="${bakedFile/-baked/-prepared}"
+    if [[ -s "${preparedFile}" ]]
+    then
+
+      diffCount=$(diff ${preparedFile} ${bakedFile} | wc -l)
+
+      if [[ 0 -ne "${diffCount}" ]]
+      then
+        >&2 echo "ERROR: There were ${diffCount} differences found. To see all of them run the following:"
+        >&2 echo "diff ${preparedFile} ${bakedFile}"
+        diffFound=1
+      fi
+
+    else
+      >&2 echo "FAILING ${rulesetName} because the prepared file '${preparedFile}' was not found."
+      >&2 echo "Did you run './scripts/diff-guide-prepare ${rulesetName}' earlier?"
+      exit 1
+    fi
+
+  done
+done
+
+if [[ ! "${diffFound}" -eq "0" ]]
+then
+  >&2 echo "ERROR: There were differences found so failing"
+  exit 1
+fi

--- a/scripts/diff-guide-prepare
+++ b/scripts/diff-guide-prepare
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+
+arg1=$1
+bakedOrPreparedSuffix=$2
+
+# Pull in the BOOK_CONFIGS
+source ./books.txt || exit 1
+
+# Check command line args
+
+if [[ -z "${arg1}" ]]
+then
+  >&2 echo 'ERROR: Argument Missing. You must specify the name of the ruleset as the 1st argument'
+  >&2 echo ' or --all for all rulesets.'
+  >&2 echo 'This script prepares the guide to compare against.'
+  >&2 echo 'Typically this step is done in the master branch'
+  >&2 echo 'and then in another branch diff-guide is called to see how the HTML changed.'
+  >&2 echo ''
+  >&2 echo "Valid rulesets are (from ./books.txt):"
+  for rulesetName in "${RULESET_NAMES[@]}"
+  do
+    >&2 echo "${rulesetName}"
+  done
+  exit 1
+fi
+
+if [[ -z "${bakedOrPreparedSuffix}" ]]
+then
+  bakedOrPreparedSuffix="prepared"
+fi
+
+
+if [[ ! "${arg1}" == "--all" ]]
+then
+  # Filter BOOK_CONFIGS to only contain the book you want to fetch
+  for rulesetName in "${RULESET_NAMES[@]}"
+  do
+
+    if [[ "${arg1}" = "${rulesetName}" ]]
+    then
+      RULESET_NAMES=("${rulesetName}")
+      foundConfig=1
+      break
+    fi
+  done
+
+  if [[ ! 1 -eq "${foundConfig}" ]]
+  then
+    >&2 echo "ERROR: Could not find Book info for ruleset named ${arg1}"
+    >&2 echo "Valid books are (from ./books.txt):"
+    for rulesetName in "${RULESET_NAMES[@]}"
+    do
+      >&2 echo "${rulesetName}"
+    done
+    exit 1
+  fi
+fi
+
+for rulesetName in "${RULESET_NAMES[@]}"
+do
+  ./scripts/generate-guide "${rulesetName}" "${bakedOrPreparedSuffix}" || exit 1
+done

--- a/scripts/generate-guide
+++ b/scripts/generate-guide
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 rulesetName=$1
+bakedOrPreparedSuffix=$2 # Overridden when running ./diff-guide-prepare
 
 sassDir='./rulesets/'
 styleguideDir='./styleguide/'
@@ -20,6 +21,13 @@ if [ -z "${rulesetName}" ]
 then
   >&2 echo 'ERROR: Argument Missing. You must specify the name of the book as the 1st argument. For example: physics'
   exit 1
+fi
+
+if [ -z "${bakedOrPreparedSuffix}" ]
+then
+  bakedOrPreparedSuffix="baked"
+else
+  >&2 echo "INFO: Generating -${bakedOrPreparedSuffix}.html files instead of -baked.html files"
 fi
 
 # Initialize rbenv (if installed)
@@ -49,11 +57,14 @@ then
 #   rm -rf "${tempDir}" || exit 1
 fi
 
-if [[ -d "${tempRulesetDir}" ]]
+# Keep the tempRulesetDir around because it could have been created by diff-guide-prepare
+if [[ ! -d "${tempRulesetDir}" ]]
 then
-  rm -rf "${tempRulesetDir}" || exit 1
+  mkdir "${tempRulesetDir}" || exit 1
+# else
+#   # rm -rf "${tempRulesetDir}" || exit 1
 fi
-mkdir "${tempRulesetDir}" || exit 1
+
 
 # Copy over all the dirs containing the styleguide comments that need to be included
 
@@ -91,54 +102,69 @@ cp -R "${bookDocumentationDir}" "${tempRulesetDir}" || exit 1
 # Find all the styleguide html files and convert them
 for snippetFileName in $(find "${tempRulesetDir}" -name "*.html")
 do
-  >&2 echo "Generating temporary ${snippetFileName}-baked.html"
-  # commented because xmllint does not like html5 element names like <figure>
-  # ./scripts/bake-file ${rulesetName} ${snippetFileName} /dev/stdout | xmllint --html --format - > ${snippetFileName}-baked.html
-  ./scripts/bake-file ${rulesetName} ${snippetFileName} ${snippetFileName}-temp1-baked.html || exit 1
 
-  # Construct an HTML file that contains both the raw and baked HTML
-  # so it can be separated in the browser
-  # (and so Phil does not have to completely rewrite kss becuase it assumes only 1 file for markup)
-  echo '<section class="-kss-autogen-guide-markup" data-kss-format="html-raw">' > ${snippetFileName}-baked.html || exit 1
-  cat ${snippetFileName} >> ${snippetFileName}-baked.html || exit 1
-  echo '</section>' >> ${snippetFileName}-baked.html || exit 1
-  echo '<section class="-kss-autogen-guide-markup" data-kss-format="html-baked">' >> ${snippetFileName}-baked.html || exit 1
-  cat ${snippetFileName}-temp1-baked.html >> ${snippetFileName}-baked.html || exit 1
-  echo '</section>' >> ${snippetFileName}-baked.html || exit 1
+  if [[ ! "${snippetFileName}" =~ "-baked.html" ]]
+  then
+    if [[ ! "${snippetFileName}" =~ "-prepared.html" ]]
+    then
 
-  rm ${snippetFileName}-temp1-baked.html || exit 1
+      >&2 echo "Generating temporary ${snippetFileName}-${bakedOrPreparedSuffix}.html"
+      # commented because xmllint does not like html5 element names like <figure>
+      # ./scripts/bake-file ${rulesetName} ${snippetFileName} /dev/stdout | xmllint --html --format - > ${snippetFileName}-baked.html
+      ./scripts/bake-file ${rulesetName} ${snippetFileName} ${snippetFileName}-temp1-${bakedOrPreparedSuffix}.html --use-repeatable-ids  || exit 1
+
+      # Construct an HTML file that contains both the raw and baked HTML
+      # so it can be separated in the browser
+      # (and so Phil does not have to completely rewrite kss becuase it assumes only 1 file for markup)
+      echo '<section class="-kss-autogen-guide-markup" data-kss-format="html-raw">' > ${snippetFileName}-${bakedOrPreparedSuffix}.html || exit 1
+      cat ${snippetFileName} >> ${snippetFileName}-${bakedOrPreparedSuffix}.html || exit 1
+      echo '</section>' >> ${snippetFileName}-${bakedOrPreparedSuffix}.html || exit 1
+      echo '<section class="-kss-autogen-guide-markup" data-kss-format="html-baked">' >> ${snippetFileName}-${bakedOrPreparedSuffix}.html || exit 1
+      cat ${snippetFileName}-temp1-${bakedOrPreparedSuffix}.html >> ${snippetFileName}-${bakedOrPreparedSuffix}.html || exit 1
+      echo '</section>' >> ${snippetFileName}-${bakedOrPreparedSuffix}.html || exit 1
+
+      rm ${snippetFileName}-temp1-${bakedOrPreparedSuffix}.html || exit 1
+    fi
+  fi
 done
 
 
->&2 echo "==> Generating the style guide"
-# The CSS path is relative to the styleguide directory, hence `./guide.css`
-# Exclude parsing the output/*.css files by setting the --mask
-$(npm bin)/kss-node --template ./js/openstax-kss-builder --verbose --homepage ${guideHomepageFile} --destination ${styleguideDir} --css ./guide.css --source ${tempRulesetDir} --mask '*.less|*.sass|*.scss|*.styl|*.stylus' > "${kssOutputFile}"  || exit 1
-
-
-# Delete the temp files created above
-# >&2 echo "==> Deleting the baked example HTML files"
-# for snippetFileName in $(find ./rulesets/books/ -name "*-baked.html")
-# do
-#   # echo "Removing temporary ${snippetFileName}"
-#   rm ${snippetFileName} || exit 1
-# done
-
-# HACK: KSS-node does not error if an HTML file is missing. Instead, it prints out a warning.
-# So, check the output of kss to see if any errors were reported.
-missingFiles=$(cat "${kssOutputFile}" | grep 'NOT FOUND!' )
-if [ -n "${missingFiles}" ]
+if [[ "${bakedOrPreparedSuffix}" == "baked" ]]
 then
-  >&2 echo "ERROR: Some HTML files were missing:"
-  >&2 echo "${missingFiles}"
-  >&2 echo "Check ${kssOutputFile} for more details"
-  exit 1
-fi
 
-# Generate an HTML report (if genhtml is installed)
-if [[ -n "$(which genhtml)" ]]
-then
-  genhtml --quiet --output ./coverage/ $(find "${tempRulesetDir}" -name "*.lcov")
-fi
+  >&2 echo "==> Generating the style guide"
+  # The CSS path is relative to the styleguide directory, hence `./guide.css`
+  # Exclude parsing the output/*.css files by setting the --mask
+  $(npm bin)/kss-node --template ./js/openstax-kss-builder --verbose --homepage ${guideHomepageFile} --destination ${styleguideDir} --css ./guide.css --source ${tempRulesetDir} --mask '*.less|*.sass|*.scss|*.styl|*.stylus' > "${kssOutputFile}"  || exit 1
 
->&2 echo "Guide is available at ${styleguideDir} . You can open it in a browser"
+
+  # Delete the temp files created above
+  # >&2 echo "==> Deleting the baked example HTML files"
+  # for snippetFileName in $(find ./rulesets/books/ -name "*-${bakedOrPreparedSuffix}.html")
+  # do
+  #   # echo "Removing temporary ${snippetFileName}"
+  #   rm ${snippetFileName} || exit 1
+  # done
+
+  # HACK: KSS-node does not error if an HTML file is missing. Instead, it prints out a warning.
+  # So, check the output of kss to see if any errors were reported.
+  missingFiles=$(cat "${kssOutputFile}" | grep 'NOT FOUND!' )
+  if [ -n "${missingFiles}" ]
+  then
+    >&2 echo "ERROR: Some HTML files were missing:"
+    >&2 echo "${missingFiles}"
+    >&2 echo "Check ${kssOutputFile} for more details"
+    exit 1
+  fi
+
+  # Generate an HTML report (if genhtml is installed)
+  if [[ -n "$(which genhtml)" ]]
+  then
+    genhtml --quiet --output ./coverage/ $(find "${tempRulesetDir}" -name "*.lcov")
+  fi
+
+  >&2 echo "Guide is available at ${styleguideDir} . You can open it in a browser"
+
+else
+  >&2 echo "INFO: Skipping actual styleguide generation because the additional arg '${bakedOrPreparedSuffix}' was provided (probably for diff-guide-prepare)"
+fi


### PR DESCRIPTION
currently, you can check if the baked HTML of a book changed between master and a branch (by running `./scripts/diff-book-prepare ${BOOK_NAME}` in the `master` branch and then `./scripts/diff-book ${BOOK_NAME}` in the branch you are working on.

This adds the same feature for styleguides by running `./scripts/diff-guide-prepare ${RULESET_NAME}` and `./scripts/diff-guide ${RULESET_NAME}` respectively.

It was added because finding regressions in an entire book generates a lot of noise (since the same change could show up in many chapters) while finding regressions in the styleguide files are much easier (since they are small HTML "test" files)

# Example output

```
ERROR: There were       28 differences found. To see all of them run the following:
diff ./tmp/hs-physics/hs-physics/styleguide/book.composite.multiplechoice.html-prepared.html ./tmp/hs-physics/hs-physics/styleguide/book.composite.multiplechoice.html-baked.html
ERROR: There were       28 differences found. To see all of them run the following:
diff ./tmp/hs-physics/hs-physics/styleguide/book.composite.performance.html-prepared.html ./tmp/hs-physics/hs-physics/styleguide/book.composite.performance.html-baked.html
ERROR: There were       37 differences found. To see all of them run the following:
diff ./tmp/hs-physics/hs-physics/styleguide/book.composite.problems.html-prepared.html ./tmp/hs-physics/hs-physics/styleguide/book.composite.problems.html-baked.html
```