### PR TITLE
Inline the 'display: none' style for metadata

### DIFF
--- a/recipes/books/_generator.scss
+++ b/recipes/books/_generator.scss
@@ -455,6 +455,7 @@
 :pass(10) {
   //After: All metadata tasks are completed
   @include modify_suppressURI($Config_hasCompositeChapter);
+  @include modify_hideMetadata();
   @include toc_prepTOCElements($Config_hasCompositeChapter);
 }
 :pass(11) {

--- a/recipes/mixins/_modify.scss
+++ b/recipes/mixins/_modify.scss
@@ -60,6 +60,11 @@
   }
 }
 
+@mixin modify_hideMetadata() {
+  [data-type="metadata"] {
+    attr-style: "display: none;";
+  }
+}
 
 
 // Replace module titles with the ones set by collection.

--- a/recipes/output/accounting.css
+++ b/recipes/output/accounting.css
@@ -1925,6 +1925,9 @@
 :pass(10) div.os-eob [data-type="cnx-archive-uri"] {
   move-to: trash; }
 
+:pass(10) [data-type="metadata"] {
+  attr-style: "display: none;"; }
+
 :pass(10) body > div[data-type="page"],
 :pass(10) body > div[data-type="composite-page"] {
   string-set: page-id attr(id); }

--- a/recipes/output/ap-biology.css
+++ b/recipes/output/ap-biology.css
@@ -2312,6 +2312,9 @@
 :pass(10) div.os-eob [data-type="cnx-archive-uri"] {
   move-to: trash; }
 
+:pass(10) [data-type="metadata"] {
+  attr-style: "display: none;"; }
+
 :pass(10) body > div[data-type="page"],
 :pass(10) body > div[data-type="composite-page"] {
   string-set: page-id attr(id); }

--- a/recipes/output/ap-physics.css
+++ b/recipes/output/ap-physics.css
@@ -1360,6 +1360,9 @@
 :pass(10) div.os-eob [data-type="cnx-archive-uri"] {
   move-to: trash; }
 
+:pass(10) [data-type="metadata"] {
+  attr-style: "display: none;"; }
+
 :pass(10) body > div[data-type="page"],
 :pass(10) body > div[data-type="composite-page"] {
   string-set: page-id attr(id); }

--- a/recipes/output/biology.css
+++ b/recipes/output/biology.css
@@ -1709,6 +1709,9 @@
 :pass(10) div.os-eob [data-type="cnx-archive-uri"] {
   move-to: trash; }
 
+:pass(10) [data-type="metadata"] {
+  attr-style: "display: none;"; }
+
 :pass(10) body > div[data-type="page"],
 :pass(10) body > div[data-type="composite-page"] {
   string-set: page-id attr(id); }

--- a/recipes/output/business-ethics.css
+++ b/recipes/output/business-ethics.css
@@ -1578,6 +1578,9 @@
 :pass(10) div.os-eob [data-type="cnx-archive-uri"] {
   move-to: trash; }
 
+:pass(10) [data-type="metadata"] {
+  attr-style: "display: none;"; }
+
 :pass(10) body > div[data-type="page"],
 :pass(10) body > div[data-type="composite-page"] {
   string-set: page-id attr(id); }

--- a/recipes/output/economics.css
+++ b/recipes/output/economics.css
@@ -1626,6 +1626,9 @@
 :pass(10) div.os-eob [data-type="cnx-archive-uri"] {
   move-to: trash; }
 
+:pass(10) [data-type="metadata"] {
+  attr-style: "display: none;"; }
+
 :pass(10) body > div[data-type="page"],
 :pass(10) body > div[data-type="composite-page"] {
   string-set: page-id attr(id); }

--- a/recipes/output/entrepreneurship.css
+++ b/recipes/output/entrepreneurship.css
@@ -1706,6 +1706,9 @@
 :pass(10) div.os-eob [data-type="cnx-archive-uri"] {
   move-to: trash; }
 
+:pass(10) [data-type="metadata"] {
+  attr-style: "display: none;"; }
+
 :pass(10) body > div[data-type="page"],
 :pass(10) body > div[data-type="composite-page"] {
   string-set: page-id attr(id); }

--- a/recipes/output/intro-business.css
+++ b/recipes/output/intro-business.css
@@ -2022,6 +2022,9 @@
 :pass(10) div.os-eob [data-type="cnx-archive-uri"] {
   move-to: trash; }
 
+:pass(10) [data-type="metadata"] {
+  attr-style: "display: none;"; }
+
 :pass(10) body > div[data-type="page"],
 :pass(10) body > div[data-type="composite-page"] {
   string-set: page-id attr(id); }

--- a/recipes/output/physics.css
+++ b/recipes/output/physics.css
@@ -1217,6 +1217,9 @@
 :pass(10) div.os-eob [data-type="cnx-archive-uri"] {
   move-to: trash; }
 
+:pass(10) [data-type="metadata"] {
+  attr-style: "display: none;"; }
+
 :pass(10) body > div[data-type="page"],
 :pass(10) body > div[data-type="composite-page"] {
   string-set: page-id attr(id); }

--- a/recipes/output/statistics.css
+++ b/recipes/output/statistics.css
@@ -1702,6 +1702,9 @@ Formula Review page
 :pass(10) div.os-eob [data-type="cnx-archive-uri"] {
   move-to: trash; }
 
+:pass(10) [data-type="metadata"] {
+  attr-style: "display: none;"; }
+
 :pass(10) body > div[data-type="page"],
 :pass(10) body > div[data-type="composite-page"] {
   string-set: page-id attr(id); }

--- a/recipes/output/u-physics.css
+++ b/recipes/output/u-physics.css
@@ -1848,6 +1848,9 @@
 :pass(10) div.os-eob [data-type="cnx-archive-uri"] {
   move-to: trash; }
 
+:pass(10) [data-type="metadata"] {
+  attr-style: "display: none;"; }
+
 :pass(10) body > div[data-type="page"],
 :pass(10) body > div[data-type="composite-page"] {
   string-set: page-id attr(id); }


### PR DESCRIPTION
After a brief discussion between Helene and I, we figured that since we are trying to make the books read acceptably even without stylesheets, we would inline some style to `display: none;` the metadata in baked books, since we can't think of a case in which we would not want them to be hidden.