### PR TITLE
Ensure pytest runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 /bin/
 /lib/
 /include/
+# pytest creates these files
+*.pyc
 
 # Ruby files
 /.bundle/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 requests
+pytest
 PyICU==1.9.8
 -e git+https://github.com/Connexions/cssselect2.git@master#egg=cssselect2
 -e git+https://github.com/Connexions/cnx-easybake.git@master#egg=cnxeasybake

--- a/script/test
+++ b/script/test
@@ -3,7 +3,7 @@ cd "$(dirname "$0")/.." || exit 111
 source ./script/bootstrap || exit 111
 
 # Verify exportable recipes
-pytest tests
+try pytest tests
 
 # Make sure the snippets are well-formed XML
 do_progress_quiet "Linting and checking XML snippets" \


### PR DESCRIPTION
This fixes 2 things:
- `pytest` was not installed as part of `./script/setup` 
- When missing, it silently failed instead of erroring