### PR TITLE
Add word 'Skills' to composite page title

### DIFF
--- a/recipes/books/intro-business/_config.scss
+++ b/recipes/books/intro-business/_config.scss
@@ -192,7 +192,7 @@ $Config_PartType_Example: (     moveTo: $AREA_NONE,          titleContent: $_exa
 $Config_ChapterCompositePages: (
   (className: "glossary",             clusterBy: $CLUSTER_NONE,   specialPageType: $PAGE_GLOSSARY, sortBy: "xhtml|dl > xhtml|dt",    name: "Key Terms"),
   (className: "section-summary",      clusterBy: $CLUSTER_NONE,   hasSolutions: false,    name: "Summary of Learning Outcomes"),
-  (className: "prep-workplace",       clusterBy: $CLUSTER_NONE,   hasSolutions: false,    name: "Preparing for Tomorrow's Workplace"),
+  (className: "prep-workplace",       clusterBy: $CLUSTER_NONE,   hasSolutions: false,    name: "Preparing for Tomorrow's Workplace Skills"),
   (className: "ethics-activity",      clusterBy: $CLUSTER_NONE,   hasSolutions: false,    name: "Ethics Activity"),
   (className: "working-net",          clusterBy: $CLUSTER_NONE,   hasSolutions: false,    name: "Working the Net"),
   (className: "critical-thinking",    clusterBy: $CLUSTER_NONE,   hasSolutions: false,    name: "Critical Thinking Case"),

--- a/recipes/books/intro-business/styleguide/book.composite.prep-tomorrow.snippet.xml
+++ b/recipes/books/intro-business/styleguide/book.composite.prep-tomorrow.snippet.xml
@@ -3,7 +3,7 @@
   <!-- START:Page -->
   <!-- Markup starts here -->
   <section id="eip-250" class="prep-workplace">
-    <title>Preparing for Tomorrow's Workplace</title>
+    <title>Preparing for Tomorrow's Workplace Skills</title>
     <para id="eip-98">
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
       dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

--- a/recipes/output/intro-business.css
+++ b/recipes/output/intro-business.css
@@ -1664,7 +1664,7 @@
 
 :pass(8) [data-type="composite-page"].os-eoc.os-prep-workplace-container::before {
   container: span;
-  content: "Preparing for Tomorrow's Workplace";
+  content: "Preparing for Tomorrow's Workplace Skills";
   class: os-text;
   move-to: h2-TITLECONTAINER; }
 


### PR DESCRIPTION
Word was missing. Simply added it onto the title in the config for the composite page. Link: Issue #445 