### PR TITLE
Empty compound composite child pages are no longer titled

### DIFF
--- a/recipes/books/_generator.scss
+++ b/recipes/books/_generator.scss
@@ -449,5 +449,8 @@ $_symbolsSectionTitle: "Symbols";
   @include toc_navTOCUnwrap();
 }
 :pass(100) {
+  // Get rid of delete-me objects that easybake misses
+  @include utils_cleanUp();
+  // Make sure trashed objects are deleted
   @include utils_clearTrash();
 }

--- a/recipes/mixins/_compose.scss
+++ b/recipes/mixins/_compose.scss
@@ -7,6 +7,7 @@
   @each $page in $compositePages {
     $name: map-get($page, name);
     $className: map-get($page, className);
+    $childPages: map-get($page, childPages);
 
     // Validate
     @include validate_type($name, string);
@@ -17,6 +18,22 @@
         os-text: $name
         );
       @include utils_title($titleContent, null, h2, "document-title");
+      @if ($childPages != null) {
+        @each $cPage in $childPages {
+          $cClassName: map-get($cPage, className);
+          $cPageName: map-get($cPage, name);
+
+          @include validate_type($cClassName, string);
+          @include validate_type($cPageName, string);
+
+          div.os-#{$cClassName}-container {
+            $cTitleContent: (
+              os-text: $cPageName
+              );
+            @include utils_title($cTitleContent, null, h3, "title");
+          }
+        }
+      }
     }
   }
 }
@@ -181,15 +198,8 @@
         }
       }
       &::after {
-        container: h3;
-        data-type: "title";
-        content: $pageName;
-        move-to: #{$className}-title;
-      }
-
-      &::after {
         class: "os-#{$className}-container";
-        content: pending(#{$className}-title) pending(#{$className}-DESTINATION);
+        content: pending(#{$className}-DESTINATION);
         @if ($sortBy != null) {
           sort-by: #{$sortBy}, nocase;
         }
@@ -219,7 +229,6 @@
         data-type: composite-page;
         data-uuid-key: "#{$keyName}";
         content: pending(composite-DESTINATION);
-
       }
     }
   }

--- a/recipes/mixins/_utils.scss
+++ b/recipes/mixins/_utils.scss
@@ -75,3 +75,10 @@
     content: clear(trash);
   }
 }
+
+@mixin utils_cleanUp() {
+  div.delete-me {
+    move-to: trash;
+  }
+}
+

--- a/recipes/output/TEAap-biology.css
+++ b/recipes/output/TEAap-biology.css
@@ -2446,6 +2446,9 @@
 :pass(11) nav#toc li > a:deferred {
   content: pending(title-spans); }
 
+:pass(100) div.delete-me {
+  move-to: trash; }
+
 :pass(100) body:deferred::after {
   content: clear(trash); }
 

--- a/recipes/output/TEAap-physics.css
+++ b/recipes/output/TEAap-physics.css
@@ -1498,6 +1498,9 @@
 :pass(11) nav#toc li > a:deferred {
   content: pending(title-spans); }
 
+:pass(100) div.delete-me {
+  move-to: trash; }
+
 :pass(100) body:deferred::after {
   content: clear(trash); }
 

--- a/recipes/output/TEAeconomics.css
+++ b/recipes/output/TEAeconomics.css
@@ -1803,6 +1803,9 @@
 :pass(11) nav#toc li > a:deferred {
   content: pending(title-spans); }
 
+:pass(100) div.delete-me {
+  move-to: trash; }
+
 :pass(100) body:deferred::after {
   content: clear(trash); }
 

--- a/recipes/output/TEAhs-physics.css
+++ b/recipes/output/TEAhs-physics.css
@@ -1600,14 +1600,8 @@
   move-to: concept-DESTINATION; }
 
 :pass(3) [data-type="chapter"]::after {
-  container: h3;
-  data-type: "title";
-  content: "Concept Items";
-  move-to: concept-title; }
-
-:pass(3) [data-type="chapter"]::after {
   class: "os-concept-container";
-  content: pending(concept-title) pending(concept-DESTINATION);
+  content: pending(concept-DESTINATION);
   move-to: composite-DESTINATION; }
 
 :pass(3) [data-type="chapter"] section.critical-thinking {
@@ -1627,14 +1621,8 @@
   move-to: critical-thinking-DESTINATION; }
 
 :pass(3) [data-type="chapter"]::after {
-  container: h3;
-  data-type: "title";
-  content: "Critical Thinking Items";
-  move-to: critical-thinking-title; }
-
-:pass(3) [data-type="chapter"]::after {
   class: "os-critical-thinking-container";
-  content: pending(critical-thinking-title) pending(critical-thinking-DESTINATION);
+  content: pending(critical-thinking-DESTINATION);
   move-to: composite-DESTINATION; }
 
 :pass(3) [data-type="chapter"] section.ost-chapter-review.problem {
@@ -1654,14 +1642,8 @@
   move-to: ost-chapter-review.problem-DESTINATION; }
 
 :pass(3) [data-type="chapter"]::after {
-  container: h3;
-  data-type: "title";
-  content: "Problems";
-  move-to: ost-chapter-review.problem-title; }
-
-:pass(3) [data-type="chapter"]::after {
   class: "os-ost-chapter-review.problem-container";
-  content: pending(ost-chapter-review.problem-title) pending(ost-chapter-review.problem-DESTINATION);
+  content: pending(ost-chapter-review.problem-DESTINATION);
   move-to: composite-DESTINATION; }
 
 :pass(3) [data-type="chapter"] section.performance {
@@ -1681,14 +1663,8 @@
   move-to: performance-DESTINATION; }
 
 :pass(3) [data-type="chapter"]::after {
-  container: h3;
-  data-type: "title";
-  content: "Performance Task";
-  move-to: performance-title; }
-
-:pass(3) [data-type="chapter"]::after {
   class: "os-performance-container";
-  content: pending(performance-title) pending(performance-DESTINATION);
+  content: pending(performance-DESTINATION);
   move-to: composite-DESTINATION; }
 
 :pass(3) [data-type="chapter"]::after {
@@ -1717,14 +1693,8 @@
   move-to: multiple-choice-DESTINATION; }
 
 :pass(3) [data-type="chapter"]::after {
-  container: h3;
-  data-type: "title";
-  content: "Multiple Choice";
-  move-to: multiple-choice-title; }
-
-:pass(3) [data-type="chapter"]::after {
   class: "os-multiple-choice-container";
-  content: pending(multiple-choice-title) pending(multiple-choice-DESTINATION);
+  content: pending(multiple-choice-DESTINATION);
   move-to: composite-DESTINATION; }
 
 :pass(3) [data-type="chapter"] section.short-answer {
@@ -1744,14 +1714,8 @@
   move-to: short-answer-DESTINATION; }
 
 :pass(3) [data-type="chapter"]::after {
-  container: h3;
-  data-type: "title";
-  content: "Short Answer";
-  move-to: short-answer-title; }
-
-:pass(3) [data-type="chapter"]::after {
   class: "os-short-answer-container";
-  content: pending(short-answer-title) pending(short-answer-DESTINATION);
+  content: pending(short-answer-DESTINATION);
   move-to: composite-DESTINATION; }
 
 :pass(3) [data-type="chapter"] section.extended-response {
@@ -1771,14 +1735,8 @@
   move-to: extended-response-DESTINATION; }
 
 :pass(3) [data-type="chapter"]::after {
-  container: h3;
-  data-type: "title";
-  content: "Extended Response";
-  move-to: extended-response-title; }
-
-:pass(3) [data-type="chapter"]::after {
   class: "os-extended-response-container";
-  content: pending(extended-response-title) pending(extended-response-DESTINATION);
+  content: pending(extended-response-DESTINATION);
   move-to: composite-DESTINATION; }
 
 :pass(3) [data-type="chapter"]::after {
@@ -2018,6 +1976,50 @@
   data-type: "document-title";
   content: pending(h2-TITLECONTAINER); }
 
+:pass(7) [data-type="composite-page"].os-eoc.os-chapter-review-container div.os-concept-container::before {
+  container: span;
+  content: "Concept Items";
+  class: os-text;
+  move-to: h3-TITLECONTAINER; }
+
+:pass(7) [data-type="composite-page"].os-eoc.os-chapter-review-container div.os-concept-container::before {
+  container: h3;
+  data-type: "title";
+  content: pending(h3-TITLECONTAINER); }
+
+:pass(7) [data-type="composite-page"].os-eoc.os-chapter-review-container div.os-critical-thinking-container::before {
+  container: span;
+  content: "Critical Thinking Items";
+  class: os-text;
+  move-to: h3-TITLECONTAINER; }
+
+:pass(7) [data-type="composite-page"].os-eoc.os-chapter-review-container div.os-critical-thinking-container::before {
+  container: h3;
+  data-type: "title";
+  content: pending(h3-TITLECONTAINER); }
+
+:pass(7) [data-type="composite-page"].os-eoc.os-chapter-review-container div.os-ost-chapter-review.problem-container::before {
+  container: span;
+  content: "Problems";
+  class: os-text;
+  move-to: h3-TITLECONTAINER; }
+
+:pass(7) [data-type="composite-page"].os-eoc.os-chapter-review-container div.os-ost-chapter-review.problem-container::before {
+  container: h3;
+  data-type: "title";
+  content: pending(h3-TITLECONTAINER); }
+
+:pass(7) [data-type="composite-page"].os-eoc.os-chapter-review-container div.os-performance-container::before {
+  container: span;
+  content: "Performance Task";
+  class: os-text;
+  move-to: h3-TITLECONTAINER; }
+
+:pass(7) [data-type="composite-page"].os-eoc.os-chapter-review-container div.os-performance-container::before {
+  container: h3;
+  data-type: "title";
+  content: pending(h3-TITLECONTAINER); }
+
 :pass(7) [data-type="composite-page"].os-eoc.os-test-prep-container::before {
   container: span;
   content: "Test Prep";
@@ -2028,6 +2030,39 @@
   container: h2;
   data-type: "document-title";
   content: pending(h2-TITLECONTAINER); }
+
+:pass(7) [data-type="composite-page"].os-eoc.os-test-prep-container div.os-multiple-choice-container::before {
+  container: span;
+  content: "Multiple Choice";
+  class: os-text;
+  move-to: h3-TITLECONTAINER; }
+
+:pass(7) [data-type="composite-page"].os-eoc.os-test-prep-container div.os-multiple-choice-container::before {
+  container: h3;
+  data-type: "title";
+  content: pending(h3-TITLECONTAINER); }
+
+:pass(7) [data-type="composite-page"].os-eoc.os-test-prep-container div.os-short-answer-container::before {
+  container: span;
+  content: "Short Answer";
+  class: os-text;
+  move-to: h3-TITLECONTAINER; }
+
+:pass(7) [data-type="composite-page"].os-eoc.os-test-prep-container div.os-short-answer-container::before {
+  container: h3;
+  data-type: "title";
+  content: pending(h3-TITLECONTAINER); }
+
+:pass(7) [data-type="composite-page"].os-eoc.os-test-prep-container div.os-extended-response-container::before {
+  container: span;
+  content: "Extended Response";
+  class: os-text;
+  move-to: h3-TITLECONTAINER; }
+
+:pass(7) [data-type="composite-page"].os-eoc.os-test-prep-container div.os-extended-response-container::before {
+  container: h3;
+  data-type: "title";
+  content: pending(h3-TITLECONTAINER); }
 
 :pass(7) [data-type="composite-page"].os-eob.os-index-container::before {
   container: span;
@@ -2538,6 +2573,9 @@
 
 :pass(11) nav#toc li > a:deferred {
   content: pending(title-spans); }
+
+:pass(100) div.delete-me {
+  move-to: trash; }
 
 :pass(100) body:deferred::after {
   content: clear(trash); }

--- a/recipes/output/TEAstatistics.css
+++ b/recipes/output/TEAstatistics.css
@@ -1839,6 +1839,9 @@ Formula Review page
 :pass(11) nav#toc li > a:deferred {
   content: pending(title-spans); }
 
+:pass(100) div.delete-me {
+  move-to: trash; }
+
 :pass(100) body:deferred::after {
   content: clear(trash); }
 

--- a/recipes/output/ap-biology.css
+++ b/recipes/output/ap-biology.css
@@ -2430,6 +2430,9 @@
 :pass(11) nav#toc li > a:deferred {
   content: pending(title-spans); }
 
+:pass(100) div.delete-me {
+  move-to: trash; }
+
 :pass(100) body:deferred::after {
   content: clear(trash); }
 

--- a/recipes/output/ap-physics.css
+++ b/recipes/output/ap-physics.css
@@ -1478,6 +1478,9 @@
 :pass(11) nav#toc li > a:deferred {
   content: pending(title-spans); }
 
+:pass(100) div.delete-me {
+  move-to: trash; }
+
 :pass(100) body:deferred::after {
   content: clear(trash); }
 

--- a/recipes/output/biology.css
+++ b/recipes/output/biology.css
@@ -1827,6 +1827,9 @@
 :pass(11) nav#toc li > a:deferred {
   content: pending(title-spans); }
 
+:pass(100) div.delete-me {
+  move-to: trash; }
+
 :pass(100) body:deferred::after {
   content: clear(trash); }
 

--- a/recipes/output/economics.css
+++ b/recipes/output/economics.css
@@ -1744,6 +1744,9 @@
 :pass(11) nav#toc li > a:deferred {
   content: pending(title-spans); }
 
+:pass(100) div.delete-me {
+  move-to: trash; }
+
 :pass(100) body:deferred::after {
   content: clear(trash); }
 

--- a/recipes/output/physics.css
+++ b/recipes/output/physics.css
@@ -1335,6 +1335,9 @@
 :pass(11) nav#toc li > a:deferred {
   content: pending(title-spans); }
 
+:pass(100) div.delete-me {
+  move-to: trash; }
+
 :pass(100) body:deferred::after {
   content: clear(trash); }
 

--- a/recipes/output/statistics.css
+++ b/recipes/output/statistics.css
@@ -1819,6 +1819,9 @@ Formula Review page
 :pass(11) nav#toc li > a:deferred {
   content: pending(title-spans); }
 
+:pass(100) div.delete-me {
+  move-to: trash; }
+
 :pass(100) body:deferred::after {
   content: clear(trash); }
 

--- a/recipes/output/u-physics.css
+++ b/recipes/output/u-physics.css
@@ -969,14 +969,8 @@
     move-to: trash; }
 
 :pass(3) [data-type="chapter"]::after {
-  container: h3;
-  data-type: "title";
-  content: "Key Terms";
-  move-to: glossary-title; }
-
-:pass(3) [data-type="chapter"]::after {
   class: "os-glossary-container";
-  content: pending(glossary-title) pending(glossary-DESTINATION);
+  content: pending(glossary-DESTINATION);
   sort-by: xhtml|dl > xhtml|dt, nocase;
   move-to: composite-DESTINATION; }
 
@@ -986,14 +980,8 @@
     move-to: trash; }
 
 :pass(3) [data-type="chapter"]::after {
-  container: h3;
-  data-type: "title";
-  content: "Key Equations";
-  move-to: key-equations-title; }
-
-:pass(3) [data-type="chapter"]::after {
   class: "os-key-equations-container";
-  content: pending(key-equations-title) pending(key-equations-DESTINATION);
+  content: pending(key-equations-DESTINATION);
   move-to: composite-DESTINATION; }
 
 :pass(3) [data-type="chapter"] section.key-concepts {
@@ -1013,14 +1001,8 @@
   move-to: key-concepts-DESTINATION; }
 
 :pass(3) [data-type="chapter"]::after {
-  container: h3;
-  data-type: "title";
-  content: "Summary";
-  move-to: key-concepts-title; }
-
-:pass(3) [data-type="chapter"]::after {
   class: "os-key-concepts-container";
-  content: pending(key-concepts-title) pending(key-concepts-DESTINATION);
+  content: pending(key-concepts-DESTINATION);
   move-to: composite-DESTINATION; }
 
 :pass(3) [data-type="chapter"] section.review-conceptual-questions {
@@ -1040,14 +1022,8 @@
   move-to: review-conceptual-questions-DESTINATION; }
 
 :pass(3) [data-type="chapter"]::after {
-  container: h3;
-  data-type: "title";
-  content: "Conceptual Questions";
-  move-to: review-conceptual-questions-title; }
-
-:pass(3) [data-type="chapter"]::after {
   class: "os-review-conceptual-questions-container";
-  content: pending(review-conceptual-questions-title) pending(review-conceptual-questions-DESTINATION);
+  content: pending(review-conceptual-questions-DESTINATION);
   move-to: composite-DESTINATION; }
 
 :pass(3) [data-type="chapter"] section.review-problems {
@@ -1067,14 +1043,8 @@
   move-to: review-problems-DESTINATION; }
 
 :pass(3) [data-type="chapter"]::after {
-  container: h3;
-  data-type: "title";
-  content: "Problems";
-  move-to: review-problems-title; }
-
-:pass(3) [data-type="chapter"]::after {
   class: "os-review-problems-container";
-  content: pending(review-problems-title) pending(review-problems-DESTINATION);
+  content: pending(review-problems-DESTINATION);
   move-to: composite-DESTINATION; }
 
 :pass(3) [data-type="chapter"] section.review-additional-problems {
@@ -1083,14 +1053,8 @@
     move-to: trash; }
 
 :pass(3) [data-type="chapter"]::after {
-  container: h3;
-  data-type: "title";
-  content: "Additional Problems";
-  move-to: review-additional-problems-title; }
-
-:pass(3) [data-type="chapter"]::after {
   class: "os-review-additional-problems-container";
-  content: pending(review-additional-problems-title) pending(review-additional-problems-DESTINATION);
+  content: pending(review-additional-problems-DESTINATION);
   move-to: composite-DESTINATION; }
 
 :pass(3) [data-type="chapter"] section.review-challenge {
@@ -1099,14 +1063,8 @@
     move-to: trash; }
 
 :pass(3) [data-type="chapter"]::after {
-  container: h3;
-  data-type: "title";
-  content: "Challenge Problems";
-  move-to: review-challenge-title; }
-
-:pass(3) [data-type="chapter"]::after {
   class: "os-review-challenge-container";
-  content: pending(review-challenge-title) pending(review-challenge-DESTINATION);
+  content: pending(review-challenge-DESTINATION);
   move-to: composite-DESTINATION; }
 
 :pass(3) [data-type="chapter"]::after {
@@ -1447,6 +1405,83 @@
   container: h2;
   data-type: "document-title";
   content: pending(h2-TITLECONTAINER); }
+
+:pass(7) [data-type="composite-page"].os-eoc.os-chapter-review-container div.os-glossary-container::before {
+  container: span;
+  content: "Key Terms";
+  class: os-text;
+  move-to: h3-TITLECONTAINER; }
+
+:pass(7) [data-type="composite-page"].os-eoc.os-chapter-review-container div.os-glossary-container::before {
+  container: h3;
+  data-type: "title";
+  content: pending(h3-TITLECONTAINER); }
+
+:pass(7) [data-type="composite-page"].os-eoc.os-chapter-review-container div.os-key-equations-container::before {
+  container: span;
+  content: "Key Equations";
+  class: os-text;
+  move-to: h3-TITLECONTAINER; }
+
+:pass(7) [data-type="composite-page"].os-eoc.os-chapter-review-container div.os-key-equations-container::before {
+  container: h3;
+  data-type: "title";
+  content: pending(h3-TITLECONTAINER); }
+
+:pass(7) [data-type="composite-page"].os-eoc.os-chapter-review-container div.os-key-concepts-container::before {
+  container: span;
+  content: "Summary";
+  class: os-text;
+  move-to: h3-TITLECONTAINER; }
+
+:pass(7) [data-type="composite-page"].os-eoc.os-chapter-review-container div.os-key-concepts-container::before {
+  container: h3;
+  data-type: "title";
+  content: pending(h3-TITLECONTAINER); }
+
+:pass(7) [data-type="composite-page"].os-eoc.os-chapter-review-container div.os-review-conceptual-questions-container::before {
+  container: span;
+  content: "Conceptual Questions";
+  class: os-text;
+  move-to: h3-TITLECONTAINER; }
+
+:pass(7) [data-type="composite-page"].os-eoc.os-chapter-review-container div.os-review-conceptual-questions-container::before {
+  container: h3;
+  data-type: "title";
+  content: pending(h3-TITLECONTAINER); }
+
+:pass(7) [data-type="composite-page"].os-eoc.os-chapter-review-container div.os-review-problems-container::before {
+  container: span;
+  content: "Problems";
+  class: os-text;
+  move-to: h3-TITLECONTAINER; }
+
+:pass(7) [data-type="composite-page"].os-eoc.os-chapter-review-container div.os-review-problems-container::before {
+  container: h3;
+  data-type: "title";
+  content: pending(h3-TITLECONTAINER); }
+
+:pass(7) [data-type="composite-page"].os-eoc.os-chapter-review-container div.os-review-additional-problems-container::before {
+  container: span;
+  content: "Additional Problems";
+  class: os-text;
+  move-to: h3-TITLECONTAINER; }
+
+:pass(7) [data-type="composite-page"].os-eoc.os-chapter-review-container div.os-review-additional-problems-container::before {
+  container: h3;
+  data-type: "title";
+  content: pending(h3-TITLECONTAINER); }
+
+:pass(7) [data-type="composite-page"].os-eoc.os-chapter-review-container div.os-review-challenge-container::before {
+  container: span;
+  content: "Challenge Problems";
+  class: os-text;
+  move-to: h3-TITLECONTAINER; }
+
+:pass(7) [data-type="composite-page"].os-eoc.os-chapter-review-container div.os-review-challenge-container::before {
+  container: h3;
+  data-type: "title";
+  content: pending(h3-TITLECONTAINER); }
 
 :pass(7) [data-type="composite-page"].os-eob.os-solutions-container::before {
   container: span;
@@ -1930,6 +1965,9 @@
 
 :pass(11) nav#toc li > a:deferred {
   content: pending(title-spans); }
+
+:pass(100) div.delete-me {
+  move-to: trash; }
 
 :pass(100) body:deferred::after {
   content: clear(trash); }


### PR DESCRIPTION
[Errata 4476](https://openstax.org/errata/4476) resolved via recipe change. Additionally, removes delete-me's missed by easybake as part of the end of bake clean up (as it was required to do so to resolve the issue, and also seems like a reasonable thing to do)