### PR TITLE
Deleted extra point in Chapter Outline

### DIFF
--- a/recipes/books/ap-physics/_config.scss
+++ b/recipes/books/ap-physics/_config.scss
@@ -69,6 +69,7 @@ $Config_Coverage_MayHaveIframes: false;
 $Config_Coverage_MayHaveMissingExercises: false;
 
 $Config_hasCompositeChapter: false;
+$Config_hasAbstract: false;
 
 $Config_ContentExercise_TitleContent : (os-number : counter(chapter) "." counter(exerciseMaybeInContent), os-title-label : "Exercise ");
 $Config_ContentExercise_TitleContentAp : (os-number : counter(appendix, upper-alpha ) "." counter(exerciseMaybeInContent), os-title-label : "Exercise ");

--- a/recipes/output/ap-physics.css
+++ b/recipes/output/ap-physics.css
@@ -481,6 +481,9 @@
 :pass(1) [data-type="metadata"] > [data-type="description"] {
   move-to: trash; }
 
+:pass(1) [data-type="abstract"] {
+  move-to: trash; }
+
 :pass(3) body {
   counter-reset: chapter; }
 


### PR DESCRIPTION
Issue: #536 

Simply I've set `hasAbstract` as false in ap-physics only as @helenemccarron said.

### **Before:**
![image](https://user-images.githubusercontent.com/20907906/44081869-1b77d65c-9fb0-11e8-82d9-23004a59ad96.png)

### **After:**
![image](https://user-images.githubusercontent.com/20907906/44081879-220010fc-9fb0-11e8-8420-91efbc47ca72.png)
