### PR TITLE
Fix Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,13 +32,14 @@ before_install:
   - wget https://github.com/SimonKagstrom/kcov/archive/master.tar.gz &&
     tar xzf master.tar.gz &&
     rm master.tar.gz &&
+    mkdir "${HOME}/kcov-build/" &&
     cd kcov-master &&
     mkdir build &&
     cd build &&
-    cmake .. &&
+    cmake -DCMAKE_INSTALL_PREFIX=${HOME}/kcov-build/ .. &&
     make &&
-    sudo make install &&
+    make install &&
     cd ../.. &&
     rm -rf kcov-master
-script: kcov ./coverage/ ./script/ci
+script: ${HOME}/kcov-build/bin/kcov ./coverage/ ./script/ci
 after_success: bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Travis was complaining about needing to have sudo access in order to install [kcov](https://github.com/SimonKagstrom/kcov) . This fixes the install so that it does not require sudo access.

Refs #468