### PR TITLE
add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,19 +21,16 @@
     You probably won't need a second paragraph. But it's here when you need it.
 ```
 
-## Reference issues when committing
-Please use the issue number within commit messages, for example `Fix #220`. This will create a link within the PR to the issue itself and help track changes. Typically, only referencing the issue is enough but if there are multiple fixes for one issue, you may add a descriptive comment when needed, for example `Fix #220 - add table numbers back to appendix`.
-
 ## Review your own code before pushing
 Before you push, check your code and squash any superfluous commits, such as fast forward merge commits. 
 
-## Comment on the issue when addressed in the PR
-When the fix for an issue has been pushed to github and is ready for review, go to the issue and reference the PR in the comments. For example you may have something like `Addressed in PR #237`. This is also a good time to mention anything that the tester should be aware of or anything we may need to keep track of later on.
+## Update the PR description with the Issue number when addressing
+When the fix for an issue has been pushed to github update the PR description to link to the Issue number. For example, you may have something like `Fixes #123`. This is also a good place to mention anything that the tester should be aware of or anything we may need to keep track of later on. If the issue is in a different repository, you can write `Fixes openstax/tutor-js#123`.
 
 At this stage, the workflow is:
 
-  - find issue `#220` on github
-  - add a comment saying `Addressed in PR #237`
+  - find your Pull Request `#234` on GitHub
+  - edit the Pull Request description to say `Fixes #123`
 
 ## Ask for peer code review 
 After all commits have been pushed for your topic branch, assign `@helenemccarron` and `@philschatz` to the Reviewers section of the PR. They will also review any CI test failures. 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,28 +1,20 @@
-# `cnx-recipes` Contributing Guidelines
+# :+1::tada: Thanks for Contributing! :tada::+1:
 
+See [openstax/CONTRIBUTING.md](https://github.com/openstax/napkin-notes/CONTRIBUTING.md) for more information!
+
+# Creating a Pull Request or Issue
+
+- include a screenshot of the new stuff in the **Issue/PR description**
+- link to the Ticket/Issue in the Issue/PR **description**
 
 ## Use a topic branch
 *(lifted from [this](https://github.com/puppetlabs/puppet/blob/master/CONTRIBUTING.md))*
 
-* Create a topic branch from where you want to base your work.
-  * This is usually the master branch.
-  * Only target release branches if you are certain your fix must be on that
-    branch.
-  * Please avoid working directly on the `master` branch.
-* Make commits of logical units.
-* Check for unnecessary whitespace with `git diff --check` before committing.
-* Make sure your commit messages are in the proper format.
-
-```
-    Add additional snippet for unnumbered appendix tables
-
-    If needed, the first paragraph of a longer commit message goes here. It's a really cool paragraph.
-
-    You probably won't need a second paragraph. But it's here when you need it.
-```
+- Create a topic branch from where you want to base your work (usually the `master` branch).
+- Make commits of logical units.
 
 ## Review your own code before pushing
-Before you push, check your code and squash any superfluous commits, such as fast forward merge commits. 
+Before you push, run `./script/test`, and check your code (squash any superfluous commits, such as fast forward merge commits). 
 
 ## Update the PR description with the Issue number when addressing
 When the fix for an issue has been pushed to github update the PR description to link to the Issue number. For example, you may have something like `Fixes #123`. This is also a good place to mention anything that the tester should be aware of or anything we may need to keep track of later on. If the issue is in a different repository, you can write `Fixes openstax/tutor-js#123`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # :+1::tada: Thanks for Contributing! :tada::+1:
 
-See [openstax/CONTRIBUTING.md](https://github.com/openstax/napkin-notes/CONTRIBUTING.md) for more information!
+See [openstax/CONTRIBUTING.md](https://github.com/openstax/napkin-notes/blob/master/CONTRIBUTING.md) for more information!
 
 # Creating a Pull Request or Issue
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,9 @@ See [openstax/CONTRIBUTING.md](https://github.com/openstax/napkin-notes/blob/mas
 ## Review your own code before pushing
 Before you push, run `./script/test`, and check your code (squash any superfluous commits, such as fast forward merge commits). 
 
+##Give your PR a descriptive title
+A title like "Resolves #234" is not very helpful because it is neither descriptive of your change set, nor does github link the issue from the PR title.
+
 ## Update the PR description with the Issue number when addressing
 When the fix for an issue has been pushed to github update the PR description to link to the Issue number. For example, you may have something like `Fixes #123`. This is also a good place to mention anything that the tester should be aware of or anything we may need to keep track of later on. If the issue is in a different repository, you can write `Fixes openstax/tutor-js#123`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,49 @@
+# `cnx-recipes` Contributing Guidelines
+
+
+## Use a topic branch
+*(lifted from [this](https://github.com/puppetlabs/puppet/blob/master/CONTRIBUTING.md))*
+
+* Create a topic branch from where you want to base your work.
+  * This is usually the master branch.
+  * Only target release branches if you are certain your fix must be on that
+    branch.
+  * Please avoid working directly on the `master` branch.
+* Make commits of logical units.
+* Check for unnecessary whitespace with `git diff --check` before committing.
+* Make sure your commit messages are in the proper format.
+
+```
+    Add additional snippet for unnumbered appendix tables
+
+    If needed, the first paragraph of a longer commit message goes here. It's a really cool paragraph.
+
+    You probably won't need a second paragraph. But it's here when you need it.
+```
+
+## Reference issues when committing
+Please use the issue number within commit messages, for example `Fix #220`. This will create a link within the PR to the issue itself and help track changes. Typically, only referencing the issue is enough but if there are multiple fixes for one issue, you may add a descriptive comment when needed, for example `Fix #220 - add table numbers back to appendix`.
+
+## Review your own code before pushing
+Before you push, check your code and squash any superfluous commits, such as fast forward merge commits. 
+
+## Comment on the issue when addressed in the PR
+When the fix for an issue has been pushed to github and is ready for review, go to the issue and reference the PR in the comments. For example you may have something like `Addressed in PR #237`. This is also a good time to mention anything that the tester should be aware of or anything we may need to keep track of later on.
+
+At this stage, the workflow is:
+
+  - find issue `#220` on github
+  - add a comment saying `Addressed in PR #237`
+
+## Ask for peer code review 
+After all commits have been pushed for your topic branch, assign `@helenemccarron` and `@philschatz` to the Reviewers section of the PR. They will also review any CI test failures. 
+
+## Assign the PR to QA
+After all reviewers have approved changes, assign the PR to the QA person who initially reported the issue(s) (Kerwin `@kerwinso` or Alan `@stackblocks`). *Note*: please use the Assignees section, not the Reviewers section.
+
+## Dev testing
+Fixes for individual issues are verified by the assigned tester in the appropriate environment. If any problems are found, the issue is updated with comments and screen captures as necessary, and reassigned to the dev that created the fix. When the issue has been verified, it is closed. Only members of the QA team should be closing issues.
+
+## Merge
+QA will merge your branch to master after they have verified the fixes addressed in that branch. Typically they will also delete the topic branch after successful merge.
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ See [openstax/CONTRIBUTING.md](https://github.com/openstax/napkin-notes/blob/mas
 ## Review your own code before pushing
 Before you push, run `./script/test`, and check your code (squash any superfluous commits, such as fast forward merge commits). 
 
-##Give your PR a descriptive title
+## Give your PR a descriptive title
 A title like "Resolves #234" is not very helpful because it is neither descriptive of your change set, nor does github link the issue from the PR title.
 
 ## Update the PR description with the Issue number when addressing
@@ -27,14 +27,16 @@ At this stage, the workflow is:
   - find your Pull Request `#234` on GitHub
   - edit the Pull Request description to say `Fixes #123`
 
+Openstax staff should also paste a link to the PR into the respective Trello card where applicable.
+
 ## Ask for peer code review 
 After all commits have been pushed for your topic branch, assign `@helenemccarron` and `@philschatz` to the Reviewers section of the PR. They will also review any CI test failures. 
 
 ## Assign the PR to QA
-After all reviewers have approved changes, assign the PR to the QA person who initially reported the issue(s) (Kerwin `@kerwinso` or Alan `@stackblocks`). *Note*: please use the Assignees section, not the Reviewers section.
+After all reviewers have approved changes, the final reviewer will assign the PR to the QA person who initially reported the issue(s) (Kerwin `@kerwinso` or Alan `@stackblocks`). *Note*: please use the Assignees section, not the Reviewers section. If the final reviewer is lagging, the dev who originally opened the PR may either nag them or assign the PR to QA themselves (or both).
 
 ## Dev testing
-Fixes for individual issues are verified by the assigned tester in the appropriate environment. If any problems are found, the issue is updated with comments and screen captures as necessary, and reassigned to the dev that created the fix. When the issue has been verified, it is closed. Only members of the QA team should be closing issues.
+Fixes for individual issues are verified by the assigned tester in the appropriate environment. If any problems are found, the issue is updated with comments and screen captures as necessary, and reassigned to the dev that created the fix. When the issue has been verified, it is closed. Typically only members of the QA team should be closing issues.
 
 ## Merge
 QA will merge your branch to master after they have verified the fixes addressed in that branch. Typically they will also delete the topic branch after successful merge.


### PR DESCRIPTION
An attempt to document some of the workflow decisions we've recently discussed in scrum. 

This flow primarily applies to PRs where a QA person is involved. We can add that note if desired.