### PR TITLE
Make splash images more compatible with Prince ver. <= 11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "devDependencies": {
     "kss": "^2.4.0",
-    "node-sass": "^4.5.3",
+    "node-sass": "^4.9.0",
     "sass-lint": "^1.9.1",
     "sassdoc": "^2.1.20"
   },

--- a/styles/framework/config/_color-map.scss
+++ b/styles/framework/config/_color-map.scss
@@ -62,8 +62,8 @@
     chapter-number-border: color-scheme(standard-white),
     chapter-title: color-scheme(standard-white),
     intro-title: color-scheme(primary),
-    splash-bottom-bar: color-scheme(primary),
-    splash-bottom-bar-border: darken(color-scheme(primary), 20%),
+    splash-title-bar: color-scheme(primary),
+    splash-title-bar-border: darken(color-scheme(primary), 10%),
 
     chapter-outline-title: color-scheme(primary),
     chapter-outline-sections: color-scheme(standard-black),

--- a/styles/output/intro-business.css
+++ b/styles/output/intro-business.css
@@ -336,9 +336,10 @@ nav#toc > ol > li {
       overflow: hidden;
       position: absolute;
       margin-bottom: -0.8in;
-      width: 6.5in;
-      height: 3.2in;
-      top: 0;
+      width: 8.75in;
+      height: 4in;
+      transform: translateX(-1.125in);
+      top: -0.8in;
       /* Prince -v latest */
       /* end Prince -v latest */ }
       [data-type="chapter"] > .introduction > [data-type="document-title"] + .os-figure figure::after {
@@ -360,8 +361,9 @@ nav#toc > ol > li {
         [data-type="chapter"] > .introduction > [data-type="document-title"] + .os-figure figure span[data-type="media"] img {
           width: 100%;
           position: relative;
+          max-width: none;
           /* Prince -v <= 11.0 */
-          margin-top: 1.6in;
+          margin-top: 2in;
           transform: translateY(-50%);
           padding-bottom: 70px;
           /* end Prince -v <= 11.0 */
@@ -383,7 +385,8 @@ nav#toc > ol > li {
   z-index: 1;
   margin: 0;
   width: 6.5in;
-  height: 3.2in; }
+  height: 4in;
+  top: -0.8in; }
   [data-type="chapter"] > h1[data-type="document-title"] .os-text {
     position: absolute;
     bottom: 0;
@@ -391,7 +394,7 @@ nav#toc > ol > li {
     height: 60px;
     white-space: normal;
     font-weight: normal;
-    left: 128px; }
+    left: 80px; }
   [data-type="chapter"] > h1[data-type="document-title"] .os-number {
     font-family: "Roboto Condensed", serif;
     bottom: 47.5px;
@@ -404,8 +407,7 @@ nav#toc > ol > li {
     position: absolute;
     border-radius: 50%;
     border: 1px solid #FFFFFF;
-    text-align: center;
-    left: 0.5in; }
+    text-align: center; }
   [data-type="chapter"] > h1[data-type="document-title"]::after {
     content: " ";
     display: block;
@@ -413,7 +415,8 @@ nav#toc > ol > li {
     height: 70px;
     position: absolute;
     bottom: 0;
-    z-index: 3; }
+    z-index: 3;
+    left: -1in; }
 
 /* -------------------------
  * Styling for Appendix

--- a/styles/output/intro-business.css
+++ b/styles/output/intro-business.css
@@ -328,7 +328,7 @@ nav#toc > ol > li {
   position: relative; }
   [data-type="chapter"] > .introduction {
     position: relative;
-    padding-top: 3.5in; }
+    padding-top: 3.2in; }
     [data-type="chapter"] > .introduction > [data-type="document-title"] {
       display: none; }
     [data-type="chapter"] > .introduction > [data-type="document-title"] + .os-figure figure {
@@ -336,9 +336,17 @@ nav#toc > ol > li {
       overflow: hidden;
       position: absolute;
       margin-bottom: -0.8in;
-      width: 6.5in;
-      height: 3.5in;
-      top: 0; }
+      width: 8.75in;
+      height: 4in;
+      transform: translateX(-1.125in);
+      top: -0.8in; }
+      [data-type="chapter"] > .introduction > [data-type="document-title"] + .os-figure figure::before {
+        width: 100%;
+        content: " ";
+        position: absolute;
+        height: 120px;
+        background: linear-gradient(rgba(0, 0, 0, 0.35), rgba(0, 0, 0, 0));
+        z-index: 1; }
       [data-type="chapter"] > .introduction > [data-type="document-title"] + .os-figure figure::after {
         width: 100%;
         content: " ";
@@ -359,7 +367,7 @@ nav#toc > ol > li {
           width: 100%;
           position: relative;
           /* Prince -v <= 11.0 */
-          margin-top: 1.75in;
+          margin-top: 2in;
           transform: translateY(-50%);
           padding-bottom: 70px;
           /* end Prince -v <= 11.0 */
@@ -382,10 +390,11 @@ nav#toc > ol > li {
   text-transform: capitalize;
   z-index: 1;
   margin: 0;
-  width: 6.5in;
-  height: 3.5in;
-  top: 0;
-  left: 0.5in; }
+  width: 8.75in;
+  height: 4in;
+  transform: translateX(-1.125in);
+  top: -0.8in;
+  left: 1.2in; }
   [data-type="chapter"] > h1[data-type="document-title"] .os-text {
     position: absolute;
     bottom: -10px;

--- a/styles/output/intro-business.css
+++ b/styles/output/intro-business.css
@@ -331,35 +331,42 @@ nav#toc > ol > li {
     padding-top: 3.5in; }
     [data-type="chapter"] > .introduction > [data-type="document-title"] {
       display: none; }
-    [data-type="chapter"] > .introduction > [data-type="document-title"] + .os-figure {
-      display: flex;
-      align-items: center;
-      position: absolute;
+    [data-type="chapter"] > .introduction > [data-type="document-title"] + .os-figure figure {
+      margin: 0;
       overflow: hidden;
-      width: 8.75in;
-      height: 4.3in;
-      transform: translateX(-1.125in);
-      top: -0.8in; }
-      [data-type="chapter"] > .introduction > [data-type="document-title"] + .os-figure figure {
-        margin: 0; }
-      [data-type="chapter"] > .introduction > [data-type="document-title"] + .os-figure .os-caption-container {
-        width: 6.5in; }
-      [data-type="chapter"] > .introduction > [data-type="document-title"] + .os-figure [data-type="media"] {
+      position: absolute;
+      margin-bottom: -0.8in;
+      width: 6.5in;
+      height: 3.5in;
+      top: 0; }
+      [data-type="chapter"] > .introduction > [data-type="document-title"] + .os-figure figure::after {
+        width: 100%;
+        content: " ";
         display: block;
-        width: 100%; }
-        [data-type="chapter"] > .introduction > [data-type="document-title"] + .os-figure [data-type="media"]::after {
-          width: 100%;
-          content: " ";
-          display: block;
-          position: absolute;
-          bottom: 0;
-          height: 70px;
-          background-color: #24739e;
-          border-top: 4px solid #11374b; }
-        [data-type="chapter"] > .introduction > [data-type="document-title"] + .os-figure [data-type="media"] img {
+        position: absolute;
+        bottom: 0;
+        height: 70px;
+        background-color: #24739e;
+        border-top: 4px solid #11374b; }
+      [data-type="chapter"] > .introduction > [data-type="document-title"] + .os-figure figure span[data-type="media"] {
+        display: block;
+        line-height: 0;
+        width: 100%;
+        height: 100%;
+        /* Prince -v latest */
+        /* end Prince -v latest */ }
+        [data-type="chapter"] > .introduction > [data-type="document-title"] + .os-figure figure span[data-type="media"] img {
           width: 100%;
           position: relative;
-          top: -35px; }
+          /* Prince -v <= 11.0 */
+          margin-top: 1.75in;
+          transform: translateY(-50%);
+          padding-bottom: 70px;
+          /* end Prince -v <= 11.0 */
+          /* Prince -v latest */
+          /* end Prince -v latest */ }
+    [data-type="chapter"] > .introduction > [data-type="document-title"] + .os-figure .os-caption-container {
+      width: 6.5in; }
 
 /* -------------------------
  * Chapter title (over the splash page)
@@ -375,11 +382,10 @@ nav#toc > ol > li {
   text-transform: capitalize;
   z-index: 1;
   margin: 0;
-  width: 8.75in;
-  height: 4.3in;
-  transform: translateX(-1.125in);
-  top: -0.8in;
-  left: 1.2in; }
+  width: 6.5in;
+  height: 3.5in;
+  top: 0;
+  left: 0.5in; }
   [data-type="chapter"] > h1[data-type="document-title"] .os-text {
     position: absolute;
     bottom: -10px;
@@ -389,21 +395,15 @@ nav#toc > ol > li {
     white-space: normal; }
   [data-type="chapter"] > h1[data-type="document-title"] .os-number {
     font-family: "Roboto Condensed", serif;
-    top: auto;
-    left: 0;
-    bottom: 50px;
+    bottom: 47.5px;
     background-color: #FFFFFF;
-    border-radius: 50%;
-    min-width: 0;
-    min-height: 0;
     width: 45px;
     height: 45px;
-    padding-top: 0;
-    border: none;
     display: block;
     line-height: 45px;
     color: #344456;
     position: absolute;
+    border-radius: 50%;
     border: 1px solid #FFFFFF;
     text-align: center; }
   [data-type="chapter"] > h1[data-type="document-title"]::after {

--- a/styles/output/intro-business.css
+++ b/styles/output/intro-business.css
@@ -336,17 +336,11 @@ nav#toc > ol > li {
       overflow: hidden;
       position: absolute;
       margin-bottom: -0.8in;
-      width: 8.75in;
-      height: 4in;
-      transform: translateX(-1.125in);
-      top: -0.8in; }
-      [data-type="chapter"] > .introduction > [data-type="document-title"] + .os-figure figure::before {
-        width: 100%;
-        content: " ";
-        position: absolute;
-        height: 120px;
-        background: linear-gradient(rgba(0, 0, 0, 0.35), rgba(0, 0, 0, 0));
-        z-index: 1; }
+      width: 6.5in;
+      height: 3.2in;
+      top: 0;
+      /* Prince -v latest */
+      /* end Prince -v latest */ }
       [data-type="chapter"] > .introduction > [data-type="document-title"] + .os-figure figure::after {
         width: 100%;
         content: " ";
@@ -355,7 +349,7 @@ nav#toc > ol > li {
         bottom: 0;
         height: 70px;
         background-color: #24739e;
-        border-top: 4px solid #11374b; }
+        border-top: 4px solid #1b5574; }
       [data-type="chapter"] > .introduction > [data-type="document-title"] + .os-figure figure span[data-type="media"] {
         display: block;
         line-height: 0;
@@ -367,7 +361,7 @@ nav#toc > ol > li {
           width: 100%;
           position: relative;
           /* Prince -v <= 11.0 */
-          margin-top: 2in;
+          margin-top: 1.6in;
           transform: translateY(-50%);
           padding-bottom: 70px;
           /* end Prince -v <= 11.0 */
@@ -381,27 +375,23 @@ nav#toc > ol > li {
  * ------------------------
  */
 [data-type="chapter"] > h1[data-type="document-title"] {
-  font-size: 23px;
+  font-size: 19px;
   position: absolute;
   color: #FFFFFF;
   white-space: nowrap;
-  font-weight: bold;
-  font-family: "Noto Sans", sans-serif;
-  text-transform: capitalize;
+  font-family: "Roboto Condensed", serif;
   z-index: 1;
   margin: 0;
-  width: 8.75in;
-  height: 4in;
-  transform: translateX(-1.125in);
-  top: -0.8in;
-  left: 1.2in; }
+  width: 6.5in;
+  height: 3.2in; }
   [data-type="chapter"] > h1[data-type="document-title"] .os-text {
     position: absolute;
-    bottom: -10px;
-    left: 80px;
-    width: 60%;
-    height: 70px;
-    white-space: normal; }
+    bottom: 0;
+    max-width: 6.5in;
+    height: 60px;
+    white-space: normal;
+    font-weight: normal;
+    left: 128px; }
   [data-type="chapter"] > h1[data-type="document-title"] .os-number {
     font-family: "Roboto Condensed", serif;
     bottom: 47.5px;
@@ -414,16 +404,15 @@ nav#toc > ol > li {
     position: absolute;
     border-radius: 50%;
     border: 1px solid #FFFFFF;
-    text-align: center; }
+    text-align: center;
+    left: 0.5in; }
   [data-type="chapter"] > h1[data-type="document-title"]::after {
     content: " ";
     display: block;
     width: 170px;
-    height: 73px;
+    height: 70px;
     position: absolute;
-    left: 0;
     bottom: 0;
-    transform: translateX(-1in);
     z-index: 3; }
 
 /* -------------------------

--- a/styles/output/intro-business.css
+++ b/styles/output/intro-business.css
@@ -336,6 +336,7 @@ nav#toc > ol > li {
       overflow: hidden;
       position: absolute;
       margin-bottom: -0.8in;
+      max-width: none;
       width: 8.75in;
       height: 4in;
       transform: translateX(-1.125in);
@@ -370,7 +371,8 @@ nav#toc > ol > li {
           /* Prince -v latest */
           /* end Prince -v latest */ }
     [data-type="chapter"] > .introduction > [data-type="document-title"] + .os-figure .os-caption-container {
-      width: 6.5in; }
+      width: 6.5in;
+      margin-top: 8px; }
 
 /* -------------------------
  * Chapter title (over the splash page)

--- a/styles/themes/theme3/config/_settings.scss
+++ b/styles/themes/theme3/config/_settings.scss
@@ -7,10 +7,11 @@
 @function theme3-settings() {
   $THEME_SETTINGS: (
     toc-number-box-size: 20px,
-    splash-page-depth: 4.3in,
+    splash-page-depth: 4.0in,
     splash-title-bar-height: 70px,
-    full-bleed-splash: false,
+    full-bleed-splash: true,
     enforce-splash-height: false,
+    splash-gradient-length: 120px,
     title-border-size: 1px,
     h1-number-border-color: color-map(h1-number-border),
     h2-number-border-color: color-map(h2-number-border),

--- a/styles/themes/theme3/config/_settings.scss
+++ b/styles/themes/theme3/config/_settings.scss
@@ -9,7 +9,7 @@
     toc-number-box-size: 20px,
     splash-page-depth: 4.0in,
     splash-title-bar-height: 70px,
-    full-bleed-splash: true,
+    full-bleed-splash: false,
     enforce-splash-height: false,
     splash-gradient-length: 120px,
     title-border-size: 1px,

--- a/styles/themes/theme3/config/_settings.scss
+++ b/styles/themes/theme3/config/_settings.scss
@@ -9,7 +9,7 @@
     toc-number-box-size: 20px,
     splash-page-depth: 4.3in,
     splash-title-bar-height: 70px,
-    full-bleed-splash: true,
+    full-bleed-splash: false,
     enforce-splash-height: false,
     title-border-size: 1px,
     h1-number-border-color: color-map(h1-number-border),

--- a/styles/themes/theme3/config/_settings.scss
+++ b/styles/themes/theme3/config/_settings.scss
@@ -9,7 +9,7 @@
     toc-number-box-size: 20px,
     splash-page-depth: 4.0in,
     splash-title-bar-height: 70px,
-    full-bleed-splash: false,
+    full-bleed-splash: true,
     enforce-splash-height: false,
     splash-gradient-length: 120px,
     title-border-size: 1px,

--- a/styles/themes/theme3/style/chapter-title.scss
+++ b/styles/themes/theme3/style/chapter-title.scss
@@ -4,39 +4,41 @@
  */
 [data-type="chapter"] {
   > h1[data-type="document-title"] {
-    font-size: size-scale(4);
+    font-size: size-scale(3);
     position: absolute;
     color: color-map(chapter-title);
     white-space: nowrap;
-    font-weight: bold;
-    font-family: font-map(sans-serif);
-    text-transform: capitalize;
+    font-family: font-map(serif);
     z-index: 1;
-    margin: 0 ;
+    margin: 0;
+    width: PAGE_CONTENT_WIDTH();
     @if settings(full-bleed-splash) {
-      width: FULL_BLEED_WIDTH();
       height: settings(splash-page-depth);
-      transform: translateX(-1 * (PAGE_HORIZONTAL_MARGIN() + (FULL_BLEED_ADD() / 2)));
       top: -1 * PAGE_VERTICAL_MARGIN();
-      left: 1.2in;
     } @else {
-      width: PAGE_CONTENT_WIDTH();
       height: settings(splash-page-depth) - PAGE_VERTICAL_MARGIN();
-      top: 0;
-      left: 0.5in;
     }
 
     .os-text {
+      $drop: 10px;
+      $left-padding: 80px;
+
       position: absolute;
-      bottom: -10px;
-      left: 80px;
-      width: 60%;
-      height: settings(splash-title-bar-height);
+      bottom: 0;
+      max-width: PAGE_CONTENT_WIDTH();
+      height: settings(splash-title-bar-height) - $drop;
       white-space: normal;
+      font-weight: normal;
+      @if settings(full-bleed-splash) {
+        left: $left-padding;
+      } @else {
+        left: $left-padding + PAGE_HORIZONTAL_MARGIN() / 2;
+      }
     }
 
     .os-number {
       $diameter: 45px;
+
       font-family: font-map(serif);
       bottom: settings(splash-title-bar-height) - ($diameter / 2);
       background-color: color-map(chapter-number-bg);
@@ -49,19 +51,25 @@
       border-radius: 50%;
       border: 1px solid color-map(chapter-number-border);
       text-align: center;
+      @if not settings(full-bleed-splash) {
+        left: PAGE_HORIZONTAL_MARGIN() / 2;
+      }
     }
 
     &::after {
+      $icon-width: 170px;
+
       content: CONTENT_BLANK();
       display: block;
-      width: 170px;
-      height: 73px;
+      width: $icon-width;
+      height: settings(splash-title-bar-height);
       position: absolute;
-      left: 0;
       bottom: 0;
-      transform: translateX(-1 * PAGE_HORIZONTAL_MARGIN());
       // background: url("ccap-business/business-books-intro-graphic.svg") 0 0 no-repeat;
       z-index: 3;
+      @if settings(full-bleed-splash) {
+        left: -1 * PAGE_HORIZONTAL_MARGIN();
+      }
     }
   }
 }

--- a/styles/themes/theme3/style/chapter-title.scss
+++ b/styles/themes/theme3/style/chapter-title.scss
@@ -36,22 +36,17 @@
     }
 
     .os-number {
+      $diameter: 45px;
       font-family: font-map(serif);
-      top: auto;
-      left: 0;
-      bottom: 50px;
+      bottom: settings(splash-title-bar-height) - ($diameter / 2);
       background-color: color-map(chapter-number-bg);
-      border-radius: 50%;
-      min-width: 0;
-      min-height: 0;
-      width: 45px;
-      height: 45px;
-      padding-top: 0;
-      border: none;
+      width: $diameter;
+      height: $diameter;
       display: block;
-      line-height: 45px;
+      line-height: $diameter;
       color: color-map(chapter-number);
       position: absolute;
+      border-radius: 50%;
       border: 1px solid color-map(chapter-number-border);
       text-align: center;
     }

--- a/styles/themes/theme3/style/splash.scss
+++ b/styles/themes/theme3/style/splash.scss
@@ -15,6 +15,7 @@
         overflow: hidden;
         position: absolute;
         margin-bottom: -1 * PAGE_VERTICAL_MARGIN();
+        max-width: none;
         @if settings(full-bleed-splash) {
           width: FULL_BLEED_WIDTH();
           height: settings(splash-page-depth);

--- a/styles/themes/theme3/style/splash.scss
+++ b/styles/themes/theme3/style/splash.scss
@@ -62,6 +62,7 @@
           img {
             width: 100%;
             position: relative;
+            max-width: none;
 
             /* Prince -v <= 11.0 */
               @if settings(full-bleed-splash) {
@@ -86,6 +87,7 @@
 
       .os-caption-container {
         width: PAGE_CONTENT_WIDTH();
+        margin-top: size-scale(-3);
       }
     }
   }

--- a/styles/themes/theme3/style/splash.scss
+++ b/styles/themes/theme3/style/splash.scss
@@ -44,8 +44,8 @@
           position: absolute;
           bottom: 0;
           height: settings(splash-title-bar-height);
-          background-color: color-map(splash-bottom-bar);
-          border-top: 4px solid color-map(splash-bottom-bar-border);
+          background-color: color-map(splash-title-bar);
+          border-top: 4px solid color-map(splash-title-bar-border);
         }
 
         span[data-type="media"] {

--- a/styles/themes/theme3/style/splash.scss
+++ b/styles/themes/theme3/style/splash.scss
@@ -25,6 +25,17 @@
           height: settings(splash-page-depth) - PAGE_VERTICAL_MARGIN();
           top: 0;
         }
+        
+        /* Prince -v latest */
+          // &::before {
+          //   width: 100%;
+          //   content: CONTENT_BLANK();
+          //   position: absolute;
+          //   height: settings(splash-gradient-length);
+          //   background: linear-gradient(rgba(0,0,0,0.35), rgba(0,0,0,0));
+          //   z-index: 1;
+          // }
+        /* end Prince -v latest */
 
         &::after {
           width: 100%;

--- a/styles/themes/theme3/style/splash.scss
+++ b/styles/themes/theme3/style/splash.scss
@@ -9,34 +9,22 @@
     }
 
     > [data-type="document-title"] + .os-figure {
-      display: flex;
-      align-items: center;
-      position: absolute;
-      overflow: hidden;
-      @if settings(full-bleed-splash) {
-        width: FULL_BLEED_WIDTH();
-        height: settings(splash-page-depth);
-        transform: translateX(-1 * (PAGE_HORIZONTAL_MARGIN() + (FULL_BLEED_ADD() / 2)));
-        top: -1 * PAGE_VERTICAL_MARGIN();
-      } @else {
-        width: PAGE_CONTENT_WIDTH();
-        height: settings(splash-page-depth) - PAGE_VERTICAL_MARGIN();
-        top: 0;
-      }
-      
 
       figure {
         margin: 0;
-      }
-
-      .os-caption-container {
-        width: PAGE_CONTENT_WIDTH();
-      }
-
-      [data-type="media"] {
-        // Please ensure that this element is a block element
-        display: block;
-        width: 100%;
+        overflow: hidden;
+        position: absolute;
+        margin-bottom: -1 * PAGE_VERTICAL_MARGIN();
+        @if settings(full-bleed-splash) {
+          width: FULL_BLEED_WIDTH();
+          height: settings(splash-page-depth);
+          transform: translateX(-1 * (PAGE_HORIZONTAL_MARGIN() + (FULL_BLEED_ADD() / 2)));
+          top: -1 * PAGE_VERTICAL_MARGIN();
+        } @else {
+          width: PAGE_CONTENT_WIDTH();
+          height: settings(splash-page-depth) - PAGE_VERTICAL_MARGIN();
+          top: 0;
+        }
 
         &::after {
           width: 100%;
@@ -49,14 +37,44 @@
           border-top: 4px solid color-map(splash-bottom-bar-border);
         }
 
-        img {
+        span[data-type="media"] {
+          // Please ensure that this element is a block element since its a span
+          display: block;
+          line-height: 0;
           width: 100%;
-          position: relative;
-          top: -1 * settings(splash-title-bar-height) / 2;
-          @if settings(enforce-splash-height) {
-            height: settings(splash-height) - settings(splash-title-bar-height);
+          height: 100%;
+          /* Prince -v latest */
+            // display: flex;
+            // align-items: center;
+          /* end Prince -v latest */
+
+          img {
+            width: 100%;
+            position: relative;
+
+            /* Prince -v <= 11.0 */
+              @if settings(full-bleed-splash) {
+                margin-top: settings(splash-page-depth) / 2;
+              } @else {
+                margin-top: (settings(splash-page-depth) - PAGE_VERTICAL_MARGIN()) / 2;
+              }
+              transform: translateY(-50%);
+              padding-bottom: settings(splash-title-bar-height);
+            /* end Prince -v <= 11.0 */
+
+            /* Prince -v latest */
+              // top: -1 * (settings(splash-title-bar-height) / 2);
+            /* end Prince -v latest */
+
+            @if settings(enforce-splash-height) {
+              height: settings(splash-height) - settings(splash-title-bar-height);
+            }
           }
         }
+      }
+
+      .os-caption-container {
+        width: PAGE_CONTENT_WIDTH();
       }
     }
   }


### PR DESCRIPTION
This makes full and non-full bleed splashes compatible with Prince 11. Also, fixes an issue with the caption not appearing.