### PR TITLE
Fix issue #242

### DIFF
--- a/rulesets/books/_common-stuff.scss
+++ b/rulesets/books/_common-stuff.scss
@@ -35,5 +35,7 @@ $Config_TargetLabels: (
   (selector: '[data-type="chapter"] :not(figure) > figure:not(.unnumbered)',  labelText: "Figure " counter(chapter) "." counter(figure)),
   (selector: '[data-type="appendix"] :not(table) > table:not(.unnumbered)',   labelText: "Table " counter(appendix, upper-alpha) "." counter(table)),
   (selector: '[data-type="appendix"] :not(figure) > figure:not(.unnumbered)', labelText: "Figure " counter(appendix, upper-alpha) "." counter(figure)),
+  (selector: '[data-type="appendix"] > table:not(.unnumbered)',   labelText: "Table " counter(appendix, upper-alpha) "." counter(table)),
+  (selector: '[data-type="appendix"] > figure:not(.unnumbered)', labelText: "Figure " counter(appendix, upper-alpha) "." counter(figure)),
   // BUG up here too
 );


### PR DESCRIPTION
Selectors for tables/figures that are direct children of appendices were added to numbering to fix issue #220. This PR adds the same selectors to target labeling.