### PR TITLE
Downgrade node-sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "devDependencies": {
     "kss": "^2.4.0",
-    "node-sass": "^4.9.0",
+    "node-sass": "^4.5.3",
     "sass-lint": "^1.9.1",
     "sassdoc": "^2.1.20"
   },


### PR DESCRIPTION
Fixes the problem that #550 tried to fix.

node-sass was failing to compile with this message:

```
$ ${HOME}/kcov-build/bin/kcov ./coverage/ ./script/ci
  Running setup.py (path:/home/travis/virtualenv/python2.7.14/src/cnxeasybake/setup.py) egg_info for package cnxeasybake produced metadata for project name cnx-easybake. Fix your #egg=cnxeasybake fragments.
  Running setup.py (path:/home/travis/virtualenv/python2.7.14/src/cnxepub/setup.py) egg_info for package cnxepub produced metadata for project name cnx-epub. Fix your #egg=cnxepub fragments.
Cloning into './vendor/rhaptos.cnxmlutils'...
remote: Counting objects: 5506, done.
remote: Compressing objects: 100% (5/5), done.
remote: Total 5506 (delta 0), reused 2 (delta 0), pack-reused 5501
Receiving objects: 100% (5506/5506), 1.30 MiB | 10.68 MiB/s, done.
Resolving deltas: 100% (3316/3316), done.
Switched to a new branch 'rng-fixes'
{
  "status": 1,
  "file": "/home/travis/build/Connexions/cnx-recipes/recipes/mixins/_modify.scss",
  "line": 165,
  "column": 13,
  "message": "Invalid CSS after \"    &:match(\": expected selector, was '\"^[ ](Symbols|SYMBO'",
  "formatted": "Error: Invalid CSS after \"    &:match(\": expected selector, was '\"^[ ](Symbols|SYMBO'\n        on line 165 of recipes/mixins/_modify.scss\n        from line 5 of recipes/mixins/_all.scss\n        from line 1 of recipes/books/principles-management/book.scss\n>>     &:match(\"^[ ](Symbols|SYMBOLS)\") {\n\n   ------------^\n"
}
./script/compile-books: ERROR: could not run [/home/travis/build/Connexions/cnx-recipes/node_modules/.bin/node-sass --source-map true --output-style nested ./recipes/books/principles-management/book.scss ./recipes/output//principles-management.css]
./script/test: ERROR: could not run [./script/compile-books]
```

It seems that `package.json` and `yarn.lock` were not in-sync. Yarn.lock pointed to 4.5.3 while package.json pointed to 4.9.0 . We could probably create a script that verifies these are still in-sync (maybe there is a `yarn --check` command or something to make sure the `yarn.lock` file is in-sync with `package.json`.

/cc @tomjw64 