### PR TITLE
fix native node bindings

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -181,11 +181,6 @@ if [[ ! ${BOOTSTRAP_ALREADY_RAN} ]]; then
           do_progress_quiet "Installing correct version of node" \
             nodenv install "$(< ./.node-version)" --skip-existing
 
-          # Add the nodenv version of node into the path so that `#!/usr/bin/env node` works.
-          # This is needed when packages build native code so they are compiled
-          # against the correct version of node (e.g. node-sass)
-          PATH="$(dirname "$(nodenv which node)" ):${PATH}"
-
         elif [[ -f "${HOME}/.nvm/nvm.sh" ]]; then
           # DEPRECATE the nvm method once deployments do not use it
           # shellcheck disable=SC1090
@@ -199,7 +194,7 @@ if [[ ! ${BOOTSTRAP_ALREADY_RAN} ]]; then
       # This is needed when packages build native code so they are compiled
       # against the correct version of node (e.g. node-sass)
       if [[ $(command -v nodenv) ]]; then
-        do_progress "Prepending node to beginning of path so native bindings compile against the right version of node"
+        do_progress "Prepending nodenv node to beginning of PATH so native bindings compile against the right version of node"
         PATH="$(dirname "$(nodenv which node)" ):${PATH}"
       elif [[ $(command -v nvm) ]]; then
         nvm use "$(< ./.node-version)"

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -180,6 +180,12 @@ if [[ ! ${BOOTSTRAP_ALREADY_RAN} ]]; then
           eval "$(nodenv init -)"
           do_progress_quiet "Installing correct version of node" \
             nodenv install "$(< ./.node-version)" --skip-existing
+
+          # Add the nodenv version of node into the path so that `#!/usr/bin/env node` works.
+          # This is needed when packages build native code so they are compiled
+          # against the correct version of node (e.g. node-sass)
+          PATH="$(dirname "$(nodenv which node)" ):${PATH}"
+
         elif [[ -f "${HOME}/.nvm/nvm.sh" ]]; then
           # DEPRECATE the nvm method once deployments do not use it
           # shellcheck disable=SC1090
@@ -187,6 +193,16 @@ if [[ ! ${BOOTSTRAP_ALREADY_RAN} ]]; then
           do_progress_quiet "${c_red}DEPRECATED:${c_none} Setting correct node version using nvm. Try using https://github.com/nodenv/nodenv instead (add it to Brewfile)" \
             nvm install "v$(< ./.node-version)"
         fi
+      fi
+
+      # Add the nodenv version of node into the path so that `#!/usr/bin/env node` works.
+      # This is needed when packages build native code so they are compiled
+      # against the correct version of node (e.g. node-sass)
+      if [[ $(command -v nodenv) ]]; then
+        do_progress "Prepending node to beginning of path so native bindings compile against the right version of node"
+        PATH="$(dirname "$(nodenv which node)" ):${PATH}"
+      elif [[ $(command -v nvm) ]]; then
+        nvm use "$(< ./.node-version)"
       fi
 
       version_actual="$(node --version 2> /dev/null)"

--- a/script/setup
+++ b/script/setup
@@ -6,14 +6,6 @@ source ./script/bootstrap || exit 111
 
 # JavaScript stuff
 if [[ -f "./package.json" ]]; then
-  # Add the nodenv version of node into the path so that `#!/usr/bin/env node` works.
-  # This is needed when packages build native code so they are compiled
-  # against the correct version of node (e.g. node-sass)
-  if [[ $(command -v nodenv) ]]; then
-    PATH="$(dirname "$(nodenv which node)" ):${PATH}"
-  elif [[ $(command -v nvm) ]]; then
-    nvm use "$(< ./.node-version)"
-  fi
   do_progress_quiet "Installing JavaScript Packages" \
     yarn --prefer-offline
 fi


### PR DESCRIPTION
since node-sass may not run the nodenv version of node. This seems to have caused problems with Travis not compiling the sass files properly.

A fix was attempted in https://github.com/Connexions/cnx-recipes/pull/475/commits/16c77f59274a0048c2955779edc708494b0a40b7 but the code should have been added to `./script/bootstrap` instead of `./script/setup`

Example Travis output:

```
$ ${HOME}/kcov-build/bin/kcov ./coverage/ ./script/ci
  Running setup.py (path:/home/travis/virtualenv/python2.7.14/src/cnxeasybake/setup.py) egg_info for package cnxeasybake produced metadata for project name cnx-easybake. Fix your #egg=cnxeasybake fragments.
  Running setup.py (path:/home/travis/virtualenv/python2.7.14/src/cnxepub/setup.py) egg_info for package cnxepub produced metadata for project name cnx-epub. Fix your #egg=cnxepub fragments.
Cloning into './vendor/rhaptos.cnxmlutils'...
remote: Counting objects: 5506, done.
remote: Compressing objects: 100% (5/5), done.
remote: Total 5506 (delta 0), reused 2 (delta 0), pack-reused 5501
Receiving objects: 100% (5506/5506), 1.30 MiB | 21.89 MiB/s, done.
Resolving deltas: 100% (3316/3316), done.
Switched to a new branch 'rng-fixes'
{
  "status": 1,
  "file": "/home/travis/build/Connexions/cnx-recipes/recipes/mixins/_modify.scss",
  "line": 165,
  "column": 13,
  "message": "Invalid CSS after \"    &:match(\": expected selector, was '\"^[ ](Symbols|SYMBO'",
  "formatted": "Error: Invalid CSS after \"    &:match(\": expected selector, was '\"^[ ](Symbols|SYMBO'\n        on line 165 of recipes/mixins/_modify.scss\n        from line 5 of recipes/mixins/_all.scss\n        from line 1 of recipes/books/principles-management/book.scss\n>>     &:match(\"^[ ](Symbols|SYMBOLS)\") {\n\n   ------------^\n"
}
./script/compile-books: ERROR: could not run [/home/travis/build/Connexions/cnx-recipes/node_modules/.bin/node-sass --source-map true --output-style nested ./recipes/books/principles-management/book.scss ./recipes/output//principles-management.css]
./script/test: ERROR: could not run [./script/compile-books]
The command "${HOME}/kcov-build/bin/kcov ./coverage/ ./script/ci" exited with 111.
cache.2
store build cache
```

/cc @tomjw64 since we DM'd about this problem