### PR TITLE
replace auto-ids with keys for consistent uuids

### DIFF
--- a/rulesets/books/ap-biology/book.scss
+++ b/rulesets/books/ap-biology/book.scss
@@ -99,7 +99,6 @@
 
 
   //After: createChapterComposites, createEOCSolutions, createBookComposites
-  @include modify_compositeAutoID();
   @include modify_chapterAutoID();
 
   @include count_countTables(table);

--- a/rulesets/books/ap-physics/book.scss
+++ b/rulesets/books/ap-physics/book.scss
@@ -113,7 +113,7 @@
   @include compose_titleEOBComposites($bookCompositePages);
 
   //After: createChapterComposites, createEOCSolutions, createBookComposites
-  @include modify_compositeAutoID();
+
   @include modify_chapterAutoID();
 
   @include count_countExercisesInContentButNotInExample(exerciseMaybeInContent);

--- a/rulesets/books/biology/book.scss
+++ b/rulesets/books/biology/book.scss
@@ -95,7 +95,7 @@
 
 
   //After: createChapterComposites, createEOCSolutions, createBookComposites
-  @include modify_compositeAutoID();
+
   @include modify_chapterAutoID();
 
   @include count_countExercisesInContentButNotInExample(exerciseMaybeInContent);

--- a/rulesets/books/economics/book.scss
+++ b/rulesets/books/economics/book.scss
@@ -93,7 +93,7 @@
 
 
   //After: createChapterComposites, createEOCSolutions, createBookComposites
-  @include modify_compositeAutoID();
+
   @include modify_chapterAutoID();
 
   @include count_countExercisesInContentButNotInExample(exerciseMaybeInContent);

--- a/rulesets/books/hs-physics/book.scss
+++ b/rulesets/books/hs-physics/book.scss
@@ -110,7 +110,7 @@
   @include compose_titleEOBComposites($bookCompositePages);
 
   //After: createChapterComposites, createEOCSolutions, createBookComposites
-  @include modify_compositeAutoID();
+
   @include modify_chapterAutoID();
 
   @include count_countExercisesInContentButNotInExample(exerciseMaybeInContent);

--- a/rulesets/books/physics/book.scss
+++ b/rulesets/books/physics/book.scss
@@ -98,7 +98,7 @@
   @include compose_titleEOBComposites($bookCompositePages);
 
   //After: createChapterComposites, createEOCSolutions, createBookComposites
-  @include modify_compositeAutoID();
+
   @include modify_chapterAutoID();
 
   @include count_countExercisesInContentButNotInExample(exerciseMaybeInContent);

--- a/rulesets/books/statistics/book.scss
+++ b/rulesets/books/statistics/book.scss
@@ -102,7 +102,6 @@
   @include compose_titleEOBComposites($bookCompositePages);
 
   //After: createChapterComposites, createEOCSolutions, createBookComposites
-  @include modify_compositeAutoID();
   @include modify_chapterAutoID();
 
   @include count_countExercisesInContentButNotInExample(exerciseMaybeInContent);

--- a/rulesets/mixins/_compose.scss
+++ b/rulesets/mixins/_compose.scss
@@ -78,6 +78,7 @@
     @if (not $compoundComposite) {
       $sectionSeparated: map-get($page, sectionSeparated);
       $isGlossary: map-get($page, isGlossary);
+      $keyName: if($isGlossary, '<glossary>', '.#{$source}');
       $sourceSelector: if($isGlossary, 'div[data-type="#{$source}"] dl', 'section.#{$source}');
       @if ($isGlossary) {
         div[data-type="#{$source}"] {
@@ -101,7 +102,7 @@
         content: pending(#{$source}-TOCOMPOSITE);
         class: "os-eoc os-#{$source}-container";
         data-type: "composite-page";
-        data-uuid-key: "#{$source}";
+        data-uuid-key: "#{$keyName}";
         @if ($sortBy != null) {
           sort-by: #{$sortBy}, nocase;
         }
@@ -191,12 +192,15 @@
     $name: map-get($compositePage, name);
     $source: map-get($compositePage, source);
     $allComposites: map-get($compositePage, contains);
+    $isGlossary: map-get($compositePage, isGlossary);
+    $keyName: if($isGlossary, '<glossary>', '.#{$source}');
+
     @include _processComposites($allComposites);
     [data-type="chapter"] {
       &::after {
         class: "os-eoc os-#{$source}-container";
         data-type: composite-page;
-        data-uuid-key: "#{$source}";
+        data-uuid-key: "#{$keyName}";
         content: pending(composite-DESTINATION);
 
       }
@@ -261,6 +265,8 @@
       $chapterSeparated: map-get($page, chapterSeparated);
       $sectionSeparated: map-get($page, sectionSeparated);
       $chapterPages: map-get($page, chapterPages);
+      $isGlossary: map-get($page, isGlossary);
+      $keyName: if($isGlossary, '<glossary>', '.#{$source}');
 
       // Validate
       @include validate_type($chapterSeparated, bool);
@@ -287,7 +293,7 @@
             content: pending(#{$source}-GETCHAPTER);
             @if ($chapterPages) {
               data-type: "composite-page";
-              data-uuid-key: "#{$source}";
+              data-uuid-key: "#{$keyName}";
             }
           }
         }
@@ -312,6 +318,7 @@
   body {
     $source: map-get($page, source);
     $isIndex: map-get($page, isIndex);
+    $keyName: if($isIndex, '<index>', '.#{$source}');
 
     // Validate
     @include validate_type($source, string);
@@ -322,7 +329,7 @@
       content: pending(#{$source}-TOCOMPOSITE);
       class: "os-eob os-#{$source}-container";
       data-type: "composite-page";
-      data-uuid-key: "#{$source}";
+      data-uuid-key: "#{$keyName}";
       @if ($isIndex) {
         group-by: span, "span::attr(group-by)", nocase;
       }
@@ -406,7 +413,7 @@
       content: pending(#{$solutionSource}-TOCOMPOSITE);
       class: "os-eoc os-#{$solutionSource}-container";
       data-type: "composite-page";
-      data-uuid-key: "chapter-solutions";  /* TODO: Is this the correct key? We'll be stuck with it because it is used for generating the collated page uuid's */
+      data-uuid-key: "solutions";
     }
   }
 }
@@ -508,7 +515,7 @@
       content: pending(#{$solutionSource}-TOCOMPOSITE);
       class: "os-eob os-#{$solutionSource}-container";
       data-type: "composite-page";
-      data-uuid-key: "#{$solutionSource}"; /* TODO: Is this the correct key? We'll be stuck with it because it is used for generating the collated page uuid's */
+      data-uuid-key: ".#{$solutionSource}"; /* TODO: Is this the correct key? We'll be stuck with it because it is used for generating the collated page uuid's */
     }
   }
 }

--- a/rulesets/mixins/_compose.scss
+++ b/rulesets/mixins/_compose.scss
@@ -101,6 +101,7 @@
         content: pending(#{$source}-TOCOMPOSITE);
         class: "os-eoc os-#{$source}-container";
         data-type: "composite-page";
+        data-uuid-key: "#{$source}";
         @if ($sortBy != null) {
           sort-by: #{$sortBy}, nocase;
         }
@@ -195,6 +196,7 @@
       &::after {
         class: "os-eoc os-#{$source}-container";
         data-type: composite-page;
+        data-uuid-key: "#{$source}";
         content: pending(composite-DESTINATION);
 
       }
@@ -285,6 +287,7 @@
             content: pending(#{$source}-GETCHAPTER);
             @if ($chapterPages) {
               data-type: "composite-page";
+              data-uuid-key: "#{$source}";
             }
           }
         }
@@ -319,6 +322,7 @@
       content: pending(#{$source}-TOCOMPOSITE);
       class: "os-eob os-#{$source}-container";
       data-type: "composite-page";
+      data-uuid-key: "#{$source}";
       @if ($isIndex) {
         group-by: span, "span::attr(group-by)", nocase;
       }
@@ -402,6 +406,7 @@
       content: pending(#{$solutionSource}-TOCOMPOSITE);
       class: "os-eoc os-#{$solutionSource}-container";
       data-type: "composite-page";
+      data-uuid-key: "chapter-solutions";  /* TODO: Is this the correct key? We'll be stuck with it because it is used for generating the collated page uuid's */
     }
   }
 }
@@ -503,6 +508,7 @@
       content: pending(#{$solutionSource}-TOCOMPOSITE);
       class: "os-eob os-#{$solutionSource}-container";
       data-type: "composite-page";
+      data-uuid-key: "#{$solutionSource}"; /* TODO: Is this the correct key? We'll be stuck with it because it is used for generating the collated page uuid's */
     }
   }
 }

--- a/rulesets/mixins/_modify.scss
+++ b/rulesets/mixins/_modify.scss
@@ -20,14 +20,6 @@
   }
 }
 
-/// Modifies the `id` of `div[data-type="composite-page"]` to its `uuid() "@1"`
-/// @group modify
-@mixin modify_compositeAutoID() {
-  div[data-type="composite-page"] {
-    attr-id: uuid() "@1";
-  }
-}
-
 /// Modifies the `id` of each chapter title to `"chapTitle" counter(chapTitleNum)`
 /// @group modify
 @mixin modify_chapterAutoID() {

--- a/rulesets/output/ap-biology.css
+++ b/rulesets/output/ap-biology.css
@@ -682,6 +682,7 @@
   content: pending(glossary-TOCOMPOSITE);
   class: "os-eoc os-glossary-container";
   data-type: "composite-page";
+  data-uuid-key: "glossary";
   sort-by: dl > dt, nocase; }
 :pass(1) div[data-type="chapter"] section.summary {
   /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
@@ -694,7 +695,8 @@
   container: div;
   content: pending(summary-TOCOMPOSITE);
   class: "os-eoc os-summary-container";
-  data-type: "composite-page"; }
+  data-type: "composite-page";
+  data-uuid-key: "summary"; }
 :pass(1) div[data-type="chapter"] section.art-exercise {
   move-to: art-exercise-TOCOMPOSITE; }
   :pass(1) div[data-type="chapter"] section.art-exercise > [data-type="title"] {
@@ -704,7 +706,8 @@
   container: div;
   content: pending(art-exercise-TOCOMPOSITE);
   class: "os-eoc os-art-exercise-container";
-  data-type: "composite-page"; }
+  data-type: "composite-page";
+  data-uuid-key: "art-exercise"; }
 :pass(1) div[data-type="chapter"] section.multiple-choice {
   move-to: multiple-choice-TOCOMPOSITE; }
   :pass(1) div[data-type="chapter"] section.multiple-choice > [data-type="title"] {
@@ -714,7 +717,8 @@
   container: div;
   content: pending(multiple-choice-TOCOMPOSITE);
   class: "os-eoc os-multiple-choice-container";
-  data-type: "composite-page"; }
+  data-type: "composite-page";
+  data-uuid-key: "multiple-choice"; }
 :pass(1) div[data-type="chapter"] section.free-response {
   move-to: free-response-TOCOMPOSITE; }
   :pass(1) div[data-type="chapter"] section.free-response > [data-type="title"] {
@@ -724,7 +728,8 @@
   container: div;
   content: pending(free-response-TOCOMPOSITE);
   class: "os-eoc os-free-response-container";
-  data-type: "composite-page"; }
+  data-type: "composite-page";
+  data-uuid-key: "free-response"; }
 :pass(1) div[data-type="chapter"] section.review {
   move-to: review-TOCOMPOSITE; }
   :pass(1) div[data-type="chapter"] section.review > [data-type="title"] {
@@ -734,7 +739,8 @@
   container: div;
   content: pending(review-TOCOMPOSITE);
   class: "os-eoc os-review-container";
-  data-type: "composite-page"; }
+  data-type: "composite-page";
+  data-uuid-key: "review"; }
 :pass(1) div[data-type="chapter"] section.critical-thinking {
   move-to: critical-thinking-TOCOMPOSITE; }
   :pass(1) div[data-type="chapter"] section.critical-thinking > [data-type="title"] {
@@ -744,7 +750,8 @@
   container: div;
   content: pending(critical-thinking-TOCOMPOSITE);
   class: "os-eoc os-critical-thinking-container";
-  data-type: "composite-page"; }
+  data-type: "composite-page";
+  data-uuid-key: "critical-thinking"; }
 :pass(1) div[data-type="chapter"] section.ap-test-prep {
   move-to: ap-test-prep-TOCOMPOSITE; }
   :pass(1) div[data-type="chapter"] section.ap-test-prep > [data-type="title"] {
@@ -754,7 +761,8 @@
   container: div;
   content: pending(ap-test-prep-TOCOMPOSITE);
   class: "os-eoc os-ap-test-prep-container";
-  data-type: "composite-page"; }
+  data-type: "composite-page";
+  data-uuid-key: "ap-test-prep"; }
 
 :pass(2) div[data-type="page"] > [data-type="document-title"],
 :pass(2) div[data-type="composite-page"] > [data-type="document-title"] {
@@ -829,12 +837,14 @@
   container: div;
   content: pending(solutions-TOCOMPOSITE);
   class: "os-eob os-solutions-container";
-  data-type: "composite-page"; }
+  data-type: "composite-page";
+  data-uuid-key: "solutions"; }
 :pass(4) body::after {
   container: div;
   content: pending(index-TOCOMPOSITE);
   class: "os-eob os-index-container";
   data-type: "composite-page";
+  data-uuid-key: "index";
   group-by: span, "span::attr(group-by)", nocase; }
 
 :pass(5) .os-index-container > div.group-by:first-of-type > span.group-label {
@@ -959,8 +969,6 @@
   container: h1;
   data-type: "document-title";
   content: pending(h1-TITLECONTAINER); }
-:pass(5) div[data-type="composite-page"] {
-  attr-id: uuid() "@1"; }
 :pass(5) div[data-type='chapter'] > h1[data-type='document-title'] {
   counter-increment: chapTitleNum;
   attr-id: "chapTitle" counter(chapTitleNum); }

--- a/rulesets/output/ap-biology.css
+++ b/rulesets/output/ap-biology.css
@@ -682,7 +682,7 @@
   content: pending(glossary-TOCOMPOSITE);
   class: "os-eoc os-glossary-container";
   data-type: "composite-page";
-  data-uuid-key: "glossary";
+  data-uuid-key: "<glossary>";
   sort-by: dl > dt, nocase; }
 :pass(1) div[data-type="chapter"] section.summary {
   /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
@@ -696,7 +696,7 @@
   content: pending(summary-TOCOMPOSITE);
   class: "os-eoc os-summary-container";
   data-type: "composite-page";
-  data-uuid-key: "summary"; }
+  data-uuid-key: ".summary"; }
 :pass(1) div[data-type="chapter"] section.art-exercise {
   move-to: art-exercise-TOCOMPOSITE; }
   :pass(1) div[data-type="chapter"] section.art-exercise > [data-type="title"] {
@@ -707,7 +707,7 @@
   content: pending(art-exercise-TOCOMPOSITE);
   class: "os-eoc os-art-exercise-container";
   data-type: "composite-page";
-  data-uuid-key: "art-exercise"; }
+  data-uuid-key: ".art-exercise"; }
 :pass(1) div[data-type="chapter"] section.multiple-choice {
   move-to: multiple-choice-TOCOMPOSITE; }
   :pass(1) div[data-type="chapter"] section.multiple-choice > [data-type="title"] {
@@ -718,7 +718,7 @@
   content: pending(multiple-choice-TOCOMPOSITE);
   class: "os-eoc os-multiple-choice-container";
   data-type: "composite-page";
-  data-uuid-key: "multiple-choice"; }
+  data-uuid-key: ".multiple-choice"; }
 :pass(1) div[data-type="chapter"] section.free-response {
   move-to: free-response-TOCOMPOSITE; }
   :pass(1) div[data-type="chapter"] section.free-response > [data-type="title"] {
@@ -729,7 +729,7 @@
   content: pending(free-response-TOCOMPOSITE);
   class: "os-eoc os-free-response-container";
   data-type: "composite-page";
-  data-uuid-key: "free-response"; }
+  data-uuid-key: ".free-response"; }
 :pass(1) div[data-type="chapter"] section.review {
   move-to: review-TOCOMPOSITE; }
   :pass(1) div[data-type="chapter"] section.review > [data-type="title"] {
@@ -740,7 +740,7 @@
   content: pending(review-TOCOMPOSITE);
   class: "os-eoc os-review-container";
   data-type: "composite-page";
-  data-uuid-key: "review"; }
+  data-uuid-key: ".review"; }
 :pass(1) div[data-type="chapter"] section.critical-thinking {
   move-to: critical-thinking-TOCOMPOSITE; }
   :pass(1) div[data-type="chapter"] section.critical-thinking > [data-type="title"] {
@@ -751,7 +751,7 @@
   content: pending(critical-thinking-TOCOMPOSITE);
   class: "os-eoc os-critical-thinking-container";
   data-type: "composite-page";
-  data-uuid-key: "critical-thinking"; }
+  data-uuid-key: ".critical-thinking"; }
 :pass(1) div[data-type="chapter"] section.ap-test-prep {
   move-to: ap-test-prep-TOCOMPOSITE; }
   :pass(1) div[data-type="chapter"] section.ap-test-prep > [data-type="title"] {
@@ -762,7 +762,7 @@
   content: pending(ap-test-prep-TOCOMPOSITE);
   class: "os-eoc os-ap-test-prep-container";
   data-type: "composite-page";
-  data-uuid-key: "ap-test-prep"; }
+  data-uuid-key: ".ap-test-prep"; }
 
 :pass(2) div[data-type="page"] > [data-type="document-title"],
 :pass(2) div[data-type="composite-page"] > [data-type="document-title"] {
@@ -838,13 +838,13 @@
   content: pending(solutions-TOCOMPOSITE);
   class: "os-eob os-solutions-container";
   data-type: "composite-page";
-  data-uuid-key: "solutions"; }
+  data-uuid-key: ".solutions"; }
 :pass(4) body::after {
   container: div;
   content: pending(index-TOCOMPOSITE);
   class: "os-eob os-index-container";
   data-type: "composite-page";
-  data-uuid-key: "index";
+  data-uuid-key: "<index>";
   group-by: span, "span::attr(group-by)", nocase; }
 
 :pass(5) .os-index-container > div.group-by:first-of-type > span.group-label {

--- a/rulesets/output/ap-physics.css
+++ b/rulesets/output/ap-physics.css
@@ -508,6 +508,7 @@ Usage Note: key: class of the containing span, value: text that will go inside s
   content: pending(glossary-TOCOMPOSITE);
   class: "os-eoc os-glossary-container";
   data-type: "composite-page";
+  data-uuid-key: "glossary";
   sort-by: dl > dt, nocase; }
 :pass(2) div[data-type="chapter"] section.section-summary {
   /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
@@ -520,7 +521,8 @@ Usage Note: key: class of the containing span, value: text that will go inside s
   container: div;
   content: pending(section-summary-TOCOMPOSITE);
   class: "os-eoc os-section-summary-container";
-  data-type: "composite-page"; }
+  data-type: "composite-page";
+  data-uuid-key: "section-summary"; }
 :pass(2) div[data-type="chapter"] section.conceptual-questions {
   /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
   content: nodes(sectionHeaderNode) content();
@@ -532,7 +534,8 @@ Usage Note: key: class of the containing span, value: text that will go inside s
   container: div;
   content: pending(conceptual-questions-TOCOMPOSITE);
   class: "os-eoc os-conceptual-questions-container";
-  data-type: "composite-page"; }
+  data-type: "composite-page";
+  data-uuid-key: "conceptual-questions"; }
 :pass(2) div[data-type="chapter"] section.problems-exercises {
   /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
   content: nodes(sectionHeaderNode) content();
@@ -544,7 +547,8 @@ Usage Note: key: class of the containing span, value: text that will go inside s
   container: div;
   content: pending(problems-exercises-TOCOMPOSITE);
   class: "os-eoc os-problems-exercises-container";
-  data-type: "composite-page"; }
+  data-type: "composite-page";
+  data-uuid-key: "problems-exercises"; }
 :pass(2) div[data-type="chapter"] section.ap-test-prep {
   /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
   content: nodes(sectionHeaderNode) content();
@@ -556,7 +560,8 @@ Usage Note: key: class of the containing span, value: text that will go inside s
   container: div;
   content: pending(ap-test-prep-TOCOMPOSITE);
   class: "os-eoc os-ap-test-prep-container";
-  data-type: "composite-page"; }
+  data-type: "composite-page";
+  data-uuid-key: "ap-test-prep"; }
 :pass(2) [data-type="page"]:not(.introduction):not(.preface) > [data-type="document-title"] {
   node-set: outlineSectionTitle; }
 :pass(2) [data-type="page"]:not(.introduction):not(.preface) [data-type="abstract"] {
@@ -676,17 +681,21 @@ Usage Note: key: class of the containing span, value: text that will go inside s
   container: div;
   content: pending(solutions-TOCOMPOSITE);
   class: "os-eob os-solutions-container";
-  data-type: "composite-page"; }
+  data-type: "composite-page";
+  data-uuid-key: "solutions";
+  /* TODO: Is this the correct key? We'll be stuck with it because it is used for generating the collated page uuid's */ }
 :pass(5) body::after {
   container: div;
   content: pending(solutions-TOCOMPOSITE);
   class: "os-eob os-solutions-container";
-  data-type: "composite-page"; }
+  data-type: "composite-page";
+  data-uuid-key: "solutions"; }
 :pass(5) body::after {
   container: div;
   content: pending(index-TOCOMPOSITE);
   class: "os-eob os-index-container";
   data-type: "composite-page";
+  data-uuid-key: "index";
   group-by: span, "span::attr(group-by)", nocase; }
 
 :pass(6) .os-index-container > div.group-by:first-of-type > span.group-label {
@@ -796,8 +805,6 @@ Usage Note: key: class of the containing span, value: text that will go inside s
   container: h1;
   data-type: "document-title";
   content: pending(h1-TITLECONTAINER); }
-:pass(6) div[data-type="composite-page"] {
-  attr-id: uuid() "@1"; }
 :pass(6) div[data-type='chapter'] > h1[data-type='document-title'] {
   counter-increment: chapTitleNum;
   attr-id: "chapTitle" counter(chapTitleNum); }

--- a/rulesets/output/ap-physics.css
+++ b/rulesets/output/ap-physics.css
@@ -508,7 +508,7 @@ Usage Note: key: class of the containing span, value: text that will go inside s
   content: pending(glossary-TOCOMPOSITE);
   class: "os-eoc os-glossary-container";
   data-type: "composite-page";
-  data-uuid-key: "glossary";
+  data-uuid-key: "<glossary>";
   sort-by: dl > dt, nocase; }
 :pass(2) div[data-type="chapter"] section.section-summary {
   /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
@@ -522,7 +522,7 @@ Usage Note: key: class of the containing span, value: text that will go inside s
   content: pending(section-summary-TOCOMPOSITE);
   class: "os-eoc os-section-summary-container";
   data-type: "composite-page";
-  data-uuid-key: "section-summary"; }
+  data-uuid-key: ".section-summary"; }
 :pass(2) div[data-type="chapter"] section.conceptual-questions {
   /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
   content: nodes(sectionHeaderNode) content();
@@ -535,7 +535,7 @@ Usage Note: key: class of the containing span, value: text that will go inside s
   content: pending(conceptual-questions-TOCOMPOSITE);
   class: "os-eoc os-conceptual-questions-container";
   data-type: "composite-page";
-  data-uuid-key: "conceptual-questions"; }
+  data-uuid-key: ".conceptual-questions"; }
 :pass(2) div[data-type="chapter"] section.problems-exercises {
   /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
   content: nodes(sectionHeaderNode) content();
@@ -548,7 +548,7 @@ Usage Note: key: class of the containing span, value: text that will go inside s
   content: pending(problems-exercises-TOCOMPOSITE);
   class: "os-eoc os-problems-exercises-container";
   data-type: "composite-page";
-  data-uuid-key: "problems-exercises"; }
+  data-uuid-key: ".problems-exercises"; }
 :pass(2) div[data-type="chapter"] section.ap-test-prep {
   /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
   content: nodes(sectionHeaderNode) content();
@@ -561,7 +561,7 @@ Usage Note: key: class of the containing span, value: text that will go inside s
   content: pending(ap-test-prep-TOCOMPOSITE);
   class: "os-eoc os-ap-test-prep-container";
   data-type: "composite-page";
-  data-uuid-key: "ap-test-prep"; }
+  data-uuid-key: ".ap-test-prep"; }
 :pass(2) [data-type="page"]:not(.introduction):not(.preface) > [data-type="document-title"] {
   node-set: outlineSectionTitle; }
 :pass(2) [data-type="page"]:not(.introduction):not(.preface) [data-type="abstract"] {
@@ -682,20 +682,20 @@ Usage Note: key: class of the containing span, value: text that will go inside s
   content: pending(solutions-TOCOMPOSITE);
   class: "os-eob os-solutions-container";
   data-type: "composite-page";
-  data-uuid-key: "solutions";
+  data-uuid-key: ".solutions";
   /* TODO: Is this the correct key? We'll be stuck with it because it is used for generating the collated page uuid's */ }
 :pass(5) body::after {
   container: div;
   content: pending(solutions-TOCOMPOSITE);
   class: "os-eob os-solutions-container";
   data-type: "composite-page";
-  data-uuid-key: "solutions"; }
+  data-uuid-key: ".solutions"; }
 :pass(5) body::after {
   container: div;
   content: pending(index-TOCOMPOSITE);
   class: "os-eob os-index-container";
   data-type: "composite-page";
-  data-uuid-key: "index";
+  data-uuid-key: "<index>";
   group-by: span, "span::attr(group-by)", nocase; }
 
 :pass(6) .os-index-container > div.group-by:first-of-type > span.group-label {

--- a/rulesets/output/biology.css
+++ b/rulesets/output/biology.css
@@ -588,6 +588,7 @@
   content: pending(glossary-TOCOMPOSITE);
   class: "os-eoc os-glossary-container";
   data-type: "composite-page";
+  data-uuid-key: "glossary";
   sort-by: dl > dt, nocase; }
 :pass(2) div[data-type="chapter"] section.summary {
   /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
@@ -600,7 +601,8 @@
   container: div;
   content: pending(summary-TOCOMPOSITE);
   class: "os-eoc os-summary-container";
-  data-type: "composite-page"; }
+  data-type: "composite-page";
+  data-uuid-key: "summary"; }
 :pass(2) div[data-type="chapter"] section.art-exercise {
   move-to: art-exercise-TOCOMPOSITE; }
   :pass(2) div[data-type="chapter"] section.art-exercise > [data-type="title"] {
@@ -610,7 +612,8 @@
   container: div;
   content: pending(art-exercise-TOCOMPOSITE);
   class: "os-eoc os-art-exercise-container";
-  data-type: "composite-page"; }
+  data-type: "composite-page";
+  data-uuid-key: "art-exercise"; }
 :pass(2) div[data-type="chapter"] section.multiple-choice {
   move-to: multiple-choice-TOCOMPOSITE; }
   :pass(2) div[data-type="chapter"] section.multiple-choice > [data-type="title"] {
@@ -620,7 +623,8 @@
   container: div;
   content: pending(multiple-choice-TOCOMPOSITE);
   class: "os-eoc os-multiple-choice-container";
-  data-type: "composite-page"; }
+  data-type: "composite-page";
+  data-uuid-key: "multiple-choice"; }
 :pass(2) div[data-type="chapter"] section.free-response {
   move-to: free-response-TOCOMPOSITE; }
   :pass(2) div[data-type="chapter"] section.free-response > [data-type="title"] {
@@ -630,7 +634,8 @@
   container: div;
   content: pending(free-response-TOCOMPOSITE);
   class: "os-eoc os-free-response-container";
-  data-type: "composite-page"; }
+  data-type: "composite-page";
+  data-uuid-key: "free-response"; }
 
 :pass(3) div[data-type="page"] > [data-type="document-title"],
 :pass(3) div[data-type="composite-page"] > [data-type="document-title"] {
@@ -732,17 +737,21 @@
   container: div;
   content: pending(solutions-TOCOMPOSITE);
   class: "os-eob os-solutions-container";
-  data-type: "composite-page"; }
+  data-type: "composite-page";
+  data-uuid-key: "solutions";
+  /* TODO: Is this the correct key? We'll be stuck with it because it is used for generating the collated page uuid's */ }
 :pass(5) body::after {
   container: div;
   content: pending(solutions-TOCOMPOSITE);
   class: "os-eob os-solutions-container";
-  data-type: "composite-page"; }
+  data-type: "composite-page";
+  data-uuid-key: "solutions"; }
 :pass(5) body::after {
   container: div;
   content: pending(index-TOCOMPOSITE);
   class: "os-eob os-index-container";
   data-type: "composite-page";
+  data-uuid-key: "index";
   group-by: span, "span::attr(group-by)", nocase; }
 
 :pass(6) .os-index-container > div.group-by:first-of-type > span.group-label {
@@ -842,8 +851,6 @@
   container: h1;
   data-type: "document-title";
   content: pending(h1-TITLECONTAINER); }
-:pass(6) div[data-type="composite-page"] {
-  attr-id: uuid() "@1"; }
 :pass(6) div[data-type='chapter'] > h1[data-type='document-title'] {
   counter-increment: chapTitleNum;
   attr-id: "chapTitle" counter(chapTitleNum); }

--- a/rulesets/output/biology.css
+++ b/rulesets/output/biology.css
@@ -588,7 +588,7 @@
   content: pending(glossary-TOCOMPOSITE);
   class: "os-eoc os-glossary-container";
   data-type: "composite-page";
-  data-uuid-key: "glossary";
+  data-uuid-key: "<glossary>";
   sort-by: dl > dt, nocase; }
 :pass(2) div[data-type="chapter"] section.summary {
   /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
@@ -602,7 +602,7 @@
   content: pending(summary-TOCOMPOSITE);
   class: "os-eoc os-summary-container";
   data-type: "composite-page";
-  data-uuid-key: "summary"; }
+  data-uuid-key: ".summary"; }
 :pass(2) div[data-type="chapter"] section.art-exercise {
   move-to: art-exercise-TOCOMPOSITE; }
   :pass(2) div[data-type="chapter"] section.art-exercise > [data-type="title"] {
@@ -613,7 +613,7 @@
   content: pending(art-exercise-TOCOMPOSITE);
   class: "os-eoc os-art-exercise-container";
   data-type: "composite-page";
-  data-uuid-key: "art-exercise"; }
+  data-uuid-key: ".art-exercise"; }
 :pass(2) div[data-type="chapter"] section.multiple-choice {
   move-to: multiple-choice-TOCOMPOSITE; }
   :pass(2) div[data-type="chapter"] section.multiple-choice > [data-type="title"] {
@@ -624,7 +624,7 @@
   content: pending(multiple-choice-TOCOMPOSITE);
   class: "os-eoc os-multiple-choice-container";
   data-type: "composite-page";
-  data-uuid-key: "multiple-choice"; }
+  data-uuid-key: ".multiple-choice"; }
 :pass(2) div[data-type="chapter"] section.free-response {
   move-to: free-response-TOCOMPOSITE; }
   :pass(2) div[data-type="chapter"] section.free-response > [data-type="title"] {
@@ -635,7 +635,7 @@
   content: pending(free-response-TOCOMPOSITE);
   class: "os-eoc os-free-response-container";
   data-type: "composite-page";
-  data-uuid-key: "free-response"; }
+  data-uuid-key: ".free-response"; }
 
 :pass(3) div[data-type="page"] > [data-type="document-title"],
 :pass(3) div[data-type="composite-page"] > [data-type="document-title"] {
@@ -738,20 +738,20 @@
   content: pending(solutions-TOCOMPOSITE);
   class: "os-eob os-solutions-container";
   data-type: "composite-page";
-  data-uuid-key: "solutions";
+  data-uuid-key: ".solutions";
   /* TODO: Is this the correct key? We'll be stuck with it because it is used for generating the collated page uuid's */ }
 :pass(5) body::after {
   container: div;
   content: pending(solutions-TOCOMPOSITE);
   class: "os-eob os-solutions-container";
   data-type: "composite-page";
-  data-uuid-key: "solutions"; }
+  data-uuid-key: ".solutions"; }
 :pass(5) body::after {
   container: div;
   content: pending(index-TOCOMPOSITE);
   class: "os-eob os-index-container";
   data-type: "composite-page";
-  data-uuid-key: "index";
+  data-uuid-key: "<index>";
   group-by: span, "span::attr(group-by)", nocase; }
 
 :pass(6) .os-index-container > div.group-by:first-of-type > span.group-label {

--- a/rulesets/output/economics.css
+++ b/rulesets/output/economics.css
@@ -580,7 +580,7 @@
   content: pending(glossary-TOCOMPOSITE);
   class: "os-eoc os-glossary-container";
   data-type: "composite-page";
-  data-uuid-key: "glossary";
+  data-uuid-key: "<glossary>";
   sort-by: dl > dt, nocase; }
 :pass(2) div[data-type="chapter"] section.summary {
   /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
@@ -594,7 +594,7 @@
   content: pending(summary-TOCOMPOSITE);
   class: "os-eoc os-summary-container";
   data-type: "composite-page";
-  data-uuid-key: "summary"; }
+  data-uuid-key: ".summary"; }
 :pass(2) div[data-type="chapter"] section.self-check-questions {
   move-to: self-check-questions-TOCOMPOSITE; }
   :pass(2) div[data-type="chapter"] section.self-check-questions > [data-type="title"] {
@@ -605,7 +605,7 @@
   content: pending(self-check-questions-TOCOMPOSITE);
   class: "os-eoc os-self-check-questions-container";
   data-type: "composite-page";
-  data-uuid-key: "self-check-questions"; }
+  data-uuid-key: ".self-check-questions"; }
 :pass(2) div[data-type="chapter"] section.review-questions {
   move-to: review-questions-TOCOMPOSITE; }
   :pass(2) div[data-type="chapter"] section.review-questions > [data-type="title"] {
@@ -616,7 +616,7 @@
   content: pending(review-questions-TOCOMPOSITE);
   class: "os-eoc os-review-questions-container";
   data-type: "composite-page";
-  data-uuid-key: "review-questions"; }
+  data-uuid-key: ".review-questions"; }
 :pass(2) div[data-type="chapter"] section.critical-thinking {
   move-to: critical-thinking-TOCOMPOSITE; }
   :pass(2) div[data-type="chapter"] section.critical-thinking > [data-type="title"] {
@@ -627,7 +627,7 @@
   content: pending(critical-thinking-TOCOMPOSITE);
   class: "os-eoc os-critical-thinking-container";
   data-type: "composite-page";
-  data-uuid-key: "critical-thinking"; }
+  data-uuid-key: ".critical-thinking"; }
 :pass(2) div[data-type="chapter"] section.problems {
   move-to: problems-TOCOMPOSITE; }
   :pass(2) div[data-type="chapter"] section.problems > [data-type="title"] {
@@ -638,7 +638,7 @@
   content: pending(problems-TOCOMPOSITE);
   class: "os-eoc os-problems-container";
   data-type: "composite-page";
-  data-uuid-key: "problems"; }
+  data-uuid-key: ".problems"; }
 :pass(2) div[data-type="chapter"] section.ap-test-prep {
   move-to: ap-test-prep-TOCOMPOSITE; }
   :pass(2) div[data-type="chapter"] section.ap-test-prep > [data-type="title"] {
@@ -649,7 +649,7 @@
   content: pending(ap-test-prep-TOCOMPOSITE);
   class: "os-eoc os-ap-test-prep-container";
   data-type: "composite-page";
-  data-uuid-key: "ap-test-prep"; }
+  data-uuid-key: ".ap-test-prep"; }
 
 :pass(3) div[data-type="page"] > [data-type="document-title"],
 :pass(3) div[data-type="composite-page"] > [data-type="document-title"] {
@@ -760,26 +760,26 @@
   content: pending(solutions-TOCOMPOSITE);
   class: "os-eob os-solutions-container";
   data-type: "composite-page";
-  data-uuid-key: "solutions";
+  data-uuid-key: ".solutions";
   /* TODO: Is this the correct key? We'll be stuck with it because it is used for generating the collated page uuid's */ }
 :pass(5) body::after {
   container: div;
   content: pending(solutions-TOCOMPOSITE);
   class: "os-eob os-solutions-container";
   data-type: "composite-page";
-  data-uuid-key: "solutions"; }
+  data-uuid-key: ".solutions"; }
 :pass(5) body::after {
   container: div;
   content: pending(references-TOCOMPOSITE);
   class: "os-eob os-references-container";
   data-type: "composite-page";
-  data-uuid-key: "references"; }
+  data-uuid-key: ".references"; }
 :pass(5) body::after {
   container: div;
   content: pending(index-TOCOMPOSITE);
   class: "os-eob os-index-container";
   data-type: "composite-page";
-  data-uuid-key: "index";
+  data-uuid-key: "<index>";
   group-by: span, "span::attr(group-by)", nocase; }
 
 :pass(6) .os-index-container > div.group-by:first-of-type > span.group-label {

--- a/rulesets/output/economics.css
+++ b/rulesets/output/economics.css
@@ -580,6 +580,7 @@
   content: pending(glossary-TOCOMPOSITE);
   class: "os-eoc os-glossary-container";
   data-type: "composite-page";
+  data-uuid-key: "glossary";
   sort-by: dl > dt, nocase; }
 :pass(2) div[data-type="chapter"] section.summary {
   /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
@@ -592,7 +593,8 @@
   container: div;
   content: pending(summary-TOCOMPOSITE);
   class: "os-eoc os-summary-container";
-  data-type: "composite-page"; }
+  data-type: "composite-page";
+  data-uuid-key: "summary"; }
 :pass(2) div[data-type="chapter"] section.self-check-questions {
   move-to: self-check-questions-TOCOMPOSITE; }
   :pass(2) div[data-type="chapter"] section.self-check-questions > [data-type="title"] {
@@ -602,7 +604,8 @@
   container: div;
   content: pending(self-check-questions-TOCOMPOSITE);
   class: "os-eoc os-self-check-questions-container";
-  data-type: "composite-page"; }
+  data-type: "composite-page";
+  data-uuid-key: "self-check-questions"; }
 :pass(2) div[data-type="chapter"] section.review-questions {
   move-to: review-questions-TOCOMPOSITE; }
   :pass(2) div[data-type="chapter"] section.review-questions > [data-type="title"] {
@@ -612,7 +615,8 @@
   container: div;
   content: pending(review-questions-TOCOMPOSITE);
   class: "os-eoc os-review-questions-container";
-  data-type: "composite-page"; }
+  data-type: "composite-page";
+  data-uuid-key: "review-questions"; }
 :pass(2) div[data-type="chapter"] section.critical-thinking {
   move-to: critical-thinking-TOCOMPOSITE; }
   :pass(2) div[data-type="chapter"] section.critical-thinking > [data-type="title"] {
@@ -622,7 +626,8 @@
   container: div;
   content: pending(critical-thinking-TOCOMPOSITE);
   class: "os-eoc os-critical-thinking-container";
-  data-type: "composite-page"; }
+  data-type: "composite-page";
+  data-uuid-key: "critical-thinking"; }
 :pass(2) div[data-type="chapter"] section.problems {
   move-to: problems-TOCOMPOSITE; }
   :pass(2) div[data-type="chapter"] section.problems > [data-type="title"] {
@@ -632,7 +637,8 @@
   container: div;
   content: pending(problems-TOCOMPOSITE);
   class: "os-eoc os-problems-container";
-  data-type: "composite-page"; }
+  data-type: "composite-page";
+  data-uuid-key: "problems"; }
 :pass(2) div[data-type="chapter"] section.ap-test-prep {
   move-to: ap-test-prep-TOCOMPOSITE; }
   :pass(2) div[data-type="chapter"] section.ap-test-prep > [data-type="title"] {
@@ -642,7 +648,8 @@
   container: div;
   content: pending(ap-test-prep-TOCOMPOSITE);
   class: "os-eoc os-ap-test-prep-container";
-  data-type: "composite-page"; }
+  data-type: "composite-page";
+  data-uuid-key: "ap-test-prep"; }
 
 :pass(3) div[data-type="page"] > [data-type="document-title"],
 :pass(3) div[data-type="composite-page"] > [data-type="document-title"] {
@@ -752,22 +759,27 @@
   container: div;
   content: pending(solutions-TOCOMPOSITE);
   class: "os-eob os-solutions-container";
-  data-type: "composite-page"; }
+  data-type: "composite-page";
+  data-uuid-key: "solutions";
+  /* TODO: Is this the correct key? We'll be stuck with it because it is used for generating the collated page uuid's */ }
 :pass(5) body::after {
   container: div;
   content: pending(solutions-TOCOMPOSITE);
   class: "os-eob os-solutions-container";
-  data-type: "composite-page"; }
+  data-type: "composite-page";
+  data-uuid-key: "solutions"; }
 :pass(5) body::after {
   container: div;
   content: pending(references-TOCOMPOSITE);
   class: "os-eob os-references-container";
-  data-type: "composite-page"; }
+  data-type: "composite-page";
+  data-uuid-key: "references"; }
 :pass(5) body::after {
   container: div;
   content: pending(index-TOCOMPOSITE);
   class: "os-eob os-index-container";
   data-type: "composite-page";
+  data-uuid-key: "index";
   group-by: span, "span::attr(group-by)", nocase; }
 
 :pass(6) .os-index-container > div.group-by:first-of-type > span.group-label {
@@ -892,8 +904,6 @@
   container: h1;
   data-type: "document-title";
   content: pending(h1-TITLECONTAINER); }
-:pass(6) div[data-type="composite-page"] {
-  attr-id: uuid() "@1"; }
 :pass(6) div[data-type='chapter'] > h1[data-type='document-title'] {
   counter-increment: chapTitleNum;
   attr-id: "chapTitle" counter(chapTitleNum); }

--- a/rulesets/output/hs-physics.css
+++ b/rulesets/output/hs-physics.css
@@ -850,6 +850,7 @@
   content: pending(glossary-TOCOMPOSITE);
   class: "os-eoc os-glossary-container";
   data-type: "composite-page";
+  data-uuid-key: "glossary";
   sort-by: dl > dt, nocase; }
 :pass(2) div[data-type="chapter"] section.summary {
   move-to: summary-TOCOMPOSITE; }
@@ -860,7 +861,8 @@
   container: div;
   content: pending(summary-TOCOMPOSITE);
   class: "os-eoc os-summary-container";
-  data-type: "composite-page"; }
+  data-type: "composite-page";
+  data-uuid-key: "summary"; }
 :pass(2) div[data-type="chapter"] section.key-equations {
   move-to: key-equations-TOCOMPOSITE; }
   :pass(2) div[data-type="chapter"] section.key-equations > [data-type="title"] {
@@ -870,7 +872,8 @@
   container: div;
   content: pending(key-equations-TOCOMPOSITE);
   class: "os-eoc os-key-equations-container";
-  data-type: "composite-page"; }
+  data-type: "composite-page";
+  data-uuid-key: "key-equations"; }
 :pass(2) div[data-type="chapter"] section.chapter-review {
   move-to: chapter-review-TOCOMPOSITE; }
   :pass(2) div[data-type="chapter"] section.chapter-review > [data-type="title"] {
@@ -880,7 +883,8 @@
   container: div;
   content: pending(chapter-review-TOCOMPOSITE);
   class: "os-eoc os-chapter-review-container";
-  data-type: "composite-page"; }
+  data-type: "composite-page";
+  data-uuid-key: "chapter-review"; }
 :pass(2) div[data-type="chapter"] section.test-prep {
   move-to: test-prep-TOCOMPOSITE; }
   :pass(2) div[data-type="chapter"] section.test-prep > [data-type="title"] {
@@ -890,7 +894,8 @@
   container: div;
   content: pending(test-prep-TOCOMPOSITE);
   class: "os-eoc os-test-prep-container";
-  data-type: "composite-page"; }
+  data-type: "composite-page";
+  data-uuid-key: "test-prep"; }
 
 :pass(3) div[data-type="page"] > [data-type="document-title"],
 :pass(3) div[data-type="composite-page"] > [data-type="document-title"] {
@@ -943,6 +948,7 @@
   content: pending(index-TOCOMPOSITE);
   class: "os-eob os-index-container";
   data-type: "composite-page";
+  data-uuid-key: "index";
   group-by: span, "span::attr(group-by)", nocase; }
 :pass(5) [data-type="chapter"] [data-type="page"] > [data-type="document-title"] {
   node-set: CompoundSectionHeaderNode; }
@@ -1037,6 +1043,7 @@
 :pass(5) [data-type="chapter"]::after {
   class: "os-eoc os-chapter-review-container";
   data-type: composite-page;
+  data-uuid-key: "chapter-review";
   content: pending(composite-DESTINATION); }
 :pass(5) [data-type="chapter"] [data-type="page"] > [data-type="document-title"] {
   node-set: CompoundSectionHeaderNode; }
@@ -1109,6 +1116,7 @@
 :pass(5) [data-type="chapter"]::after {
   class: "os-eoc os-test-prep-container";
   data-type: composite-page;
+  data-uuid-key: "test-prep";
   content: pending(composite-DESTINATION); }
 
 :pass(6) .os-index-container > div.group-by:first-of-type > span.group-label {
@@ -1201,8 +1209,6 @@
   container: h1;
   data-type: "document-title";
   content: pending(h1-TITLECONTAINER); }
-:pass(6) div[data-type="composite-page"] {
-  attr-id: uuid() "@1"; }
 :pass(6) div[data-type='chapter'] > h1[data-type='document-title'] {
   counter-increment: chapTitleNum;
   attr-id: "chapTitle" counter(chapTitleNum); }

--- a/rulesets/output/hs-physics.css
+++ b/rulesets/output/hs-physics.css
@@ -850,7 +850,7 @@
   content: pending(glossary-TOCOMPOSITE);
   class: "os-eoc os-glossary-container";
   data-type: "composite-page";
-  data-uuid-key: "glossary";
+  data-uuid-key: "<glossary>";
   sort-by: dl > dt, nocase; }
 :pass(2) div[data-type="chapter"] section.summary {
   move-to: summary-TOCOMPOSITE; }
@@ -862,7 +862,7 @@
   content: pending(summary-TOCOMPOSITE);
   class: "os-eoc os-summary-container";
   data-type: "composite-page";
-  data-uuid-key: "summary"; }
+  data-uuid-key: ".summary"; }
 :pass(2) div[data-type="chapter"] section.key-equations {
   move-to: key-equations-TOCOMPOSITE; }
   :pass(2) div[data-type="chapter"] section.key-equations > [data-type="title"] {
@@ -873,7 +873,7 @@
   content: pending(key-equations-TOCOMPOSITE);
   class: "os-eoc os-key-equations-container";
   data-type: "composite-page";
-  data-uuid-key: "key-equations"; }
+  data-uuid-key: ".key-equations"; }
 :pass(2) div[data-type="chapter"] section.chapter-review {
   move-to: chapter-review-TOCOMPOSITE; }
   :pass(2) div[data-type="chapter"] section.chapter-review > [data-type="title"] {
@@ -884,7 +884,7 @@
   content: pending(chapter-review-TOCOMPOSITE);
   class: "os-eoc os-chapter-review-container";
   data-type: "composite-page";
-  data-uuid-key: "chapter-review"; }
+  data-uuid-key: ".chapter-review"; }
 :pass(2) div[data-type="chapter"] section.test-prep {
   move-to: test-prep-TOCOMPOSITE; }
   :pass(2) div[data-type="chapter"] section.test-prep > [data-type="title"] {
@@ -895,7 +895,7 @@
   content: pending(test-prep-TOCOMPOSITE);
   class: "os-eoc os-test-prep-container";
   data-type: "composite-page";
-  data-uuid-key: "test-prep"; }
+  data-uuid-key: ".test-prep"; }
 
 :pass(3) div[data-type="page"] > [data-type="document-title"],
 :pass(3) div[data-type="composite-page"] > [data-type="document-title"] {
@@ -948,7 +948,7 @@
   content: pending(index-TOCOMPOSITE);
   class: "os-eob os-index-container";
   data-type: "composite-page";
-  data-uuid-key: "index";
+  data-uuid-key: "<index>";
   group-by: span, "span::attr(group-by)", nocase; }
 :pass(5) [data-type="chapter"] [data-type="page"] > [data-type="document-title"] {
   node-set: CompoundSectionHeaderNode; }
@@ -1043,7 +1043,7 @@
 :pass(5) [data-type="chapter"]::after {
   class: "os-eoc os-chapter-review-container";
   data-type: composite-page;
-  data-uuid-key: "chapter-review";
+  data-uuid-key: ".chapter-review";
   content: pending(composite-DESTINATION); }
 :pass(5) [data-type="chapter"] [data-type="page"] > [data-type="document-title"] {
   node-set: CompoundSectionHeaderNode; }
@@ -1116,7 +1116,7 @@
 :pass(5) [data-type="chapter"]::after {
   class: "os-eoc os-test-prep-container";
   data-type: composite-page;
-  data-uuid-key: "test-prep";
+  data-uuid-key: ".test-prep";
   content: pending(composite-DESTINATION); }
 
 :pass(6) .os-index-container > div.group-by:first-of-type > span.group-label {

--- a/rulesets/output/physics.css
+++ b/rulesets/output/physics.css
@@ -480,7 +480,7 @@
   content: pending(glossary-TOCOMPOSITE);
   class: "os-eoc os-glossary-container";
   data-type: "composite-page";
-  data-uuid-key: "glossary";
+  data-uuid-key: "<glossary>";
   sort-by: dl > dt, nocase; }
 :pass(2) div[data-type="chapter"] section.section-summary {
   /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
@@ -494,7 +494,7 @@
   content: pending(section-summary-TOCOMPOSITE);
   class: "os-eoc os-section-summary-container";
   data-type: "composite-page";
-  data-uuid-key: "section-summary"; }
+  data-uuid-key: ".section-summary"; }
 :pass(2) div[data-type="chapter"] section.conceptual-questions {
   /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
   content: nodes(sectionHeaderNode) content();
@@ -507,7 +507,7 @@
   content: pending(conceptual-questions-TOCOMPOSITE);
   class: "os-eoc os-conceptual-questions-container";
   data-type: "composite-page";
-  data-uuid-key: "conceptual-questions"; }
+  data-uuid-key: ".conceptual-questions"; }
 :pass(2) div[data-type="chapter"] section.problems-exercises {
   /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
   content: nodes(sectionHeaderNode) content();
@@ -520,7 +520,7 @@
   content: pending(problems-exercises-TOCOMPOSITE);
   class: "os-eoc os-problems-exercises-container";
   data-type: "composite-page";
-  data-uuid-key: "problems-exercises"; }
+  data-uuid-key: ".problems-exercises"; }
 :pass(2) [data-type="page"]:not(.introduction):not(.preface) > [data-type="document-title"] {
   node-set: outlineSectionTitle; }
 :pass(2) [data-type="page"]:not(.introduction):not(.preface) [data-type="abstract"] {
@@ -604,7 +604,7 @@
   content: pending(index-TOCOMPOSITE);
   class: "os-eob os-index-container";
   data-type: "composite-page";
-  data-uuid-key: "index";
+  data-uuid-key: "<index>";
   group-by: span, "span::attr(group-by)", nocase; }
 
 :pass(6) .os-index-container > div.group-by:first-of-type > span.group-label {

--- a/rulesets/output/physics.css
+++ b/rulesets/output/physics.css
@@ -480,6 +480,7 @@
   content: pending(glossary-TOCOMPOSITE);
   class: "os-eoc os-glossary-container";
   data-type: "composite-page";
+  data-uuid-key: "glossary";
   sort-by: dl > dt, nocase; }
 :pass(2) div[data-type="chapter"] section.section-summary {
   /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
@@ -492,7 +493,8 @@
   container: div;
   content: pending(section-summary-TOCOMPOSITE);
   class: "os-eoc os-section-summary-container";
-  data-type: "composite-page"; }
+  data-type: "composite-page";
+  data-uuid-key: "section-summary"; }
 :pass(2) div[data-type="chapter"] section.conceptual-questions {
   /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
   content: nodes(sectionHeaderNode) content();
@@ -504,7 +506,8 @@
   container: div;
   content: pending(conceptual-questions-TOCOMPOSITE);
   class: "os-eoc os-conceptual-questions-container";
-  data-type: "composite-page"; }
+  data-type: "composite-page";
+  data-uuid-key: "conceptual-questions"; }
 :pass(2) div[data-type="chapter"] section.problems-exercises {
   /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
   content: nodes(sectionHeaderNode) content();
@@ -516,7 +519,8 @@
   container: div;
   content: pending(problems-exercises-TOCOMPOSITE);
   class: "os-eoc os-problems-exercises-container";
-  data-type: "composite-page"; }
+  data-type: "composite-page";
+  data-uuid-key: "problems-exercises"; }
 :pass(2) [data-type="page"]:not(.introduction):not(.preface) > [data-type="document-title"] {
   node-set: outlineSectionTitle; }
 :pass(2) [data-type="page"]:not(.introduction):not(.preface) [data-type="abstract"] {
@@ -600,6 +604,7 @@
   content: pending(index-TOCOMPOSITE);
   class: "os-eob os-index-container";
   data-type: "composite-page";
+  data-uuid-key: "index";
   group-by: span, "span::attr(group-by)", nocase; }
 
 :pass(6) .os-index-container > div.group-by:first-of-type > span.group-label {
@@ -683,8 +688,6 @@
   container: h1;
   data-type: "document-title";
   content: pending(h1-TITLECONTAINER); }
-:pass(6) div[data-type="composite-page"] {
-  attr-id: uuid() "@1"; }
 :pass(6) div[data-type='chapter'] > h1[data-type='document-title'] {
   counter-increment: chapTitleNum;
   attr-id: "chapTitle" counter(chapTitleNum); }

--- a/rulesets/output/statistics.css
+++ b/rulesets/output/statistics.css
@@ -550,7 +550,7 @@
   content: pending(glossary-TOCOMPOSITE);
   class: "os-eoc os-glossary-container";
   data-type: "composite-page";
-  data-uuid-key: "glossary";
+  data-uuid-key: "<glossary>";
   sort-by: dl > dt, nocase; }
 :pass(2) div[data-type="chapter"] section.summary {
   /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
@@ -564,7 +564,7 @@
   content: pending(summary-TOCOMPOSITE);
   class: "os-eoc os-summary-container";
   data-type: "composite-page";
-  data-uuid-key: "summary"; }
+  data-uuid-key: ".summary"; }
 :pass(2) div[data-type="chapter"] section.formula-review {
   /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
   content: nodes(sectionHeaderNode) content();
@@ -577,7 +577,7 @@
   content: pending(formula-review-TOCOMPOSITE);
   class: "os-eoc os-formula-review-container";
   data-type: "composite-page";
-  data-uuid-key: "formula-review"; }
+  data-uuid-key: ".formula-review"; }
 :pass(2) div[data-type="chapter"] section.practice {
   /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
   content: nodes(sectionHeaderNode) content();
@@ -590,7 +590,7 @@
   content: pending(practice-TOCOMPOSITE);
   class: "os-eoc os-practice-container";
   data-type: "composite-page";
-  data-uuid-key: "practice"; }
+  data-uuid-key: ".practice"; }
 :pass(2) div[data-type="chapter"] section.bring-together-exercises {
   move-to: bring-together-exercises-TOCOMPOSITE; }
   :pass(2) div[data-type="chapter"] section.bring-together-exercises > [data-type="title"] {
@@ -601,7 +601,7 @@
   content: pending(bring-together-exercises-TOCOMPOSITE);
   class: "os-eoc os-bring-together-exercises-container";
   data-type: "composite-page";
-  data-uuid-key: "bring-together-exercises"; }
+  data-uuid-key: ".bring-together-exercises"; }
 :pass(2) div[data-type="chapter"] section.free-response {
   /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
   content: nodes(sectionHeaderNode) content();
@@ -614,7 +614,7 @@
   content: pending(free-response-TOCOMPOSITE);
   class: "os-eoc os-free-response-container";
   data-type: "composite-page";
-  data-uuid-key: "free-response"; }
+  data-uuid-key: ".free-response"; }
 :pass(2) div[data-type="chapter"] section.bring-together-homework {
   move-to: bring-together-homework-TOCOMPOSITE; }
   :pass(2) div[data-type="chapter"] section.bring-together-homework > [data-type="title"] {
@@ -625,7 +625,7 @@
   content: pending(bring-together-homework-TOCOMPOSITE);
   class: "os-eoc os-bring-together-homework-container";
   data-type: "composite-page";
-  data-uuid-key: "bring-together-homework"; }
+  data-uuid-key: ".bring-together-homework"; }
 :pass(2) div[data-type="chapter"] section.references {
   /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
   content: nodes(sectionHeaderNode) content();
@@ -638,7 +638,7 @@
   content: pending(references-TOCOMPOSITE);
   class: "os-eoc os-references-container";
   data-type: "composite-page";
-  data-uuid-key: "references"; }
+  data-uuid-key: ".references"; }
 :pass(2) .try [data-type="exercise"]:not(.unnumbered) {
   class: attr(class) " unnumbered"; }
 :pass(2) [data-type="example"] [data-type="exercise"]:not(.unnumbered) {
@@ -733,14 +733,13 @@
   content: pending(solutions-TOCOMPOSITE);
   class: "os-eoc os-solutions-container";
   data-type: "composite-page";
-  data-uuid-key: "chapter-solutions";
-  /* TODO: Is this the correct key? We'll be stuck with it because it is used for generating the collated page uuid's */ }
+  data-uuid-key: "solutions"; }
 :pass(5) body::after {
   container: div;
   content: pending(index-TOCOMPOSITE);
   class: "os-eob os-index-container";
   data-type: "composite-page";
-  data-uuid-key: "index";
+  data-uuid-key: "<index>";
   group-by: span, "span::attr(group-by)", nocase; }
 
 :pass(6) .os-index-container > div.group-by:first-of-type > span.group-label {

--- a/rulesets/output/statistics.css
+++ b/rulesets/output/statistics.css
@@ -550,6 +550,7 @@
   content: pending(glossary-TOCOMPOSITE);
   class: "os-eoc os-glossary-container";
   data-type: "composite-page";
+  data-uuid-key: "glossary";
   sort-by: dl > dt, nocase; }
 :pass(2) div[data-type="chapter"] section.summary {
   /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
@@ -562,7 +563,8 @@
   container: div;
   content: pending(summary-TOCOMPOSITE);
   class: "os-eoc os-summary-container";
-  data-type: "composite-page"; }
+  data-type: "composite-page";
+  data-uuid-key: "summary"; }
 :pass(2) div[data-type="chapter"] section.formula-review {
   /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
   content: nodes(sectionHeaderNode) content();
@@ -574,7 +576,8 @@
   container: div;
   content: pending(formula-review-TOCOMPOSITE);
   class: "os-eoc os-formula-review-container";
-  data-type: "composite-page"; }
+  data-type: "composite-page";
+  data-uuid-key: "formula-review"; }
 :pass(2) div[data-type="chapter"] section.practice {
   /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
   content: nodes(sectionHeaderNode) content();
@@ -586,7 +589,8 @@
   container: div;
   content: pending(practice-TOCOMPOSITE);
   class: "os-eoc os-practice-container";
-  data-type: "composite-page"; }
+  data-type: "composite-page";
+  data-uuid-key: "practice"; }
 :pass(2) div[data-type="chapter"] section.bring-together-exercises {
   move-to: bring-together-exercises-TOCOMPOSITE; }
   :pass(2) div[data-type="chapter"] section.bring-together-exercises > [data-type="title"] {
@@ -596,7 +600,8 @@
   container: div;
   content: pending(bring-together-exercises-TOCOMPOSITE);
   class: "os-eoc os-bring-together-exercises-container";
-  data-type: "composite-page"; }
+  data-type: "composite-page";
+  data-uuid-key: "bring-together-exercises"; }
 :pass(2) div[data-type="chapter"] section.free-response {
   /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
   content: nodes(sectionHeaderNode) content();
@@ -608,7 +613,8 @@
   container: div;
   content: pending(free-response-TOCOMPOSITE);
   class: "os-eoc os-free-response-container";
-  data-type: "composite-page"; }
+  data-type: "composite-page";
+  data-uuid-key: "free-response"; }
 :pass(2) div[data-type="chapter"] section.bring-together-homework {
   move-to: bring-together-homework-TOCOMPOSITE; }
   :pass(2) div[data-type="chapter"] section.bring-together-homework > [data-type="title"] {
@@ -618,7 +624,8 @@
   container: div;
   content: pending(bring-together-homework-TOCOMPOSITE);
   class: "os-eoc os-bring-together-homework-container";
-  data-type: "composite-page"; }
+  data-type: "composite-page";
+  data-uuid-key: "bring-together-homework"; }
 :pass(2) div[data-type="chapter"] section.references {
   /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
   content: nodes(sectionHeaderNode) content();
@@ -630,7 +637,8 @@
   container: div;
   content: pending(references-TOCOMPOSITE);
   class: "os-eoc os-references-container";
-  data-type: "composite-page"; }
+  data-type: "composite-page";
+  data-uuid-key: "references"; }
 :pass(2) .try [data-type="exercise"]:not(.unnumbered) {
   class: attr(class) " unnumbered"; }
 :pass(2) [data-type="example"] [data-type="exercise"]:not(.unnumbered) {
@@ -724,12 +732,15 @@
   container: div;
   content: pending(solutions-TOCOMPOSITE);
   class: "os-eoc os-solutions-container";
-  data-type: "composite-page"; }
+  data-type: "composite-page";
+  data-uuid-key: "chapter-solutions";
+  /* TODO: Is this the correct key? We'll be stuck with it because it is used for generating the collated page uuid's */ }
 :pass(5) body::after {
   container: div;
   content: pending(index-TOCOMPOSITE);
   class: "os-eob os-index-container";
   data-type: "composite-page";
+  data-uuid-key: "index";
   group-by: span, "span::attr(group-by)", nocase; }
 
 :pass(6) .os-index-container > div.group-by:first-of-type > span.group-label {
@@ -860,8 +871,6 @@
   container: h1;
   data-type: "document-title";
   content: pending(h1-TITLECONTAINER); }
-:pass(6) div[data-type="composite-page"] {
-  attr-id: uuid() "@1"; }
 :pass(6) div[data-type='chapter'] > h1[data-type='document-title'] {
   counter-increment: chapTitleNum;
   attr-id: "chapTitle" counter(chapTitleNum); }


### PR DESCRIPTION
UUID's were being autogenerated each time a book was baked. This helps make them consistent by providing a key to base the uuid-generation off of.

The logic for determining which uuid to use should be:

`collated_page_uuid = if type-of(@id) is 'uuid' then @id else uuid5(parent_uuid, @id || @data-uuid-key || @class || title/text())`