### PR TITLE
Add glossary instead of key terms

### DIFF
--- a/recipes/books/business-ethics/_config.scss
+++ b/recipes/books/business-ethics/_config.scss
@@ -114,15 +114,10 @@ $Config_Notes: (
 */
 $Config_ChapterCompositePages: (
   (className: "section-summary",         clusterBy: $CLUSTER_SECTION,                      name: "Summary"),
-
-  (className: "key-terms",               clusterBy: $CLUSTER_NONE,      name: "Key Terms"),
-
+  (className: "glossary",                clusterBy: $CLUSTER_NONE,      name: "Key Terms",  specialPageType: $PAGE_GLOSSARY, sortBy: "xhtml|dl > xhtml|dt",),
   (className: "assessment-questions",    clusterBy: $CLUSTER_SECTION,   name: "Assessment Questions", hasSolutions: true, moveSolutionsTo: $AREA_NONE,   numberAt: $NUMBER_BEFORE_MOVE,),
-
   (className: "references",              clusterBy: $CLUSTER_SECTION,                      name: "End Notes"),
-
   (className: "figure-credits",          clusterBy: $CLUSTER_NONE,                         name: "Figure Credits"),
-
   (className: "case-study",              clusterBy: $CLUSTER_NONE,                         name: "Case Study"),
 );
 

--- a/recipes/output/business-ethics.css
+++ b/recipes/output/business-ethics.css
@@ -874,18 +874,23 @@
   data-type: "composite-page";
   data-uuid-key: ".section-summary"; }
 
-:pass(3) div[data-type="chapter"] section.key-terms {
-  move-to: key-terms-TOCOMPOSITE; }
-  :pass(3) div[data-type="chapter"] section.key-terms > [data-type="title"] {
+:pass(3) div[data-type="chapter"] div[data-type="glossary"] {
+  /* Discard this Page-specific glossary because it is collated later and the title is added when this is collated */
+  move-to: trash; }
+
+:pass(3) div[data-type="chapter"] div[data-type="glossary"] dl {
+  move-to: glossary-TOCOMPOSITE; }
+  :pass(3) div[data-type="chapter"] div[data-type="glossary"] dl > [data-type="title"] {
     /* Discard this Page-specific title because a chapter title is added when collated */
     move-to: trash; }
 
 :pass(3) div[data-type="chapter"]::after {
   container: div;
-  content: pending(key-terms-TOCOMPOSITE);
-  class: "os-eoc os-key-terms-container";
+  content: pending(glossary-TOCOMPOSITE);
+  class: "os-eoc os-glossary-container";
   data-type: "composite-page";
-  data-uuid-key: ".key-terms"; }
+  data-uuid-key: "<glossary>";
+  sort-by: xhtml|dl > xhtml|dt, nocase; }
 
 :pass(3) div[data-type="chapter"] section.assessment-questions {
   /* TODO: Is this used? because it looks like there is a typo here. `sectionHeaderNode` is not defined */
@@ -1218,13 +1223,13 @@
   data-type: "document-title";
   content: pending(h2-TITLECONTAINER); }
 
-:pass(8) [data-type="composite-page"].os-eoc.os-key-terms-container::before {
+:pass(8) [data-type="composite-page"].os-eoc.os-glossary-container::before {
   container: span;
   content: "Key Terms";
   class: os-text;
   move-to: h2-TITLECONTAINER; }
 
-:pass(8) [data-type="composite-page"].os-eoc.os-key-terms-container::before {
+:pass(8) [data-type="composite-page"].os-eoc.os-glossary-container::before {
   container: h2;
   data-type: "document-title";
   content: pending(h2-TITLECONTAINER); }


### PR DESCRIPTION
issue #522

Remove the EOC section "key terms" to use the glossary.


![2018-08-07_16-03-00](https://user-images.githubusercontent.com/8514591/43802449-6d4acb06-9a5b-11e8-8a57-b523abb8b533.png)
