### PR TITLE
Only display 'Symbol' in index when there are terms in its section

### DIFF
--- a/rulesets/mixins/_modify.scss
+++ b/rulesets/mixins/_modify.scss
@@ -106,7 +106,7 @@
   }
 }
 
-/// Modifies the ' Symbols' group name in index
+/// Modifies the ' Symbols' group name in index, should it exist, as the first group-label.
 /// @arg {string} $location - The string of the location where title needs to be added
 /// @arg {string} $name - The string of the title for this group
 /// @group modify

--- a/rulesets/mixins/_modify.scss
+++ b/rulesets/mixins/_modify.scss
@@ -112,7 +112,9 @@
 /// @group modify
 @mixin modify_addIndexSymbolGroup($location, $name) {
   .os-#{$location}-container > div.group-by:first-of-type > span.group-label {
-    content: $name;
+    &:empty {
+      content: $name;
+    }
   }
 }
 /// Adds metadata to the composite pages

--- a/rulesets/mixins/_modify.scss
+++ b/rulesets/mixins/_modify.scss
@@ -106,7 +106,7 @@
   }
 }
 
-/// Modifies the ' Symbols' group to remove the leading spacey
+/// Modifies the ' Symbols' group name in index
 /// @arg {string} $location - The string of the location where title needs to be added
 /// @arg {string} $name - The string of the title for this group
 /// @group modify

--- a/rulesets/mixins/_modify.scss
+++ b/rulesets/mixins/_modify.scss
@@ -100,19 +100,19 @@
         attr-group-by: first-letter(content());
       }
       &:match("^[^a-zA-Z]") {
-        attr-group-by: "";
+        attr-group-by: " Symbols";
       }
     }
   }
 }
 
-/// Adds a title for the first index group. `ie. Symbols`
+/// Modifies the ' Symbols' group to remove the leading spacey
 /// @arg {string} $location - The string of the location where title needs to be added
 /// @arg {string} $name - The string of the title for this group
 /// @group modify
 @mixin modify_addIndexSymbolGroup($location, $name) {
   .os-#{$location}-container > div.group-by:first-of-type > span.group-label {
-    &:empty {
+    &:match("^[ ](Symbols|SYMBOLS)") {
       content: $name;
     }
   }

--- a/rulesets/output/TEAap-biology.css
+++ b/rulesets/output/TEAap-biology.css
@@ -1227,7 +1227,7 @@
     attr-group-by: first-letter(content()); }
   :pass(2) div[data-type="page"] span[data-type="term"]:match("^[^a-zA-Z]"),
   :pass(2) div[data-type="composite-page"] span[data-type="term"]:match("^[^a-zA-Z]") {
-    attr-group-by: ""; }
+    attr-group-by: " Symbols"; }
 :pass(2) div[data-type="page"] > [data-type="document-title"],
 :pass(2) div[data-type="composite-page"] > [data-type="document-title"] {
   node-set: sectionHeaderNode; }
@@ -1443,7 +1443,7 @@
   data-uuid-key: "<index>";
   group-by: span, "span::attr(group-by)", nocase; }
 
-:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label:empty {
+:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label:match("^[ ](Symbols|SYMBOLS)") {
   content: "Symbols"; }
 :pass(7) body {
   counter-reset: chapter; }

--- a/rulesets/output/TEAap-biology.css
+++ b/rulesets/output/TEAap-biology.css
@@ -1443,7 +1443,7 @@
   data-uuid-key: "<index>";
   group-by: span, "span::attr(group-by)", nocase; }
 
-:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label:match("^[^a-zA-Z]") {
+:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label:empty {
   content: "Symbols"; }
 :pass(7) body {
   counter-reset: chapter; }

--- a/rulesets/output/TEAap-biology.css
+++ b/rulesets/output/TEAap-biology.css
@@ -1443,7 +1443,7 @@
   data-uuid-key: "<index>";
   group-by: span, "span::attr(group-by)", nocase; }
 
-:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label {
+:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label:match("^[^a-zA-Z]") {
   content: "Symbols"; }
 :pass(7) body {
   counter-reset: chapter; }

--- a/rulesets/output/TEAap-physics.css
+++ b/rulesets/output/TEAap-physics.css
@@ -710,7 +710,7 @@
   data-uuid-key: "<index>";
   group-by: span, "span::attr(group-by)", nocase; }
 
-:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label:match("^[^a-zA-Z]") {
+:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label:empty {
   content: "Symbols"; }
 :pass(7) body {
   counter-reset: chapter; }

--- a/rulesets/output/TEAap-physics.css
+++ b/rulesets/output/TEAap-physics.css
@@ -710,7 +710,7 @@
   data-uuid-key: "<index>";
   group-by: span, "span::attr(group-by)", nocase; }
 
-:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label {
+:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label:match("^[^a-zA-Z]") {
   content: "Symbols"; }
 :pass(7) body {
   counter-reset: chapter; }

--- a/rulesets/output/TEAap-physics.css
+++ b/rulesets/output/TEAap-physics.css
@@ -514,7 +514,7 @@
     attr-group-by: first-letter(content()); }
   :pass(2) div[data-type="page"] span[data-type="term"]:match("^[^a-zA-Z]"),
   :pass(2) div[data-type="composite-page"] span[data-type="term"]:match("^[^a-zA-Z]") {
-    attr-group-by: ""; }
+    attr-group-by: " Symbols"; }
 :pass(2) div[data-type="page"] > [data-type="document-title"],
 :pass(2) div[data-type="composite-page"] > [data-type="document-title"] {
   node-set: sectionHeaderNode; }
@@ -710,7 +710,7 @@
   data-uuid-key: "<index>";
   group-by: span, "span::attr(group-by)", nocase; }
 
-:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label:empty {
+:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label:match("^[ ](Symbols|SYMBOLS)") {
   content: "Symbols"; }
 :pass(7) body {
   counter-reset: chapter; }

--- a/rulesets/output/TEAeconomics.css
+++ b/rulesets/output/TEAeconomics.css
@@ -934,7 +934,7 @@
   data-uuid-key: "<index>";
   group-by: span, "span::attr(group-by)", nocase; }
 
-:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label {
+:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label:match("^[^a-zA-Z]") {
   content: "Symbols"; }
 :pass(7) body {
   counter-reset: chapter; }

--- a/rulesets/output/TEAeconomics.css
+++ b/rulesets/output/TEAeconomics.css
@@ -693,7 +693,7 @@
     attr-group-by: first-letter(content()); }
   :pass(2) div[data-type="page"] span[data-type="term"]:match("^[^a-zA-Z]"),
   :pass(2) div[data-type="composite-page"] span[data-type="term"]:match("^[^a-zA-Z]") {
-    attr-group-by: ""; }
+    attr-group-by: " Symbols"; }
 :pass(2) div[data-type="page"] > [data-type="document-title"],
 :pass(2) div[data-type="composite-page"] > [data-type="document-title"] {
   node-set: sectionHeaderNode; }
@@ -934,7 +934,7 @@
   data-uuid-key: "<index>";
   group-by: span, "span::attr(group-by)", nocase; }
 
-:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label:empty {
+:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label:match("^[ ](Symbols|SYMBOLS)") {
   content: "Symbols"; }
 :pass(7) body {
   counter-reset: chapter; }

--- a/rulesets/output/TEAeconomics.css
+++ b/rulesets/output/TEAeconomics.css
@@ -934,7 +934,7 @@
   data-uuid-key: "<index>";
   group-by: span, "span::attr(group-by)", nocase; }
 
-:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label:match("^[^a-zA-Z]") {
+:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label:empty {
   content: "Symbols"; }
 :pass(7) body {
   counter-reset: chapter; }

--- a/rulesets/output/TEAhs-physics.css
+++ b/rulesets/output/TEAhs-physics.css
@@ -1571,7 +1571,7 @@
   data-uuid-key: "<index>";
   group-by: span, "span::attr(group-by)", nocase; }
 
-:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label:match("^[^a-zA-Z]") {
+:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label:empty {
   content: "Symbols"; }
 :pass(7) body {
   counter-reset: chapter; }

--- a/rulesets/output/TEAhs-physics.css
+++ b/rulesets/output/TEAhs-physics.css
@@ -1571,7 +1571,7 @@
   data-uuid-key: "<index>";
   group-by: span, "span::attr(group-by)", nocase; }
 
-:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label {
+:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label:match("^[^a-zA-Z]") {
   content: "Symbols"; }
 :pass(7) body {
   counter-reset: chapter; }

--- a/rulesets/output/TEAhs-physics.css
+++ b/rulesets/output/TEAhs-physics.css
@@ -1237,7 +1237,7 @@
     attr-group-by: first-letter(content()); }
   :pass(2) div[data-type="page"] span[data-type="term"]:match("^[^a-zA-Z]"),
   :pass(2) div[data-type="composite-page"] span[data-type="term"]:match("^[^a-zA-Z]") {
-    attr-group-by: ""; }
+    attr-group-by: " Symbols"; }
 :pass(2) div[data-type="page"] > [data-type="document-title"],
 :pass(2) div[data-type="composite-page"] > [data-type="document-title"] {
   node-set: sectionHeaderNode; }
@@ -1571,7 +1571,7 @@
   data-uuid-key: "<index>";
   group-by: span, "span::attr(group-by)", nocase; }
 
-:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label:empty {
+:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label:match("^[ ](Symbols|SYMBOLS)") {
   content: "Symbols"; }
 :pass(7) body {
   counter-reset: chapter; }

--- a/rulesets/output/TEAstatistics.css
+++ b/rulesets/output/TEAstatistics.css
@@ -993,7 +993,7 @@ Formula Review page
   data-uuid-key: "<index>";
   group-by: span, "span::attr(group-by)", nocase; }
 
-:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label:match("^[^a-zA-Z]") {
+:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label:empty {
   content: "Symbols"; }
 :pass(7) body {
   counter-reset: chapter; }

--- a/rulesets/output/TEAstatistics.css
+++ b/rulesets/output/TEAstatistics.css
@@ -993,7 +993,7 @@ Formula Review page
   data-uuid-key: "<index>";
   group-by: span, "span::attr(group-by)", nocase; }
 
-:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label {
+:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label:match("^[^a-zA-Z]") {
   content: "Symbols"; }
 :pass(7) body {
   counter-reset: chapter; }

--- a/rulesets/output/TEAstatistics.css
+++ b/rulesets/output/TEAstatistics.css
@@ -799,7 +799,7 @@ Formula Review page
     attr-group-by: first-letter(content()); }
   :pass(2) div[data-type="page"] span[data-type="term"]:match("^[^a-zA-Z]"),
   :pass(2) div[data-type="composite-page"] span[data-type="term"]:match("^[^a-zA-Z]") {
-    attr-group-by: ""; }
+    attr-group-by: " Symbols"; }
 :pass(2) div[data-type="page"] > [data-type="document-title"],
 :pass(2) div[data-type="composite-page"] > [data-type="document-title"] {
   node-set: sectionHeaderNode; }
@@ -993,7 +993,7 @@ Formula Review page
   data-uuid-key: "<index>";
   group-by: span, "span::attr(group-by)", nocase; }
 
-:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label:empty {
+:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label:match("^[ ](Symbols|SYMBOLS)") {
   content: "Symbols"; }
 :pass(7) body {
   counter-reset: chapter; }

--- a/rulesets/output/ap-biology.css
+++ b/rulesets/output/ap-biology.css
@@ -1470,7 +1470,7 @@
   data-uuid-key: "<index>";
   group-by: span, "span::attr(group-by)", nocase; }
 
-:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label:match("^[^a-zA-Z]") {
+:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label:empty {
   content: "Symbols"; }
 :pass(7) body {
   counter-reset: chapter; }

--- a/rulesets/output/ap-biology.css
+++ b/rulesets/output/ap-biology.css
@@ -1231,7 +1231,7 @@
     attr-group-by: first-letter(content()); }
   :pass(2) div[data-type="page"] span[data-type="term"]:match("^[^a-zA-Z]"),
   :pass(2) div[data-type="composite-page"] span[data-type="term"]:match("^[^a-zA-Z]") {
-    attr-group-by: ""; }
+    attr-group-by: " Symbols"; }
 :pass(2) div[data-type="page"] > [data-type="document-title"],
 :pass(2) div[data-type="composite-page"] > [data-type="document-title"] {
   node-set: sectionHeaderNode; }
@@ -1470,7 +1470,7 @@
   data-uuid-key: "<index>";
   group-by: span, "span::attr(group-by)", nocase; }
 
-:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label:empty {
+:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label:match("^[ ](Symbols|SYMBOLS)") {
   content: "Symbols"; }
 :pass(7) body {
   counter-reset: chapter; }

--- a/rulesets/output/ap-biology.css
+++ b/rulesets/output/ap-biology.css
@@ -1470,7 +1470,7 @@
   data-uuid-key: "<index>";
   group-by: span, "span::attr(group-by)", nocase; }
 
-:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label {
+:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label:match("^[^a-zA-Z]") {
   content: "Symbols"; }
 :pass(7) body {
   counter-reset: chapter; }

--- a/rulesets/output/ap-physics.css
+++ b/rulesets/output/ap-physics.css
@@ -726,7 +726,7 @@
   data-uuid-key: "<index>";
   group-by: span, "span::attr(group-by)", nocase; }
 
-:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label:match("^[^a-zA-Z]") {
+:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label:empty {
   content: "Symbols"; }
 :pass(7) body {
   counter-reset: chapter; }

--- a/rulesets/output/ap-physics.css
+++ b/rulesets/output/ap-physics.css
@@ -726,7 +726,7 @@
   data-uuid-key: "<index>";
   group-by: span, "span::attr(group-by)", nocase; }
 
-:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label {
+:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label:match("^[^a-zA-Z]") {
   content: "Symbols"; }
 :pass(7) body {
   counter-reset: chapter; }

--- a/rulesets/output/ap-physics.css
+++ b/rulesets/output/ap-physics.css
@@ -520,7 +520,7 @@
     attr-group-by: first-letter(content()); }
   :pass(2) div[data-type="page"] span[data-type="term"]:match("^[^a-zA-Z]"),
   :pass(2) div[data-type="composite-page"] span[data-type="term"]:match("^[^a-zA-Z]") {
-    attr-group-by: ""; }
+    attr-group-by: " Symbols"; }
 :pass(2) div[data-type="page"] > [data-type="document-title"],
 :pass(2) div[data-type="composite-page"] > [data-type="document-title"] {
   node-set: sectionHeaderNode; }
@@ -726,7 +726,7 @@
   data-uuid-key: "<index>";
   group-by: span, "span::attr(group-by)", nocase; }
 
-:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label:empty {
+:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label:match("^[ ](Symbols|SYMBOLS)") {
   content: "Symbols"; }
 :pass(7) body {
   counter-reset: chapter; }

--- a/rulesets/output/biology.css
+++ b/rulesets/output/biology.css
@@ -789,7 +789,7 @@
     attr-group-by: first-letter(content()); }
   :pass(2) div[data-type="page"] span[data-type="term"]:match("^[^a-zA-Z]"),
   :pass(2) div[data-type="composite-page"] span[data-type="term"]:match("^[^a-zA-Z]") {
-    attr-group-by: ""; }
+    attr-group-by: " Symbols"; }
 :pass(2) div[data-type="page"] > [data-type="document-title"],
 :pass(2) div[data-type="composite-page"] > [data-type="document-title"] {
   node-set: sectionHeaderNode; }
@@ -1006,7 +1006,7 @@
   data-uuid-key: "<index>";
   group-by: span, "span::attr(group-by)", nocase; }
 
-:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label:empty {
+:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label:match("^[ ](Symbols|SYMBOLS)") {
   content: "Symbols"; }
 :pass(7) body {
   counter-reset: chapter; }

--- a/rulesets/output/biology.css
+++ b/rulesets/output/biology.css
@@ -1006,7 +1006,7 @@
   data-uuid-key: "<index>";
   group-by: span, "span::attr(group-by)", nocase; }
 
-:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label {
+:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label:empty {
   content: "Symbols"; }
 :pass(7) body {
   counter-reset: chapter; }

--- a/rulesets/output/economics.css
+++ b/rulesets/output/economics.css
@@ -699,7 +699,7 @@
     attr-group-by: first-letter(content()); }
   :pass(2) div[data-type="page"] span[data-type="term"]:match("^[^a-zA-Z]"),
   :pass(2) div[data-type="composite-page"] span[data-type="term"]:match("^[^a-zA-Z]") {
-    attr-group-by: ""; }
+    attr-group-by: " Symbols"; }
 :pass(2) div[data-type="page"] > [data-type="document-title"],
 :pass(2) div[data-type="composite-page"] > [data-type="document-title"] {
   node-set: sectionHeaderNode; }
@@ -925,7 +925,7 @@
   data-uuid-key: "<index>";
   group-by: span, "span::attr(group-by)", nocase; }
 
-:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label:empty {
+:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label:match("^[ ](Symbols|SYMBOLS)") {
   content: "Symbols"; }
 :pass(7) body {
   counter-reset: chapter; }

--- a/rulesets/output/economics.css
+++ b/rulesets/output/economics.css
@@ -925,7 +925,7 @@
   data-uuid-key: "<index>";
   group-by: span, "span::attr(group-by)", nocase; }
 
-:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label:match("^[^a-zA-Z]") {
+:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label:empty {
   content: "Symbols"; }
 :pass(7) body {
   counter-reset: chapter; }

--- a/rulesets/output/economics.css
+++ b/rulesets/output/economics.css
@@ -925,7 +925,7 @@
   data-uuid-key: "<index>";
   group-by: span, "span::attr(group-by)", nocase; }
 
-:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label {
+:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label:match("^[^a-zA-Z]") {
   content: "Symbols"; }
 :pass(7) body {
   counter-reset: chapter; }

--- a/rulesets/output/physics.css
+++ b/rulesets/output/physics.css
@@ -646,7 +646,7 @@
   data-uuid-key: "<index>";
   group-by: span, "span::attr(group-by)", nocase; }
 
-:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label {
+:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label:match("^[^a-zA-Z]") {
   content: "Symbols"; }
 :pass(7) body {
   counter-reset: chapter; }

--- a/rulesets/output/physics.css
+++ b/rulesets/output/physics.css
@@ -646,7 +646,7 @@
   data-uuid-key: "<index>";
   group-by: span, "span::attr(group-by)", nocase; }
 
-:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label:match("^[^a-zA-Z]") {
+:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label:empty {
   content: "Symbols"; }
 :pass(7) body {
   counter-reset: chapter; }

--- a/rulesets/output/physics.css
+++ b/rulesets/output/physics.css
@@ -495,7 +495,7 @@
     attr-group-by: first-letter(content()); }
   :pass(2) div[data-type="page"] span[data-type="term"]:match("^[^a-zA-Z]"),
   :pass(2) div[data-type="composite-page"] span[data-type="term"]:match("^[^a-zA-Z]") {
-    attr-group-by: ""; }
+    attr-group-by: " Symbols"; }
 :pass(2) div[data-type="page"] > [data-type="document-title"],
 :pass(2) div[data-type="composite-page"] > [data-type="document-title"] {
   node-set: sectionHeaderNode; }
@@ -646,7 +646,7 @@
   data-uuid-key: "<index>";
   group-by: span, "span::attr(group-by)", nocase; }
 
-:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label:empty {
+:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label:match("^[ ](Symbols|SYMBOLS)") {
   content: "Symbols"; }
 :pass(7) body {
   counter-reset: chapter; }

--- a/rulesets/output/statistics.css
+++ b/rulesets/output/statistics.css
@@ -1009,7 +1009,7 @@ Formula Review page
   data-uuid-key: "<index>";
   group-by: span, "span::attr(group-by)", nocase; }
 
-:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label {
+:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label:match("^[^a-zA-Z]") {
   content: "Symbols"; }
 :pass(7) body {
   counter-reset: chapter; }

--- a/rulesets/output/statistics.css
+++ b/rulesets/output/statistics.css
@@ -805,7 +805,7 @@ Formula Review page
     attr-group-by: first-letter(content()); }
   :pass(2) div[data-type="page"] span[data-type="term"]:match("^[^a-zA-Z]"),
   :pass(2) div[data-type="composite-page"] span[data-type="term"]:match("^[^a-zA-Z]") {
-    attr-group-by: ""; }
+    attr-group-by: " Symbols"; }
 :pass(2) div[data-type="page"] > [data-type="document-title"],
 :pass(2) div[data-type="composite-page"] > [data-type="document-title"] {
   node-set: sectionHeaderNode; }
@@ -1009,7 +1009,7 @@ Formula Review page
   data-uuid-key: "<index>";
   group-by: span, "span::attr(group-by)", nocase; }
 
-:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label:empty {
+:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label:match("^[ ](Symbols|SYMBOLS)") {
   content: "Symbols"; }
 :pass(7) body {
   counter-reset: chapter; }

--- a/rulesets/output/statistics.css
+++ b/rulesets/output/statistics.css
@@ -1009,7 +1009,7 @@ Formula Review page
   data-uuid-key: "<index>";
   group-by: span, "span::attr(group-by)", nocase; }
 
-:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label:match("^[^a-zA-Z]") {
+:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label:empty {
   content: "Symbols"; }
 :pass(7) body {
   counter-reset: chapter; }

--- a/rulesets/output/u-physics.css
+++ b/rulesets/output/u-physics.css
@@ -1194,7 +1194,7 @@
   data-uuid-key: "<index>";
   group-by: span, "span::attr(group-by)", nocase; }
 
-:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label:match("^[^a-zA-Z]") {
+:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label:empty {
   content: "Symbols"; }
 :pass(7) body {
   counter-reset: chapter; }

--- a/rulesets/output/u-physics.css
+++ b/rulesets/output/u-physics.css
@@ -1194,7 +1194,7 @@
   data-uuid-key: "<index>";
   group-by: span, "span::attr(group-by)", nocase; }
 
-:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label {
+:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label:match("^[^a-zA-Z]") {
   content: "Symbols"; }
 :pass(7) body {
   counter-reset: chapter; }

--- a/rulesets/output/u-physics.css
+++ b/rulesets/output/u-physics.css
@@ -840,7 +840,7 @@
     attr-group-by: first-letter(content()); }
   :pass(2) div[data-type="page"] span[data-type="term"]:match("^[^a-zA-Z]"),
   :pass(2) div[data-type="composite-page"] span[data-type="term"]:match("^[^a-zA-Z]") {
-    attr-group-by: ""; }
+    attr-group-by: " Symbols"; }
 :pass(2) div[data-type="page"] > [data-type="document-title"],
 :pass(2) div[data-type="composite-page"] > [data-type="document-title"] {
   node-set: sectionHeaderNode; }
@@ -1194,7 +1194,7 @@
   data-uuid-key: "<index>";
   group-by: span, "span::attr(group-by)", nocase; }
 
-:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label:empty {
+:pass(7) .os-index-container > div.group-by:first-of-type > span.group-label:match("^[ ](Symbols|SYMBOLS)") {
   content: "Symbols"; }
 :pass(7) body {
   counter-reset: chapter; }


### PR DESCRIPTION
Stops a hardcoded "Symbol" group container title from overriding the "A" group container title to resolve issue #278.