### PR TITLE
exercise data-type for ap-biology

### DIFF
--- a/rulesets/books/ap-biology/styleguide/book.composite.ap-test-prep.html
+++ b/rulesets/books/ap-biology/styleguide/book.composite.ap-test-prep.html
@@ -7,7 +7,7 @@
     <!-- Markup starts here -->
     <section class="ap-test-prep">
       <h3 data-type="title">Test Prep for AP<sup>&#174;</sup> Courses</h3>
-      <div data-type="exercise os-exercise" id="ex1">
+      <div data-type="exercise" class="os-exercise" id="ex1">
         <div data-type="problem">
           <p>What is 2+2?</p>
         </div>
@@ -24,7 +24,7 @@
     <!-- Markup starts here -->
     <section class="ap-test-prep">
       <h3 data-type="title">Test Prep for AP<sup>&#174;</sup> Courses</h3>
-      <div data-type="exercise os-exercise" id="ex2">
+      <div data-type="exercise" class="os-exercise" id="ex2">
         <div data-type="problem">
           <p>What is 3+3?</p>
         </div>

--- a/rulesets/output/ap-biology.css
+++ b/rulesets/output/ap-biology.css
@@ -9,7 +9,7 @@
 
   Markup: ./book.page.html-baked.html
 
-  Style guide: book.page
+  Style guide: book.1-page
 */
 /*
   Page Elements
@@ -204,7 +204,7 @@
   - aren't numbered in the content and in the TOC (the chapters and sections are)
   - follow the same rules as a regular data-type="page" (header hierarchy, metadata, etc.)
 
-  Style guide: book.composite
+  Style guide: book.2-composite
 */
 /*
   Chapter
@@ -215,7 +215,7 @@
 
   Markup: ./book.chapter.html-baked.html
 
-  Style guide: book.chapter
+  Style guide: book.0-chapter
 */
 /*
   Unnumbered Content


### PR DESCRIPTION
It seems to be a small typo from #135. I noticed it as part of #144. is the class `os-exercise` in the CNXML content or is it not actually used?

/cc @zroehr 