### PR TITLE
package manifest.json; python3 compatability

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,4 @@ include LICENSE
 include versioneer.py
 include cnxrecipes/_version.py
 include cnxrecipes/recipes/*.css
+include cnxrecipes/recipes/manifest.json

--- a/cnxrecipes/__init__.py
+++ b/cnxrecipes/__init__.py
@@ -1,11 +1,12 @@
 import json
-from pkg_resources import resource_stream, resource_string
+from pkg_resources import resource_string
 
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
 
-recipes = json.load(resource_stream(__name__, 'recipes/manifest.json'))
+recipes = json.loads(resource_string(__name__,
+                                     'recipes/manifest.json').decode('utf-8'))
 # Convert filenames to strings
 for recipe in recipes:
     recipe['file'] = resource_string(__name__,


### PR DESCRIPTION
missed a file, and made it python3 compat.