### PR TITLE
fix pyICU compiling

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -4,4 +4,5 @@ brew "rbenv"
 brew "lcov"
 brew "shellcheck"
 brew "icu4c" # needed by cnx-easybake. Commented because it is already installed because of node
+brew "gettext"
 brew "intltool"

--- a/Brewfile
+++ b/Brewfile
@@ -3,4 +3,5 @@ brew "python"
 brew "rbenv"
 brew "lcov"
 brew "shellcheck"
-# brew "icu4c" # needed by cnx-easybake. Commented because it is already installed because of node
+brew "icu4c" # needed by cnx-easybake. Commented because it is already installed because of node
+brew "intltool"

--- a/Brewfile
+++ b/Brewfile
@@ -3,6 +3,4 @@ brew "python"
 brew "rbenv"
 brew "lcov"
 brew "shellcheck"
-brew "icu4c" # needed by cnx-easybake. Commented because it is already installed because of node
-# brew "gettext"
-# brew "intltool"
+brew "icu4c" # needed by cnx-easybake (it is already installed because of node/yarn) but just being explicit

--- a/Brewfile
+++ b/Brewfile
@@ -4,5 +4,5 @@ brew "rbenv"
 brew "lcov"
 brew "shellcheck"
 brew "icu4c" # needed by cnx-easybake. Commented because it is already installed because of node
-brew "gettext"
-brew "intltool"
+# brew "gettext"
+# brew "intltool"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 requests
--e git+https://github.com/Connexions/cssselect2.git#egg=cssselect2
--e git+https://github.com/Connexions/cnx-easybake.git#egg=cnxeasybake
--e git+https://github.com/Connexions/cnx-epub.git#egg=cnxepub
+PyICU==1.9.8
+-e git+https://github.com/Connexions/cssselect2.git@master#egg=cssselect2
+-e git+https://github.com/Connexions/cnx-easybake.git@master#egg=cnxeasybake
+-e git+https://github.com/Connexions/cnx-epub.git@master#egg=cnxepub

--- a/script/_bootstrap.sh
+++ b/script/_bootstrap.sh
@@ -14,7 +14,4 @@ if [[ "$(uname -s)" = "Darwin" ]]; then
     export PYICU_LFLAGS="-L${path_to_icu4c}/${icu_version}/lib"
   fi
 
-  # if [[ ! $(which icu-config) ]]; then
-  #   try brew link icu4c gettext --force
-  # fi
 fi

--- a/script/_bootstrap.sh
+++ b/script/_bootstrap.sh
@@ -4,7 +4,8 @@ if [[ "$(uname -s)" = "Darwin" ]]; then
   # from https://tobywf.com/2017/05/installing-pyicu-on-macos/
   if [[ ! ${ICU_VERSION} ]]; then
     path_to_icu4c="/usr/local/Cellar/icu4c"
-    icu_version=$(ls ${path_to_icu4c})
+    # Assume that the latest version is the one we want to use
+    icu_version=$(ls ${path_to_icu4c} | sort -n | tail -n 1)
     icu_version_major="${icu_version%.*}"
 
     export ICU_VERSION="${icu_version_major}"

--- a/script/_bootstrap.sh
+++ b/script/_bootstrap.sh
@@ -5,6 +5,7 @@ if [[ "$(uname -s)" = "Darwin" ]]; then
   if [[ ! ${ICU_VERSION} ]]; then
     path_to_icu4c="/usr/local/Cellar/icu4c"
     # Assume that the latest version is the one we want to use
+    # shellcheck disable=SC2012
     icu_version=$(ls ${path_to_icu4c} | sort -n | tail -n 1)
     icu_version_major="${icu_version%.*}"
 

--- a/script/_bootstrap.sh
+++ b/script/_bootstrap.sh
@@ -14,7 +14,7 @@ if [[ "$(uname -s)" = "Darwin" ]]; then
     export PYICU_LFLAGS="-L${path_to_icu4c}/${icu_version}/lib"
   fi
 
-  if [[ ! $(which icu-config) ]]; then
-    try brew link icu4c gettext --force
-  fi
+  # if [[ ! $(which icu-config) ]]; then
+  #   try brew link icu4c gettext --force
+  # fi
 fi

--- a/script/_bootstrap.sh
+++ b/script/_bootstrap.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-# from https://tobywf.com/2017/05/installing-pyicu-on-macos/
-if [[ ! ${ICU_VERSION} ]]; then
-  if [[ "$(uname -s)" = "Darwin" ]]; then
+if [[ "$(uname -s)" = "Darwin" ]]; then
+  # from https://tobywf.com/2017/05/installing-pyicu-on-macos/
+  if [[ ! ${ICU_VERSION} ]]; then
     path_to_icu4c="/usr/local/Cellar/icu4c"
     icu_version=$(ls ${path_to_icu4c})
     icu_version_major="${icu_version%.*}"
@@ -10,5 +10,9 @@ if [[ ! ${ICU_VERSION} ]]; then
     export ICU_VERSION="${icu_version_major}"
     export PYICU_INCLUDES="${path_to_icu4c}/${icu_version}/include"
     export PYICU_LFLAGS="-L${path_to_icu4c}/${icu_version}/lib"
+  fi
+
+  if [[ ! $(which icu-config) ]]; then
+    try brew link icu4c gettext --force
   fi
 fi

--- a/script/clean
+++ b/script/clean
@@ -20,7 +20,7 @@ done
 # PyICU is built with a specific version of icu4c and when icu4c is updated the cached egg is no longer useful
 if [[ "$(uname -s)" = "Darwin" ]]; then
   if [[ -d "${HOME}/Library/Caches/pip" ]]; then
-    rm -rf "${HOME}/Library/Caches/pip"
+    rm -rf "${HOME}/Library/Caches/pip" || exit 111
   fi
 fi
 

--- a/script/clean
+++ b/script/clean
@@ -17,4 +17,9 @@ for dir_name in "${dirs_to_remove[@]}"; do
   fi
 done
 
+# PyICU is built with a specific version of icu4c and when icu4c is updated the cached egg is no longer useful
+if [[ -d "${HOME}/Library/Caches/pip" ]]; then
+  rm -rf "${HOME}/Library/Caches/pip"
+fi
+
 echo "Done cleaning"

--- a/script/clean
+++ b/script/clean
@@ -18,8 +18,10 @@ for dir_name in "${dirs_to_remove[@]}"; do
 done
 
 # PyICU is built with a specific version of icu4c and when icu4c is updated the cached egg is no longer useful
-if [[ -d "${HOME}/Library/Caches/pip" ]]; then
-  rm -rf "${HOME}/Library/Caches/pip"
+if [[ "$(uname -s)" = "Darwin" ]]; then
+  if [[ -d "${HOME}/Library/Caches/pip" ]]; then
+    rm -rf "${HOME}/Library/Caches/pip"
+  fi
 fi
 
 echo "Done cleaning"


### PR DESCRIPTION
Original error:

```
./script/setup

...
Building PyICU 2.0.2 for ICU 60.1
    60

    Could not configure CXXFLAGS with icu-config
...
```


and now:

```
./script/test

    from .oven import Oven  # noqa
  File "/Users/phil/github/cnx/cnx-recipes/venv/src/cnxeasybake/cnxeasybake/oven.py", line 13, in <module>
    from icu import Locale, Collator, UnicodeString
  File "/Users/phil/github/cnx/cnx-recipes/venv/lib/python2.7/site-packages/icu/__init__.py", line 37, in <module>
    from _icu import *
ImportError: dlopen(/Users/phil/github/cnx/cnx-recipes/venv/lib/python2.7/site-packages/_icu.so, 2): Symbol not found: __ZNK6icu_6014Transliterator12getTargetSetERNS_10UnicodeSetE
  Referenced from: /Users/phil/github/cnx/cnx-recipes/venv/lib/python2.7/site-packages/_icu.so
  Expected in: flat namespace
 in /Users/phil/github/cnx/cnx-recipes/venv/lib/python2.7/site-packages/_icu.so
./script/generate-guide:
```


To make sure this works, be sure to run `./script/clean` and then `./script/setup`