### PR TITLE
Number equations even when they aren't within section tags

### DIFF
--- a/recipes/README.md
+++ b/recipes/README.md
@@ -69,6 +69,7 @@ The config settings are variables that start with `$Config_` and have the follow
   - `$Config_Coverage_MayHaveSimlinks`: a boolean
   - `$Config_Coverage_MayHaveIframes`: a boolean
   - `$Config_Coverage_MayHaveMissingExercises`: a boolean
+- `$Config_UnnumberedEquations`: a list of [UnnumberedExercises](#unnumberedexercise)
 - `$Config_HACK_modifyAnyContainerTitleSelector`: a boolean
 - `$Config_hasCompositeAppendixes`: a boolean (used for some TEA books)
 
@@ -156,9 +157,12 @@ A `Note` contains the following fields:
 
 ## UnnumberedExercise
 
-Sometimes exercises in notes should not be numbered. This shows which ones.
+Sometimes exercises (or equations) in notes should not be numbered. This shows which ones.
+
+The name of this type is currently a little confusing but it is this because the need for unnumbered Exercises came before the need for unnumbered Equations.
+
 TODO: It would be nice to move these into the note config but it seems like
-the context is not always a note, and the child is not always an exercise.
+the context is not always a note, and the child is not always an exercise/equation.
 so the proper place to put this requires a bit more thought
 
 It contains the following fields:

--- a/recipes/books/_common-stuff.scss
+++ b/recipes/books/_common-stuff.scss
@@ -22,7 +22,7 @@ $Config_PartType_Figure_CaptionContentAp: (os-title-label: "Figure ", os-number:
 $Config_ContentExercise_TitleContent : (os-number : counter(exerciseMaybeInContent), os-title-label : "Exercise ");
 $Config_ContentSolution_TitleContent : null; // It seems that this is null for all books
 
-
+$Config_UnnumberedEquations: ();
 
 //If this method of setting the content of the label explicity becomes a problem,
 //try grabbing the numbering information from the element's header

--- a/recipes/books/_generator.scss
+++ b/recipes/books/_generator.scss
@@ -35,6 +35,14 @@ $_symbolsSectionTitle: "Symbols";
   }
   @include modify_GenericNote();
 
+  @each $unnumberedEquation in $Config_UnnumberedEquations {
+    $contextSelector: map-get($unnumberedEquation, contextSelector);
+    $childSelector: map-get($unnumberedEquation, childSelector);
+    @include validate_type($contextSelector, string);
+    @include validate_typeOptional($childSelector, string);
+    @include modify_addUnnumbered($contextSelector, $childSelector);
+  }
+
   //the metadata has been moved to the content, remove it from the metadata
   @include modify_trash('[data-type="metadata"] > [data-type="description"]');
   @if $Config_Coverage_MayHaveMissingExercises == true {
@@ -113,16 +121,14 @@ $_symbolsSectionTitle: "Symbols";
   // Number equations if they have a titleContent
   // @include validate_enum(map-get($Config_PartType_Equation, moveTo), $AREA__PREFIX__);
   $titleContent               : map-get($Config_PartType_Equation, titleContent);
-  $excludeNumberingInClassName: map-get($Config_PartType_Equation, excludeNumberingInClassName);
   $numberAt                   : map-get($Config_PartType_Equation, numberAt);
   $numberAfterEq              : map-get($Config_PartType_Equation, numberAfterEq);
   @if $titleContent {
-    @include validate_typeOptional($excludeNumberingInClassName, string);
     @include validate_typeOptional($numberAfterEq, bool);
     @include validate_enum($numberAt, $NUMBER__PREFIX__);
     @include count_countEquations(equation);
     @if $numberAt == $NUMBER_BEFORE_MOVE {
-      @include number_equations($titleContent, $excludeNumberingInClassName, $numberAfterEq);
+      @include number_equations($titleContent, $numberAfterEq);
     }
   }
 
@@ -322,16 +328,14 @@ $_symbolsSectionTitle: "Symbols";
   // Number equations if they have a titleContent
   // @include validate_enum(map-get($Config_PartType_Equation, moveTo), $AREA__PREFIX__);
   $titleContent               : map-get($Config_PartType_Equation, titleContent);
-  $excludeNumberingInClassName: map-get($Config_PartType_Equation, excludeNumberingInClassName);
   $numberAt                   : map-get($Config_PartType_Equation, numberAt);
   $numberAfterEq              : map-get($Config_PartType_Equation, numberAfterEq);
   @if $titleContent {
-    @include validate_typeOptional($excludeNumberingInClassName, string);
     @include validate_typeOptional($numberAfterEq, bool);
     @include validate_enum($numberAt, $NUMBER__PREFIX__);
     @if $numberAt == $NUMBER_AFTER_MOVE {
       @include count_countEquations(equation);
-      @include number_equations($titleContent, $excludeNumberingInClassName, $numberAfterEq);
+      @include number_equations($titleContent, $numberAfterEq);
     }
   }
   @include reference_refBookMetadataNodeAs(bookMetadata);

--- a/recipes/books/ap-physics/_config.scss
+++ b/recipes/books/ap-physics/_config.scss
@@ -38,9 +38,12 @@ $Config_UnnumberedExercises: (
   (contextSelector: '[data-type="exercise"][data-element-type="check-understanding"]',  childSelector: null),
 );
 
+$Config_UnnumberedEquations: (
+  (contextSelector: 'section.section-summary', childSelector: '[data-type="equation"]'),
+);
 
 $Config_PartType_Chapter:  (outlineTitle: 'Chapter Outline');
-$Config_PartType_Equation: (moveTo: $AREA_NONE, numberAt: $NUMBER_AFTER_MOVE, titleContent: $_equationTitleContent, excludeNumberingInClassName: "section-summary");
+$Config_PartType_Equation: (moveTo: $AREA_NONE, numberAt: $NUMBER_AFTER_MOVE, titleContent: $_equationTitleContent);
 $Config_PartType_Exercise: (moveTo: $AREA_EOC, resetAt: $RESET_COMPOSITE_PAGE,  numberAt: $NUMBER_BEFORE_MOVE, titleContent: $_exerciseTitleContent);
 $Config_PartType_Example:  (moveTo: $AREA_NONE, titleContent: $_exampleTitleContent,
                                           solutionTitleContent: $_exampleSolutionTitleContent);

--- a/recipes/books/physics/_config.scss
+++ b/recipes/books/physics/_config.scss
@@ -84,9 +84,13 @@ $Config_Notes: ( );
 
 $Config_UnnumberedExercises: (); // There are no unnumbered exercises
 
+$Config_UnnumberedEquations: (
+  (contextSelector: 'section.section-summary', childSelector: '[data-type="equation"]'),
+);
+
 $Config_PartType_Chapter:  (outlineTitle: 'Chapter Outline', hasLearningObjectives: true);
 // TODO: Is this a mistake; should we be numbering after the move?
-$Config_PartType_Equation: (moveTo: $AREA_NONE, titleContent: $_equationTitleContent, numberAt: $NUMBER_BEFORE_MOVE, excludeNumberingInClassName: "section-summary");
+$Config_PartType_Equation: (moveTo: $AREA_NONE, titleContent: $_equationTitleContent, numberAt: $NUMBER_BEFORE_MOVE);
 $Config_PartType_Exercise: (moveTo: $AREA_EOC, resetAt: $RESET_COMPOSITE_PAGE,  numberAt: $NUMBER_BEFORE_MOVE, titleContent: $_exerciseTitleContent);
 $Config_PartType_Example:  (moveTo: $AREA_NONE,                          titleContent: $_exampleTitleContent,
                                                                   solutionTitleContent: $_exampleSolutionTitleContent);

--- a/recipes/books/u-physics/_config.scss
+++ b/recipes/books/u-physics/_config.scss
@@ -165,7 +165,6 @@ $Config_Notes: (
 $Config_UnnumberedExercises: (
   (contextSelector: '.check-understanding',                   childSelector: '[data-type="exercise"]'),
 );
-  
 
 $Config_abstractTitle: "Learning Objectives";
 $Config_PartType_Exercise: (moveTo: $AREA_EOC, resetAt: $RESET_CHAPTER, numberAt: $NUMBER_BEFORE_MOVE, titleContent: (os-divider: ".", os-number: counter(exercise)));

--- a/recipes/books/u-physics/_config.scss
+++ b/recipes/books/u-physics/_config.scss
@@ -164,7 +164,8 @@ $Config_Notes: (
 
 $Config_UnnumberedExercises: (
   (contextSelector: '.check-understanding',                   childSelector: '[data-type="exercise"]'),
-  );
+);
+  
 
 $Config_abstractTitle: "Learning Objectives";
 $Config_PartType_Exercise: (moveTo: $AREA_EOC, resetAt: $RESET_CHAPTER, numberAt: $NUMBER_BEFORE_MOVE, titleContent: (os-divider: ".", os-number: counter(exercise)));

--- a/recipes/mixins/_number.scss
+++ b/recipes/mixins/_number.scss
@@ -298,18 +298,19 @@
   }
 }
 
-@mixin number_equations ($numberedEquation, $excludedClass, $numberAfterEq) {
-  $sectionSelector: if($excludedClass, 'section:not(.#{$excludedClass})', 'section');
-  #{$sectionSelector} [data-type="equation"]:not(.unnumbered) {
-    @if $numberAfterEq {
-      @include utils_title($numberedEquation, equationNum);
-      &::after {
-        class: os-equation-number;
-        container: div;
-        content: pending(equationNum)
+@mixin number_equations ($numberedEquation, $numberAfterEq) {
+  [data-type="chapter"], .appendix {
+    [data-type="equation"]:not(.unnumbered) {
+      @if $numberAfterEq {
+        @include utils_title($numberedEquation, equationNum);
+        &::after {
+          class: os-equation-number;
+          container: div;
+          content: pending(equationNum)
+        }
+      } @else {
+        @include utils_title($numberedEquation);
       }
-    } @else {
-      @include utils_title($numberedEquation);
     }
   }
 }

--- a/recipes/output/TEAap-physics.css
+++ b/recipes/output/TEAap-physics.css
@@ -376,6 +376,8 @@
   move-to: genericNote; }
 :pass(0) div[data-type="note"][class="note"]:deferred {
   content: pending(genericNote) content(); }
+:pass(0) section.section-summary [data-type="equation"]:not(.unnumbered) {
+  class: attr(class) " unnumbered"; }
 :pass(0) [data-type="metadata"] > [data-type="description"] {
   move-to: trash; }
 
@@ -750,11 +752,11 @@
   counter-reset: equation; }
 :pass(7) [data-type="equation"]:not(.unnumbered) {
   counter-increment: equation; }
-:pass(7) section:not(.section-summary) [data-type="equation"]:not(.unnumbered)::before {
+:pass(7) [data-type="chapter"] [data-type="equation"]:not(.unnumbered)::before, :pass(7) .appendix [data-type="equation"]:not(.unnumbered)::before {
   container: span;
   content: " ";
   class: os-divider; }
-:pass(7) section:not(.section-summary) [data-type="equation"]:not(.unnumbered)::before {
+:pass(7) [data-type="chapter"] [data-type="equation"]:not(.unnumbered)::before, :pass(7) .appendix [data-type="equation"]:not(.unnumbered)::before {
   container: span;
   content: counter(chapter) "." counter(equation);
   class: os-number; }

--- a/recipes/output/TEAhs-physics.css
+++ b/recipes/output/TEAhs-physics.css
@@ -1627,7 +1627,7 @@
   counter-reset: equation; }
 :pass(7) [data-type="equation"]:not(.unnumbered) {
   counter-increment: equation; }
-:pass(7) section:not(.summary) [data-type="equation"]:not(.unnumbered)::before {
+:pass(7) [data-type="chapter"] [data-type="equation"]:not(.unnumbered)::before, :pass(7) .appendix [data-type="equation"]:not(.unnumbered)::before {
   container: span;
   content: counter(chapter) "." counter(equation);
   class: os-number; }

--- a/recipes/output/ap-physics.css
+++ b/recipes/output/ap-physics.css
@@ -382,6 +382,8 @@
   move-to: genericNote; }
 :pass(0) div[data-type="note"][class="note"]:deferred {
   content: pending(genericNote) content(); }
+:pass(0) section.section-summary [data-type="equation"]:not(.unnumbered) {
+  class: attr(class) " unnumbered"; }
 :pass(0) [data-type="metadata"] > [data-type="description"] {
   move-to: trash; }
 
@@ -766,11 +768,11 @@
   counter-reset: equation; }
 :pass(7) [data-type="equation"]:not(.unnumbered) {
   counter-increment: equation; }
-:pass(7) section:not(.section-summary) [data-type="equation"]:not(.unnumbered)::before {
+:pass(7) [data-type="chapter"] [data-type="equation"]:not(.unnumbered)::before, :pass(7) .appendix [data-type="equation"]:not(.unnumbered)::before {
   container: span;
   content: " ";
   class: os-divider; }
-:pass(7) section:not(.section-summary) [data-type="equation"]:not(.unnumbered)::before {
+:pass(7) [data-type="chapter"] [data-type="equation"]:not(.unnumbered)::before, :pass(7) .appendix [data-type="equation"]:not(.unnumbered)::before {
   container: span;
   content: counter(chapter) "." counter(equation);
   class: os-number; }

--- a/recipes/output/physics.css
+++ b/recipes/output/physics.css
@@ -353,6 +353,8 @@
   move-to: genericNote; }
 :pass(0) div[data-type="note"][class="note"]:deferred {
   content: pending(genericNote) content(); }
+:pass(0) section.section-summary [data-type="equation"]:not(.unnumbered) {
+  class: attr(class) " unnumbered"; }
 :pass(0) [data-type="metadata"] > [data-type="description"] {
   move-to: trash; }
 
@@ -476,7 +478,7 @@
   counter-reset: equation; }
 :pass(2) [data-type="equation"]:not(.unnumbered) {
   counter-increment: equation; }
-:pass(2) section:not(.section-summary) [data-type="equation"]:not(.unnumbered)::before {
+:pass(2) [data-type="chapter"] [data-type="equation"]:not(.unnumbered)::before, :pass(2) .appendix [data-type="equation"]:not(.unnumbered)::before {
   container: span;
   content: counter(chapter) "." counter(equation);
   class: os-number; }

--- a/recipes/output/u-physics.css
+++ b/recipes/output/u-physics.css
@@ -731,12 +731,12 @@
   counter-reset: equation; }
 :pass(2) [data-type="equation"]:not(.unnumbered) {
   counter-increment: equation; }
-:pass(2) section [data-type="equation"]:not(.unnumbered)::before {
+:pass(2) [data-type="chapter"] [data-type="equation"]:not(.unnumbered)::before, :pass(2) .appendix [data-type="equation"]:not(.unnumbered)::before {
   container: span;
   content: "(" counter(chapter) "." counter(equation) ")";
   class: os-number;
   move-to: equationNum; }
-:pass(2) section [data-type="equation"]:not(.unnumbered)::after {
+:pass(2) [data-type="chapter"] [data-type="equation"]:not(.unnumbered)::after, :pass(2) .appendix [data-type="equation"]:not(.unnumbered)::after {
   class: os-equation-number;
   container: div;
   content: pending(equationNum); }


### PR DESCRIPTION
To number the equations that remained unnumbered but should have been in issue #275. This also adds the class `unnumbered` to the equations that are NOT supposed to be numbered based on their location. 