### PR TITLE
define CSS to use the XHTML namespace

### DIFF
--- a/recipes/books/_example/_config.scss
+++ b/recipes/books/_example/_config.scss
@@ -71,7 +71,7 @@ $_compoundTestPrep: (
   Style guide: book.composite.practice
 */
 $Config_ChapterCompositePages: (
-  (className: "glossary",        specialPageType: $PAGE_GLOSSARY, sortBy: "dl > dt",   name: "Key Terms"),
+  (className: "glossary",        specialPageType: $PAGE_GLOSSARY, sortBy: "xhtml|dl > xhtml|dt",   name: "Key Terms"),
   (className: "summary",         clusterBy: $CLUSTER_SECTION,                               name: "Chapter Review"),
   (className: "formula-review",  clusterBy: $CLUSTER_SECTION,                               name: "Formula Review"),
   (className: "practice",        clusterBy: $CLUSTER_SECTION, hasSolutions: true,           name: "Practice"),

--- a/recipes/books/_generator.scss
+++ b/recipes/books/_generator.scss
@@ -1,5 +1,8 @@
 // This is the ROOT of the output CSS file that is generated.
 
+// Set the namespace to be XHTML
+@namespace "http://www.w3.org/1999/xhtml";
+
 $_symbolsSectionTitle: "Symbols";
 
 //Currently, none of the books have composite chapters
@@ -296,7 +299,7 @@ $_symbolsSectionTitle: "Symbols";
 :pass(7) {
   //After: prepIndexTerms, createBookComposites
   @include modify_addIndexSymbolGroup("index", $_symbolsSectionTitle);
-  
+
   //After: composite page creation
   @include count_countChapters(chapter);
   @include count_countAppendices(appendix);
@@ -315,7 +318,7 @@ $_symbolsSectionTitle: "Symbols";
     @else if  $resetAt == $RESET_COMPOSITE_PAGE { $resetSel: '[data-type="composite-page"]'; }
     @else { @error 'BUG: Invalid enum'; }
     @include count_countEOCExercises(exercise, $resetSel);
-    
+
     @if $numberAt == $NUMBER_AFTER_MOVE {
        @include number_numberEOCExercises($titleContent, $titleContent);
     } @else if $numberAt == $NUMBER_BEFORE_MOVE {
@@ -347,7 +350,7 @@ $_symbolsSectionTitle: "Symbols";
   @include modify_chapterAutoID();
   @include count_countExercisesInContentButNotInExample(exerciseMaybeInContent);
   // This has to run before number_numberEOCExercises because its selector is more general than the EOC selector
-  @include number_numberContentExercises($Config_ContentExercise_TitleContent, $Config_ContentSolution_TitleContent); 
+  @include number_numberContentExercises($Config_ContentExercise_TitleContent, $Config_ContentSolution_TitleContent);
 
   @include count_countTables(table);
   @include count_countFigures(figure);

--- a/recipes/books/_generator.scss
+++ b/recipes/books/_generator.scss
@@ -1,7 +1,7 @@
 // This is the ROOT of the output CSS file that is generated.
 
-// Set the namespace to be XHTML
-@namespace "http://www.w3.org/1999/xhtml";
+// Declare a namespace prefix for use in `sort-by:``
+@namespace xhtml "http://www.w3.org/1999/xhtml";
 
 $_symbolsSectionTitle: "Symbols";
 

--- a/recipes/books/biology/_config.scss
+++ b/recipes/books/biology/_config.scss
@@ -52,7 +52,7 @@
 */
 
 // These are defined as variables because they are used in ap-biology
-$BiologyPageKeyTerms        : (className: "glossary",        clusterBy: $CLUSTER_NONE, specialPageType: $PAGE_GLOSSARY, sortBy: "dl > dt", name: "Key Terms");
+$BiologyPageKeyTerms        : (className: "glossary",        clusterBy: $CLUSTER_NONE, specialPageType: $PAGE_GLOSSARY, sortBy: "xhtml|dl > xhtml|dt", name: "Key Terms");
 $BiologyPageSummary         : (className: "summary",         clusterBy: $CLUSTER_SECTION, name: "Chapter Summary");
 $BiologyPageArtConnection   : (className: "art-exercise",    clusterBy: $CLUSTER_NONE, hasSolutions: true,     name: "Art Connection Questions");
 $BiologyPageReviewQuestions : (className: "multiple-choice", clusterBy: $CLUSTER_NONE, hasSolutions: true,     name: "Review Questions");

--- a/recipes/books/economics/_config.scss
+++ b/recipes/books/economics/_config.scss
@@ -79,7 +79,7 @@
   Style guide: book.2-composite.references
 */
 $Config_ChapterCompositePages: (
-  (className: "glossary",             clusterBy: $CLUSTER_NONE, specialPageType: $PAGE_GLOSSARY, sortBy: "dl > dt", name: "Key Terms"),
+  (className: "glossary",             clusterBy: $CLUSTER_NONE, specialPageType: $PAGE_GLOSSARY, sortBy: "xhtml|dl > xhtml|dt", name: "Key Terms"),
   (className: "summary",              clusterBy: $CLUSTER_SECTION, hasSolutions: false,  name: "Key Concepts and Summary"),
   (className: "self-check-questions", clusterBy: $CLUSTER_NONE,    hasSolutions: true,   name: "Self-Check Questions"),
   (className: "review-questions",     clusterBy: $CLUSTER_NONE,    hasSolutions: false,  name: "Review Questions"),

--- a/recipes/books/hs-physics/_config.scss
+++ b/recipes/books/hs-physics/_config.scss
@@ -133,7 +133,7 @@ $_testPrepChildPages: (
 
 
 $Config_ChapterCompositePages: (
-  (className: "glossary",       clusterBy: $CLUSTER_NONE, specialPageType: $PAGE_GLOSSARY, sortBy: "dl > dt", name: "Key Terms"),
+  (className: "glossary",       clusterBy: $CLUSTER_NONE, specialPageType: $PAGE_GLOSSARY, sortBy: "xhtml|dl > xhtml|dt", name: "Key Terms"),
   (className: "summary",        clusterBy: $CLUSTER_NONE, sectionSeparated: false, name: "Section Summary"),
   (className: "key-equations",  clusterBy: $CLUSTER_NONE, sectionSeparated: false, name: "Key Equations"),
 

--- a/recipes/books/physics/_config.scss
+++ b/recipes/books/physics/_config.scss
@@ -31,7 +31,7 @@
 
   Style guide: book.2-composite.problems
 */
-$PhysicsPageKeyTerms           : (className: "glossary",              clusterBy: $CLUSTER_NONE, specialPageType: $PAGE_GLOSSARY, sortBy: "dl > dt", name: "Glossary");
+$PhysicsPageKeyTerms           : (className: "glossary",              clusterBy: $CLUSTER_NONE, specialPageType: $PAGE_GLOSSARY, sortBy: "xhtml|dl > xhtml|dt", name: "Glossary");
 $PhysicsPageSummary            : (className: "section-summary",       clusterBy: $CLUSTER_SECTION, name: "Section Summary");
 $PhysicsPageConceptualQuestions: (className: "conceptual-questions",  clusterBy: $CLUSTER_SECTION, name: "Conceptual Questions");
 $PhysicsPageProblems           : (className: "problems-exercises",    clusterBy: $CLUSTER_SECTION, name: "Problems & Exercises");

--- a/recipes/books/statistics/_config.scss
+++ b/recipes/books/statistics/_config.scss
@@ -77,7 +77,7 @@ Formula Review page
   Style guide: book.composite.solutions
 */
 $Config_ChapterCompositePages: (
-  (className: "glossary",                 clusterBy: $CLUSTER_NONE, specialPageType: $PAGE_GLOSSARY, sortBy: "dl > dt",    name: "Key Terms"),
+  (className: "glossary",                 clusterBy: $CLUSTER_NONE, specialPageType: $PAGE_GLOSSARY, sortBy: "xhtml|dl > xhtml|dt",    name: "Key Terms"),
   (className: "summary",                  clusterBy: $CLUSTER_SECTION,                               name: "Chapter Review"),
   (className: "formula-review",           clusterBy: $CLUSTER_SECTION,                               name: "Formula Review"),
   (className: "practice",                 clusterBy: $CLUSTER_SECTION, hasSolutions: true,           name: "Practice"),

--- a/recipes/books/u-physics/_config.scss
+++ b/recipes/books/u-physics/_config.scss
@@ -87,7 +87,7 @@
 */
 
 $_chapterReviewChildPages: (
-  (className: "glossary",             clusterBy: $CLUSTER_NONE, specialPageType: $PAGE_GLOSSARY, sortBy: "dl > dt", name: "Key Terms"),
+  (className: "glossary",             clusterBy: $CLUSTER_NONE, specialPageType: $PAGE_GLOSSARY, sortBy: "xhtml|dl > xhtml|dt", name: "Key Terms"),
   (className: "key-equations", clusterBy: $CLUSTER_NONE,    hasSolutions: false,   name: "Key Equations"),
   (className: "key-concepts",              clusterBy: $CLUSTER_SECTION, hasSolutions: false,  name: "Summary"),
   (className: "review-conceptual-questions", clusterBy: $CLUSTER_SECTION,    hasSolutions: true,   name: "Conceptual Questions"),

--- a/recipes/output/TEAap-biology.css
+++ b/recipes/output/TEAap-biology.css
@@ -473,7 +473,7 @@
 
   Style guide: page.note.ost-sciprac-activity
 */
-@namespace "http://www.w3.org/1999/xhtml";
+@namespace xhtml "http://www.w3.org/1999/xhtml";
 :pass(0) div.preface > [data-type="document-title"] {
   container: h1;
   content: content(); }
@@ -1246,7 +1246,7 @@
   class: "os-eoc os-glossary-container";
   data-type: "composite-page";
   data-uuid-key: "<glossary>";
-  sort-by: dl > dt, nocase; }
+  sort-by: xhtml|dl > xhtml|dt, nocase; }
 :pass(2) div[data-type="chapter"] section.summary {
   /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
   content: nodes(sectionHeaderNode) content();

--- a/recipes/output/TEAap-biology.css
+++ b/recipes/output/TEAap-biology.css
@@ -473,6 +473,7 @@
 
   Style guide: page.note.ost-sciprac-activity
 */
+@namespace "http://www.w3.org/1999/xhtml";
 :pass(0) div.preface > [data-type="document-title"] {
   container: h1;
   content: content(); }

--- a/recipes/output/TEAap-physics.css
+++ b/recipes/output/TEAap-physics.css
@@ -316,7 +316,7 @@
 
   Style guide: book.composite.ap-test-prep
 */
-@namespace "http://www.w3.org/1999/xhtml";
+@namespace xhtml "http://www.w3.org/1999/xhtml";
 :pass(0) div.preface > [data-type="document-title"] {
   container: h1;
   content: content(); }
@@ -535,7 +535,7 @@
   class: "os-eoc os-glossary-container";
   data-type: "composite-page";
   data-uuid-key: "<glossary>";
-  sort-by: dl > dt, nocase; }
+  sort-by: xhtml|dl > xhtml|dt, nocase; }
 :pass(2) div[data-type="chapter"] section.section-summary {
   /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
   content: nodes(sectionHeaderNode) content();

--- a/recipes/output/TEAap-physics.css
+++ b/recipes/output/TEAap-physics.css
@@ -316,6 +316,7 @@
 
   Style guide: book.composite.ap-test-prep
 */
+@namespace "http://www.w3.org/1999/xhtml";
 :pass(0) div.preface > [data-type="document-title"] {
   container: h1;
   content: content(); }

--- a/recipes/output/TEAeconomics.css
+++ b/recipes/output/TEAeconomics.css
@@ -381,6 +381,7 @@
 
   Style guide: page.note.workout
 */
+@namespace "http://www.w3.org/1999/xhtml";
 :pass(0) div.preface > [data-type="document-title"] {
   container: h1;
   content: content(); }

--- a/recipes/output/TEAeconomics.css
+++ b/recipes/output/TEAeconomics.css
@@ -381,7 +381,7 @@
 
   Style guide: page.note.workout
 */
-@namespace "http://www.w3.org/1999/xhtml";
+@namespace xhtml "http://www.w3.org/1999/xhtml";
 :pass(0) div.preface > [data-type="document-title"] {
   container: h1;
   content: content(); }
@@ -712,7 +712,7 @@
   class: "os-eoc os-glossary-container";
   data-type: "composite-page";
   data-uuid-key: "<glossary>";
-  sort-by: dl > dt, nocase; }
+  sort-by: xhtml|dl > xhtml|dt, nocase; }
 :pass(2) div[data-type="chapter"] section.summary {
   /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
   content: nodes(sectionHeaderNode) content();

--- a/recipes/output/TEAhs-physics.css
+++ b/recipes/output/TEAhs-physics.css
@@ -517,7 +517,7 @@
 
   Style guide: page.exercise.grasp-check
 */
-@namespace "http://www.w3.org/1999/xhtml";
+@namespace xhtml "http://www.w3.org/1999/xhtml";
 :pass(0) div.preface > [data-type="document-title"] {
   container: h1;
   content: content(); }
@@ -1256,7 +1256,7 @@
   class: "os-eoc os-glossary-container";
   data-type: "composite-page";
   data-uuid-key: "<glossary>";
-  sort-by: dl > dt, nocase; }
+  sort-by: xhtml|dl > xhtml|dt, nocase; }
 :pass(2) div[data-type="chapter"] section.summary {
   move-to: summary-TOCOMPOSITE; }
   :pass(2) div[data-type="chapter"] section.summary > [data-type="title"] {

--- a/recipes/output/TEAhs-physics.css
+++ b/recipes/output/TEAhs-physics.css
@@ -517,6 +517,7 @@
 
   Style guide: page.exercise.grasp-check
 */
+@namespace "http://www.w3.org/1999/xhtml";
 :pass(0) div.preface > [data-type="document-title"] {
   container: h1;
   content: content(); }

--- a/recipes/output/TEAstatistics.css
+++ b/recipes/output/TEAstatistics.css
@@ -397,6 +397,7 @@ Formula Review page
 
   Style guide: page.note.chapter-objectives
 */
+@namespace "http://www.w3.org/1999/xhtml";
 :pass(0) div.preface > [data-type="document-title"] {
   container: h1;
   content: content(); }

--- a/recipes/output/TEAstatistics.css
+++ b/recipes/output/TEAstatistics.css
@@ -397,7 +397,7 @@ Formula Review page
 
   Style guide: page.note.chapter-objectives
 */
-@namespace "http://www.w3.org/1999/xhtml";
+@namespace xhtml "http://www.w3.org/1999/xhtml";
 :pass(0) div.preface > [data-type="document-title"] {
   container: h1;
   content: content(); }
@@ -818,7 +818,7 @@ Formula Review page
   class: "os-eoc os-glossary-container";
   data-type: "composite-page";
   data-uuid-key: "<glossary>";
-  sort-by: dl > dt, nocase; }
+  sort-by: xhtml|dl > xhtml|dt, nocase; }
 :pass(2) div[data-type="chapter"] section.summary {
   /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
   content: nodes(sectionHeaderNode) content();

--- a/recipes/output/ap-biology.css
+++ b/recipes/output/ap-biology.css
@@ -473,6 +473,7 @@
 
   Style guide: page.note.ost-sciprac-activity
 */
+@namespace "http://www.w3.org/1999/xhtml";
 :pass(0) div.preface > [data-type="document-title"] {
   container: h1;
   content: content(); }

--- a/recipes/output/ap-biology.css
+++ b/recipes/output/ap-biology.css
@@ -473,7 +473,7 @@
 
   Style guide: page.note.ost-sciprac-activity
 */
-@namespace "http://www.w3.org/1999/xhtml";
+@namespace xhtml "http://www.w3.org/1999/xhtml";
 :pass(0) div.preface > [data-type="document-title"] {
   container: h1;
   content: content(); }
@@ -1250,7 +1250,7 @@
   class: "os-eoc os-glossary-container";
   data-type: "composite-page";
   data-uuid-key: "<glossary>";
-  sort-by: dl > dt, nocase; }
+  sort-by: xhtml|dl > xhtml|dt, nocase; }
 :pass(2) div[data-type="chapter"] section.summary {
   /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
   content: nodes(sectionHeaderNode) content();

--- a/recipes/output/ap-physics.css
+++ b/recipes/output/ap-physics.css
@@ -316,6 +316,7 @@
 
   Style guide: book.composite.ap-test-prep
 */
+@namespace "http://www.w3.org/1999/xhtml";
 :pass(0) div.preface > [data-type="document-title"] {
   container: h1;
   content: content(); }

--- a/recipes/output/ap-physics.css
+++ b/recipes/output/ap-physics.css
@@ -316,7 +316,7 @@
 
   Style guide: book.composite.ap-test-prep
 */
-@namespace "http://www.w3.org/1999/xhtml";
+@namespace xhtml "http://www.w3.org/1999/xhtml";
 :pass(0) div.preface > [data-type="document-title"] {
   container: h1;
   content: content(); }
@@ -541,7 +541,7 @@
   class: "os-eoc os-glossary-container";
   data-type: "composite-page";
   data-uuid-key: "<glossary>";
-  sort-by: dl > dt, nocase; }
+  sort-by: xhtml|dl > xhtml|dt, nocase; }
 :pass(2) div[data-type="chapter"] section.section-summary {
   /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
   content: nodes(sectionHeaderNode) content();

--- a/recipes/output/biology.css
+++ b/recipes/output/biology.css
@@ -367,6 +367,7 @@
 
   Style guide: page.note.link-to-learning
 */
+@namespace "http://www.w3.org/1999/xhtml";
 :pass(0) div.preface > [data-type="document-title"] {
   container: h1;
   content: content(); }

--- a/recipes/output/biology.css
+++ b/recipes/output/biology.css
@@ -367,7 +367,7 @@
 
   Style guide: page.note.link-to-learning
 */
-@namespace "http://www.w3.org/1999/xhtml";
+@namespace xhtml "http://www.w3.org/1999/xhtml";
 :pass(0) div.preface > [data-type="document-title"] {
   container: h1;
   content: content(); }
@@ -808,7 +808,7 @@
   class: "os-eoc os-glossary-container";
   data-type: "composite-page";
   data-uuid-key: "<glossary>";
-  sort-by: dl > dt, nocase; }
+  sort-by: xhtml|dl > xhtml|dt, nocase; }
 :pass(2) div[data-type="chapter"] section.summary {
   /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
   content: nodes(sectionHeaderNode) content();

--- a/recipes/output/economics.css
+++ b/recipes/output/economics.css
@@ -381,6 +381,7 @@
 
   Style guide: page.note.workout
 */
+@namespace "http://www.w3.org/1999/xhtml";
 :pass(0) div.preface > [data-type="document-title"] {
   container: h1;
   content: content(); }

--- a/recipes/output/economics.css
+++ b/recipes/output/economics.css
@@ -381,7 +381,7 @@
 
   Style guide: page.note.workout
 */
-@namespace "http://www.w3.org/1999/xhtml";
+@namespace xhtml "http://www.w3.org/1999/xhtml";
 :pass(0) div.preface > [data-type="document-title"] {
   container: h1;
   content: content(); }
@@ -718,7 +718,7 @@
   class: "os-eoc os-glossary-container";
   data-type: "composite-page";
   data-uuid-key: "<glossary>";
-  sort-by: dl > dt, nocase; }
+  sort-by: xhtml|dl > xhtml|dt, nocase; }
 :pass(2) div[data-type="chapter"] section.summary {
   /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
   content: nodes(sectionHeaderNode) content();

--- a/recipes/output/physics.css
+++ b/recipes/output/physics.css
@@ -307,6 +307,7 @@
 
   Style guide: page.note.chapter-objectives
 */
+@namespace "http://www.w3.org/1999/xhtml";
 :pass(0) div.preface > [data-type="document-title"] {
   container: h1;
   content: content(); }

--- a/recipes/output/physics.css
+++ b/recipes/output/physics.css
@@ -307,7 +307,7 @@
 
   Style guide: page.note.chapter-objectives
 */
-@namespace "http://www.w3.org/1999/xhtml";
+@namespace xhtml "http://www.w3.org/1999/xhtml";
 :pass(0) div.preface > [data-type="document-title"] {
   container: h1;
   content: content(); }
@@ -516,7 +516,7 @@
   class: "os-eoc os-glossary-container";
   data-type: "composite-page";
   data-uuid-key: "<glossary>";
-  sort-by: dl > dt, nocase; }
+  sort-by: xhtml|dl > xhtml|dt, nocase; }
 :pass(2) div[data-type="chapter"] section.section-summary {
   /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
   content: nodes(sectionHeaderNode) content();

--- a/recipes/output/statistics.css
+++ b/recipes/output/statistics.css
@@ -397,6 +397,7 @@ Formula Review page
 
   Style guide: page.note.chapter-objectives
 */
+@namespace "http://www.w3.org/1999/xhtml";
 :pass(0) div.preface > [data-type="document-title"] {
   container: h1;
   content: content(); }

--- a/recipes/output/statistics.css
+++ b/recipes/output/statistics.css
@@ -397,7 +397,7 @@ Formula Review page
 
   Style guide: page.note.chapter-objectives
 */
-@namespace "http://www.w3.org/1999/xhtml";
+@namespace xhtml "http://www.w3.org/1999/xhtml";
 :pass(0) div.preface > [data-type="document-title"] {
   container: h1;
   content: content(); }
@@ -824,7 +824,7 @@ Formula Review page
   class: "os-eoc os-glossary-container";
   data-type: "composite-page";
   data-uuid-key: "<glossary>";
-  sort-by: dl > dt, nocase; }
+  sort-by: xhtml|dl > xhtml|dt, nocase; }
 :pass(2) div[data-type="chapter"] section.summary {
   /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
   content: nodes(sectionHeaderNode) content();

--- a/recipes/output/u-physics.css
+++ b/recipes/output/u-physics.css
@@ -398,7 +398,7 @@
 :pass(0) [data-type="note"].check-understanding p:first-child strong:first-child {
   move-to: trash; }
 
-@namespace "http://www.w3.org/1999/xhtml";
+@namespace xhtml "http://www.w3.org/1999/xhtml";
 :pass(0) div.preface > [data-type="document-title"] {
   container: h1;
   content: content(); }

--- a/recipes/output/u-physics.css
+++ b/recipes/output/u-physics.css
@@ -398,6 +398,7 @@
 :pass(0) [data-type="note"].check-understanding p:first-child strong:first-child {
   move-to: trash; }
 
+@namespace "http://www.w3.org/1999/xhtml";
 :pass(0) div.preface > [data-type="document-title"] {
   container: h1;
   content: content(); }


### PR DESCRIPTION
This is related to https://github.com/Connexions/cnx-epub/pull/119 and part of getting cnx-easybake to parse XHTML instead of HTML. 

Easybake does not choke with this code in place.

/cc @reedstrm 