### PR TITLE
Normalize Exercises Numbers in the EOC and EOB

### DIFF
--- a/recipes/books/_common-stuff.scss
+++ b/recipes/books/_common-stuff.scss
@@ -28,7 +28,7 @@ $Config_ContentSolution_TitleContentAp : null; // It seems that this is null for
 
 
 //global exercises numbering. There is a whitespace in the divider
-$_exerciseTitleContent: (os-divider: ". ", os-number: counter(exercise));
+$Config_exerciseTitleContent: (os-divider: ". ", os-number: counter(exercise));
 
 $Config_UnnumberedEquations: ();
 

--- a/recipes/books/_common-stuff.scss
+++ b/recipes/books/_common-stuff.scss
@@ -26,6 +26,10 @@ $Config_ContentSolution_TitleContent : null; // It seems that this is null for a
 $Config_ContentExercise_TitleContentAp : (os-number : counter(exerciseMaybeInContent), os-title-label : "Exercise ");
 $Config_ContentSolution_TitleContentAp : null; // It seems that this is null for all books
 
+
+//global exercises numbering. There is a whitespace in the divider
+$_exerciseTitleContent: (os-divider: ". ", os-number: counter(exercise));
+
 $Config_UnnumberedEquations: ();
 
 $Config_addSolutionHeader: ();

--- a/recipes/books/_example/_config.scss
+++ b/recipes/books/_example/_config.scss
@@ -15,7 +15,7 @@ $RECIPE_NAME: "_example";
 // They are local vars that are used below.
 // NOTE: The order of each value matters; it is the order in which these
 // elements will occur in the generated text.
-$_exerciseTitleContent       : (os-divider: ".", os-number: counter(exercise));
+
 $_exampleTitleContent        : (os-title-label: "Example ", os-number: counter(chapter) "." counter(example));
 $_exampleSolutionTitleContent: (os-title-label: "Solution ", os-number: counter(chapter) "." counter(example));
 $_tryTitleContent            : (os-title-label: "Try It ", os-number: counter(chapter) "." counter(example)); // try it notes are numbered based on the example preceeding them

--- a/recipes/books/_example/_config.scss
+++ b/recipes/books/_example/_config.scss
@@ -143,7 +143,7 @@ $Config_UnnumberedExercises: (
 //  OTHER PARTS
 // ==========================================================
 
-$Config_PartType_Exercise: (moveTo: $AREA_EOC, resetAt: $RESET_CHAPTER,  numberAt: $NUMBER_BEFORE_MOVE, titleContent: $_exerciseTitleContent);
+$Config_PartType_Exercise: (moveTo: $AREA_EOC, resetAt: $RESET_CHAPTER,  numberAt: $NUMBER_BEFORE_MOVE, titleContent: $Config_exerciseTitleContent);
 $Config_PartType_Example:  (moveTo: $AREA_NONE,                          titleContent: $_exampleTitleContent,
                                                                   solutionTitleContent: $_exampleSolutionTitleContent);
 $Config_PartType_Chapter:  (outlineTitle: 'Chapter Outline');

--- a/recipes/books/accounting/_config.scss
+++ b/recipes/books/accounting/_config.scss
@@ -199,7 +199,7 @@ $Config_ChapterCompositePages: (
 (className: "thought-provokers", clusterBy: $CLUSTER_NONE,  name: "Thought Provokers", hasSolutions: true, moveSolutionsTo: $AREA_NONE,   numberAt: $NUMBER_BEFORE_MOVE, prefixExercise: 'TP'),
 );
 
-$Config_PartType_Exercise: (moveTo: $AREA_EOC, resetAt: $RESET_COMPOSITE_PAGE, numberAt: $NUMBER_BEFORE_MOVE, titleContent: $_exerciseTitleContent, );
+$Config_PartType_Exercise: (moveTo: $AREA_EOC, resetAt: $RESET_COMPOSITE_PAGE, numberAt: $NUMBER_BEFORE_MOVE, titleContent: $Config_exerciseTitleContent, );
 
 $Config_BookCompositePages: (
 (className: "end-of-book-solutions",     clusterBy: $CLUSTER_CHAPTER, compoundComposite: true, moveSolutionsTo: $AREA_EOB, name: "Answer Key",),

--- a/recipes/books/accounting/_config.scss
+++ b/recipes/books/accounting/_config.scss
@@ -199,7 +199,7 @@ $Config_ChapterCompositePages: (
 (className: "thought-provokers", clusterBy: $CLUSTER_NONE,  name: "Thought Provokers", hasSolutions: true, moveSolutionsTo: $AREA_NONE,   numberAt: $NUMBER_BEFORE_MOVE, prefixExercise: 'TP'),
 );
 
-$Config_PartType_Exercise: (moveTo: $AREA_EOC, resetAt: $RESET_COMPOSITE_PAGE, numberAt: $NUMBER_BEFORE_MOVE, titleContent: (os-number: counter(exercise), ));
+$Config_PartType_Exercise: (moveTo: $AREA_EOC, resetAt: $RESET_COMPOSITE_PAGE, numberAt: $NUMBER_BEFORE_MOVE, titleContent: $_exerciseTitleContent, );
 
 $Config_BookCompositePages: (
 (className: "end-of-book-solutions",     clusterBy: $CLUSTER_CHAPTER, compoundComposite: true, moveSolutionsTo: $AREA_EOB, name: "Answer Key",),

--- a/recipes/books/ap-physics/_config.scss
+++ b/recipes/books/ap-physics/_config.scss
@@ -54,7 +54,7 @@ $Config_UnnumberedEquations: (
 
 $Config_PartType_Chapter:  (outlineTitle: 'Chapter Outline');
 $Config_PartType_Equation: (moveTo: $AREA_NONE, numberAt: $NUMBER_BEFORE_MOVE, titleContent: $_equationTitleContent, numberAfterEq: true);
-$Config_PartType_Exercise: (moveTo: $AREA_EOC, resetAt: $RESET_COMPOSITE_PAGE,  numberAt: $NUMBER_BEFORE_MOVE, titleContent: $_exerciseTitleContent);
+$Config_PartType_Exercise: (moveTo: $AREA_EOC, resetAt: $RESET_COMPOSITE_PAGE,  numberAt: $NUMBER_BEFORE_MOVE, titleContent: $Config_exerciseTitleContent);
 $Config_PartType_Example:  (moveTo: $AREA_NONE, titleContent: $_exampleTitleContent,
                                           solutionTitleContent: $_exampleSolutionTitleContent);
 $Config_PartType_Solution: (moveTo: $AREA_NONE);

--- a/recipes/books/biology/_config.scss
+++ b/recipes/books/biology/_config.scss
@@ -151,7 +151,7 @@ $Config_PartType_Figure_CaptionContentAp: (os-title-label: "Figure ", os-number:
 $Config_SetTableCaption : (captionType: $CAPTION_TABLE, defaultContainer: caption, hasCaption: true, hasTitle: true);
 $Config_SetFigureCaption: (captionType: $CAPTION_FIGURE, defaultContainer: figcaption, hasCaption: true, hasTitle: true);
 
-$Config_PartType_Exercise: (moveTo: $AREA_EOC, resetAt: $RESET_CHAPTER, numberAt: $NUMBER_BEFORE_MOVE, titleContent: (os-divider: ".", os-number: counter(exercise), ));
+$Config_PartType_Exercise: (moveTo: $AREA_EOC, resetAt: $RESET_CHAPTER, numberAt: $NUMBER_BEFORE_MOVE, titleContent: $_exerciseTitleContent);
 $Config_PartType_Example:  (moveTo: $AREA_TRASH, ); // Oddly, this does not trash the examples... But maybe it shoudl be something other than NONE?
 $Config_PartType_Chapter:  (outlineTitle: "Chapter Outline", );
 $Config_PartType_Equation: (titleContent: null, );

--- a/recipes/books/biology/_config.scss
+++ b/recipes/books/biology/_config.scss
@@ -151,7 +151,7 @@ $Config_PartType_Figure_CaptionContentAp: (os-title-label: "Figure ", os-number:
 $Config_SetTableCaption : (captionType: $CAPTION_TABLE, defaultContainer: caption, hasCaption: true, hasTitle: true);
 $Config_SetFigureCaption: (captionType: $CAPTION_FIGURE, defaultContainer: figcaption, hasCaption: true, hasTitle: true);
 
-$Config_PartType_Exercise: (moveTo: $AREA_EOC, resetAt: $RESET_CHAPTER, numberAt: $NUMBER_BEFORE_MOVE, titleContent: $_exerciseTitleContent);
+$Config_PartType_Exercise: (moveTo: $AREA_EOC, resetAt: $RESET_CHAPTER, numberAt: $NUMBER_BEFORE_MOVE, titleContent: $Config_exerciseTitleContent);
 $Config_PartType_Example:  (moveTo: $AREA_TRASH, ); // Oddly, this does not trash the examples... But maybe it shoudl be something other than NONE?
 $Config_PartType_Chapter:  (outlineTitle: "Chapter Outline", );
 $Config_PartType_Equation: (titleContent: null, );

--- a/recipes/books/business-ethics/_config.scss
+++ b/recipes/books/business-ethics/_config.scss
@@ -137,7 +137,7 @@ $Config_BookCompositePages: (
   (className: "index",        clusterBy: $CLUSTER_NONE, specialPageType: $PAGE_INDEX, name: "Index"),
 );
 
-$Config_PartType_Exercise: (moveTo: $AREA_EOC, resetAt: $RESET_CHAPTER, numberAt: $NUMBER_BEFORE_MOVE, titleContent: $_exerciseTitleContent);
+$Config_PartType_Exercise: (moveTo: $AREA_EOC, resetAt: $RESET_CHAPTER, numberAt: $NUMBER_BEFORE_MOVE, titleContent: $Config_exerciseTitleContent);
 
 $Config_SetTableCaption : (captionType: $CAPTION_TABLE, defaultContainer: caption, hasCaption: true, hasTitle: true, hasTopTitle: true);
 

--- a/recipes/books/business-ethics/_config.scss
+++ b/recipes/books/business-ethics/_config.scss
@@ -137,7 +137,7 @@ $Config_BookCompositePages: (
   (className: "index",        clusterBy: $CLUSTER_NONE, specialPageType: $PAGE_INDEX, name: "Index"),
 );
 
-$Config_PartType_Exercise: (moveTo: $AREA_EOC, resetAt: $RESET_CHAPTER, numberAt: $NUMBER_BEFORE_MOVE, titleContent: (os-divider: ".", os-number: counter(exercise), ));
+$Config_PartType_Exercise: (moveTo: $AREA_EOC, resetAt: $RESET_CHAPTER, numberAt: $NUMBER_BEFORE_MOVE, titleContent: $_exerciseTitleContent);
 
 $Config_SetTableCaption : (captionType: $CAPTION_TABLE, defaultContainer: caption, hasCaption: true, hasTitle: true, hasTopTitle: true);
 

--- a/recipes/books/economics/_config.scss
+++ b/recipes/books/economics/_config.scss
@@ -149,7 +149,7 @@ $Config_Notes: (
 
 $Config_UnnumberedExercises: (); // There are no unnumbered exercises
 
-$Config_PartType_Exercise: (moveTo: $AREA_EOC, resetAt: $RESET_CHAPTER, numberAt: $NUMBER_BEFORE_MOVE, titleContent: (os-divider: ".", os-number: counter(exercise)));
+$Config_PartType_Exercise: (moveTo: $AREA_EOC, resetAt: $RESET_CHAPTER, numberAt: $NUMBER_BEFORE_MOVE, titleContent: $_exerciseTitleContent);
 $Config_PartType_Example:  ();
 $Config_PartType_Chapter:  ();
 $Config_PartType_Equation: ();

--- a/recipes/books/economics/_config.scss
+++ b/recipes/books/economics/_config.scss
@@ -149,7 +149,7 @@ $Config_Notes: (
 
 $Config_UnnumberedExercises: (); // There are no unnumbered exercises
 
-$Config_PartType_Exercise: (moveTo: $AREA_EOC, resetAt: $RESET_CHAPTER, numberAt: $NUMBER_BEFORE_MOVE, titleContent: $_exerciseTitleContent);
+$Config_PartType_Exercise: (moveTo: $AREA_EOC, resetAt: $RESET_CHAPTER, numberAt: $NUMBER_BEFORE_MOVE, titleContent: $Config_exerciseTitleContent);
 $Config_PartType_Example:  ();
 $Config_PartType_Chapter:  ();
 $Config_PartType_Equation: ();

--- a/recipes/books/entrepreneurship/_config.scss
+++ b/recipes/books/entrepreneurship/_config.scss
@@ -168,7 +168,7 @@ $Config_ChapterCompositePages: (
 );
 
 $Config_PartType_Exercise: (
-  moveTo: $AREA_EOC, resetAt:     $RESET_COMPOSITE_PAGE, numberAt: $NUMBER_BEFORE_MOVE, titleContent: $_exerciseTitleContent
+  moveTo: $AREA_EOC, resetAt:     $RESET_COMPOSITE_PAGE, numberAt: $NUMBER_BEFORE_MOVE, titleContent: $Config_exerciseTitleContent
 );
 
 /*==========================================================

--- a/recipes/books/entrepreneurship/_config.scss
+++ b/recipes/books/entrepreneurship/_config.scss
@@ -168,7 +168,7 @@ $Config_ChapterCompositePages: (
 );
 
 $Config_PartType_Exercise: (
-  moveTo: $AREA_EOC, resetAt:     $RESET_COMPOSITE_PAGE, numberAt: $NUMBER_BEFORE_MOVE, titleContent: (os-number: counter(exercise), )
+  moveTo: $AREA_EOC, resetAt:     $RESET_COMPOSITE_PAGE, numberAt: $NUMBER_BEFORE_MOVE, titleContent: $_exerciseTitleContent
 );
 
 /*==========================================================

--- a/recipes/books/hs-physics/_config.scss
+++ b/recipes/books/hs-physics/_config.scss
@@ -324,7 +324,7 @@ $Config_UnnumberedExercises: (
 
 $Config_PartType_Chapter:  (outlineTitle: 'Chapter Outline');
 $Config_PartType_Equation: (moveTo: $AREA_NONE, titleContent: $_equationNumber, numberAt: $NUMBER_AFTER_MOVE, excludeNumberingInClassName: "summary");
-$Config_PartType_Exercise: (moveTo: $AREA_EOC, resetAt: $RESET_COMPOSITE_PAGE,  numberAt: $NUMBER_BEFORE_MOVE, titleContent: $_exerciseTitleContent);
+$Config_PartType_Exercise: (moveTo: $AREA_EOC, resetAt: $RESET_COMPOSITE_PAGE,  numberAt: $NUMBER_BEFORE_MOVE, titleContent: $Config_exerciseTitleContent);
 $Config_PartType_Example:  ();
 $Config_PartType_Solution: (moveTo: $AREA_TRASH, HACKRemoveAllSolutionsNotJustEoC: true); // FIXME: change this to $AREA_NONE once cnx-easybake is fixed or the order of operations is fixed
 

--- a/recipes/books/hs-physics/_config.scss
+++ b/recipes/books/hs-physics/_config.scss
@@ -153,7 +153,7 @@ $Config_BookCompositePages: (
 //unfortunately a base obj cannot be created for all Content because it would make the order of the keys static
 //when they need to be able to be in any order because of possible changes in titling order between books
 //Usage Note: key: class of the containing span, value: text that will go inside span
-$_exerciseTitleContent: (os-divider: ". ", os-number: counter(exercise)); // TODO: Remove this space?
+
 $_equationNumber      : (os-number: counter(chapter) "." counter(equation));
 /*==========================================================
   HIGH SCHOOL PHYSICS CONFIG

--- a/recipes/books/intro-business/_config.scss
+++ b/recipes/books/intro-business/_config.scss
@@ -213,7 +213,7 @@ $Config_PartType_Figure_CaptionContent  : (os-title-label: "Exhibit ", os-number
 $Config_PartType_Figure_CaptionContentAp: (os-title-label: "Exhibit ", os-number: counter(appendix, upper-alpha) counter(figure), os-divider: " ");
 $Config_PartType_Figure_CaptionContentPr: (os-title-label: "Exhibit ", os-number: counter(figure),                                os-divider: " ");
 
-$Config_PartType_Exercise: (moveTo: $AREA_EOC, resetAt: $RESET_CHAPTER, numberAt: $NUMBER_BEFORE_MOVE, titleContent: (os-divider: ".", os-number: counter(exercise)));
+$Config_PartType_Exercise: (moveTo: $AREA_EOC, resetAt: $RESET_CHAPTER, numberAt: $NUMBER_BEFORE_MOVE, titleContent: $_exerciseTitleContent);
 
 $Config_SetTableCaption : (captionType: $CAPTION_TABLE, defaultContainer: caption, hasCaption: true, hasTopTitle: true);
 

--- a/recipes/books/intro-business/_config.scss
+++ b/recipes/books/intro-business/_config.scss
@@ -213,7 +213,7 @@ $Config_PartType_Figure_CaptionContent  : (os-title-label: "Exhibit ", os-number
 $Config_PartType_Figure_CaptionContentAp: (os-title-label: "Exhibit ", os-number: counter(appendix, upper-alpha) counter(figure), os-divider: " ");
 $Config_PartType_Figure_CaptionContentPr: (os-title-label: "Exhibit ", os-number: counter(figure),                                os-divider: " ");
 
-$Config_PartType_Exercise: (moveTo: $AREA_EOC, resetAt: $RESET_CHAPTER, numberAt: $NUMBER_BEFORE_MOVE, titleContent: $_exerciseTitleContent);
+$Config_PartType_Exercise: (moveTo: $AREA_EOC, resetAt: $RESET_CHAPTER, numberAt: $NUMBER_BEFORE_MOVE, titleContent: $Config_exerciseTitleContent);
 
 $Config_SetTableCaption : (captionType: $CAPTION_TABLE, defaultContainer: caption, hasCaption: true, hasTopTitle: true);
 

--- a/recipes/books/physics/_config.scss
+++ b/recipes/books/physics/_config.scss
@@ -57,7 +57,6 @@ $Config_BookCompositePages: (
 //Usage Note: key: class of the containing span, value: text that will go inside span
 $Config_PartType_Chapter_TitleContent : (os-number: counter(chapter), os-divider: " ");
 $Config_PartType_Section_TitleContent : (os-number: counter(chapter) "." counter(section), os-divider: " ");
-$_exerciseTitleContent       : (os-number: counter(exercise));
 $_exampleTitleContent        : (os-title-label: "Example ", os-number: counter(chapter) "." counter(example), os-divider: " ");
 $_exampleSolutionTitleContent: (os-title-label: "Solution ", os-number: counter(chapter) "." counter(example));
 $_equationTitleContent       : (os-number: counter(chapter) "." counter(equation));

--- a/recipes/books/physics/_config.scss
+++ b/recipes/books/physics/_config.scss
@@ -91,7 +91,7 @@ $Config_UnnumberedEquations: (
 $Config_PartType_Chapter:  (outlineTitle: 'Chapter Outline', hasLearningObjectives: true);
 // TODO: Is this a mistake; should we be numbering after the move?
 $Config_PartType_Equation: (moveTo: $AREA_NONE, titleContent: $_equationTitleContent, numberAt: $NUMBER_AFTER_MOVE, numberAfterEq: true);
-$Config_PartType_Exercise: (moveTo: $AREA_EOC, resetAt: $RESET_COMPOSITE_PAGE,  numberAt: $NUMBER_BEFORE_MOVE, titleContent: $_exerciseTitleContent);
+$Config_PartType_Exercise: (moveTo: $AREA_EOC, resetAt: $RESET_COMPOSITE_PAGE,  numberAt: $NUMBER_BEFORE_MOVE, titleContent: $Config_exerciseTitleContent);
 $Config_PartType_Example:  (moveTo: $AREA_NONE,                          titleContent: $_exampleTitleContent,
                                                                   solutionTitleContent: $_exampleSolutionTitleContent);
 $Config_PartType_Solution: (moveTo: $AREA_TRASH);

--- a/recipes/books/principles-management/_config.scss
+++ b/recipes/books/principles-management/_config.scss
@@ -247,7 +247,7 @@ $Config_TargetLabels: (
 
 $Config_PartType_Example:  (moveTo: $AREA_NONE, titleContent: $_exampleTitleContent, solutionTitleContent: $_exampleSolutionTitleContent);
 
-$Config_PartType_Exercise: (moveTo: $AREA_EOC, resetAt: $RESET_CHAPTER,  numberAt: $NUMBER_BEFORE_MOVE, titleContent: (os-divider: ".", os-number: counter(exercise)));
+$Config_PartType_Exercise: (moveTo: $AREA_EOC, resetAt: $RESET_CHAPTER,  numberAt: $NUMBER_BEFORE_MOVE, titleContent: $_exerciseTitleContent);
 
 
 /*

--- a/recipes/books/principles-management/_config.scss
+++ b/recipes/books/principles-management/_config.scss
@@ -247,7 +247,7 @@ $Config_TargetLabels: (
 
 $Config_PartType_Example:  (moveTo: $AREA_NONE, titleContent: $_exampleTitleContent, solutionTitleContent: $_exampleSolutionTitleContent);
 
-$Config_PartType_Exercise: (moveTo: $AREA_EOC, resetAt: $RESET_CHAPTER,  numberAt: $NUMBER_BEFORE_MOVE, titleContent: $_exerciseTitleContent);
+$Config_PartType_Exercise: (moveTo: $AREA_EOC, resetAt: $RESET_CHAPTER,  numberAt: $NUMBER_BEFORE_MOVE, titleContent: $Config_exerciseTitleContent);
 
 
 /*

--- a/recipes/books/statistics/_config.scss
+++ b/recipes/books/statistics/_config.scss
@@ -101,7 +101,7 @@ $Config_BookCompositePages: (
 //when they need to be able to be in any order because of possible changes in titling order between books
 //Usage Note: key: class of the containing span, value: text that will go inside span
 // Drat, the order of os-title-label, os-number, os-divider matters ;(
-$_exerciseTitleContent       : (os-divider: ".", os-number: counter(exercise) );
+
 $_exampleTitleContent        : (os-title-label: "Example ", os-number: counter(chapter) "." counter(example), os-divider: " ");
 $_exampleSolutionTitleContent: (os-title-label: "Solution ", os-number: counter(chapter) "." counter(example), os-divider: " ");
 $_labTitleContent           : (os-title-label: "Stats Lab ", os-number: counter(chapter) "." counter(lab));

--- a/recipes/books/statistics/_config.scss
+++ b/recipes/books/statistics/_config.scss
@@ -190,7 +190,7 @@ $Config_UnnumberedExercises: (
 
   Style guide: page.note.chapter-objectives
 */
-$Config_PartType_Exercise: (moveTo: $AREA_EOC, resetAt: $RESET_CHAPTER,  numberAt: $NUMBER_BEFORE_MOVE, titleContent: $_exerciseTitleContent);
+$Config_PartType_Exercise: (moveTo: $AREA_EOC, resetAt: $RESET_CHAPTER,  numberAt: $NUMBER_BEFORE_MOVE, titleContent: $Config_exerciseTitleContent);
 $Config_PartType_Example:  (moveTo: $AREA_NONE,                          titleContent: $_exampleTitleContent,
                                                                   solutionTitleContent: $_exampleSolutionTitleContent);
 $Config_PartType_Chapter:  ();

--- a/recipes/books/u-physics/_config.scss
+++ b/recipes/books/u-physics/_config.scss
@@ -168,7 +168,7 @@ $Config_UnnumberedExercises: (
 );
 
 $Config_abstractTitle: "Learning Objectives";
-$Config_PartType_Exercise: (moveTo: $AREA_EOC, resetAt: $RESET_CHAPTER, numberAt: $NUMBER_BEFORE_MOVE, titleContent: (os-divider: ".", os-number: counter(exercise)));
+$Config_PartType_Exercise: (moveTo: $AREA_EOC, resetAt: $RESET_CHAPTER, numberAt: $NUMBER_BEFORE_MOVE, titleContent: $_exerciseTitleContent);
 $Config_PartType_Example:  (moveTo: $AREA_NONE,                          titleContent: $_exampleTitleContent,
                                                                   solutionTitleContent: $_exampleSolutionTitleContent);
 $Config_PartType_Chapter:  (outlineTitle: 'Chapter Outline');

--- a/recipes/books/u-physics/_config.scss
+++ b/recipes/books/u-physics/_config.scss
@@ -168,7 +168,7 @@ $Config_UnnumberedExercises: (
 );
 
 $Config_abstractTitle: "Learning Objectives";
-$Config_PartType_Exercise: (moveTo: $AREA_EOC, resetAt: $RESET_CHAPTER, numberAt: $NUMBER_BEFORE_MOVE, titleContent: $_exerciseTitleContent);
+$Config_PartType_Exercise: (moveTo: $AREA_EOC, resetAt: $RESET_CHAPTER, numberAt: $NUMBER_BEFORE_MOVE, titleContent: $Config_exerciseTitleContent);
 $Config_PartType_Example:  (moveTo: $AREA_NONE,                          titleContent: $_exampleTitleContent,
                                                                   solutionTitleContent: $_exampleSolutionTitleContent);
 $Config_PartType_Chapter:  (outlineTitle: 'Chapter Outline');

--- a/recipes/output/accounting.css
+++ b/recipes/output/accounting.css
@@ -1275,8 +1275,18 @@
 
 :pass(5) .os-eoc [data-type="exercise"] [data-type="problem"]::before {
   container: span;
+  content: ". ";
+  class: os-divider; }
+
+:pass(5) .os-eoc [data-type="exercise"] [data-type="problem"]::before {
+  container: span;
   content: counter(exercise);
   class: os-number; }
+
+:pass(5) .os-eoc [data-type="exercise"] [data-type="solution"]::before {
+  container: span;
+  content: ". ";
+  class: os-divider; }
 
 :pass(5) .os-eoc [data-type="exercise"] [data-type="solution"]::before {
   container: span;

--- a/recipes/output/ap-biology.css
+++ b/recipes/output/ap-biology.css
@@ -1757,7 +1757,7 @@
 
 :pass(5) .os-eoc [data-type="exercise"] [data-type="problem"]::before {
   container: span;
-  content: ".";
+  content: ". ";
   class: os-divider; }
 
 :pass(5) .os-eoc [data-type="exercise"] [data-type="problem"]::before {
@@ -1767,7 +1767,7 @@
 
 :pass(5) .os-eoc [data-type="exercise"] [data-type="solution"]::before {
   container: span;
-  content: ".";
+  content: ". ";
   class: os-divider; }
 
 :pass(5) .os-eoc [data-type="exercise"] [data-type="solution"]::before {

--- a/recipes/output/ap-physics.css
+++ b/recipes/output/ap-physics.css
@@ -873,8 +873,18 @@
 
 :pass(5) .os-eoc [data-type="exercise"] [data-type="problem"]::before {
   container: span;
+  content: ". ";
+  class: os-divider; }
+
+:pass(5) .os-eoc [data-type="exercise"] [data-type="problem"]::before {
+  container: span;
   content: counter(exercise);
   class: os-number; }
+
+:pass(5) .os-eoc [data-type="exercise"] [data-type="solution"]::before {
+  container: span;
+  content: ". ";
+  class: os-divider; }
 
 :pass(5) .os-eoc [data-type="exercise"] [data-type="solution"]::before {
   container: span;

--- a/recipes/output/biology.css
+++ b/recipes/output/biology.css
@@ -1166,7 +1166,7 @@
 
 :pass(5) .os-eoc [data-type="exercise"] [data-type="problem"]::before {
   container: span;
-  content: ".";
+  content: ". ";
   class: os-divider; }
 
 :pass(5) .os-eoc [data-type="exercise"] [data-type="problem"]::before {
@@ -1176,7 +1176,7 @@
 
 :pass(5) .os-eoc [data-type="exercise"] [data-type="solution"]::before {
   container: span;
-  content: ".";
+  content: ". ";
   class: os-divider; }
 
 :pass(5) .os-eoc [data-type="exercise"] [data-type="solution"]::before {

--- a/recipes/output/business-ethics.css
+++ b/recipes/output/business-ethics.css
@@ -1071,7 +1071,7 @@
 
 :pass(5) .os-eoc [data-type="exercise"] [data-type="problem"]::before {
   container: span;
-  content: ".";
+  content: ". ";
   class: os-divider; }
 
 :pass(5) .os-eoc [data-type="exercise"] [data-type="problem"]::before {
@@ -1081,7 +1081,7 @@
 
 :pass(5) .os-eoc [data-type="exercise"] [data-type="solution"]::before {
   container: span;
-  content: ".";
+  content: ". ";
   class: os-divider; }
 
 :pass(5) .os-eoc [data-type="exercise"] [data-type="solution"]::before {

--- a/recipes/output/economics.css
+++ b/recipes/output/economics.css
@@ -1059,7 +1059,7 @@
 
 :pass(5) .os-eoc [data-type="exercise"] [data-type="problem"]::before {
   container: span;
-  content: ".";
+  content: ". ";
   class: os-divider; }
 
 :pass(5) .os-eoc [data-type="exercise"] [data-type="problem"]::before {
@@ -1069,7 +1069,7 @@
 
 :pass(5) .os-eoc [data-type="exercise"] [data-type="solution"]::before {
   container: span;
-  content: ".";
+  content: ". ";
   class: os-divider; }
 
 :pass(5) .os-eoc [data-type="exercise"] [data-type="solution"]::before {

--- a/recipes/output/entrepreneurship.css
+++ b/recipes/output/entrepreneurship.css
@@ -1150,8 +1150,18 @@
 
 :pass(5) .os-eoc [data-type="exercise"] [data-type="problem"]::before {
   container: span;
+  content: ". ";
+  class: os-divider; }
+
+:pass(5) .os-eoc [data-type="exercise"] [data-type="problem"]::before {
+  container: span;
   content: counter(exercise);
   class: os-number; }
+
+:pass(5) .os-eoc [data-type="exercise"] [data-type="solution"]::before {
+  container: span;
+  content: ". ";
+  class: os-divider; }
 
 :pass(5) .os-eoc [data-type="exercise"] [data-type="solution"]::before {
   container: span;

--- a/recipes/output/intro-business.css
+++ b/recipes/output/intro-business.css
@@ -1504,7 +1504,7 @@
 
 :pass(5) .os-eoc [data-type="exercise"] [data-type="problem"]::before {
   container: span;
-  content: ".";
+  content: ". ";
   class: os-divider; }
 
 :pass(5) .os-eoc [data-type="exercise"] [data-type="problem"]::before {
@@ -1514,7 +1514,7 @@
 
 :pass(5) .os-eoc [data-type="exercise"] [data-type="solution"]::before {
   container: span;
-  content: ".";
+  content: ". ";
   class: os-divider; }
 
 :pass(5) .os-eoc [data-type="exercise"] [data-type="solution"]::before {

--- a/recipes/output/physics.css
+++ b/recipes/output/physics.css
@@ -798,8 +798,18 @@
 
 :pass(5) .os-eoc [data-type="exercise"] [data-type="problem"]::before {
   container: span;
+  content: ". ";
+  class: os-divider; }
+
+:pass(5) .os-eoc [data-type="exercise"] [data-type="problem"]::before {
+  container: span;
   content: counter(exercise);
   class: os-number; }
+
+:pass(5) .os-eoc [data-type="exercise"] [data-type="solution"]::before {
+  container: span;
+  content: ". ";
+  class: os-divider; }
 
 :pass(5) .os-eoc [data-type="exercise"] [data-type="solution"]::before {
   container: span;

--- a/recipes/output/principles-management.css
+++ b/recipes/output/principles-management.css
@@ -1558,7 +1558,7 @@
 
 :pass(5) .os-eoc [data-type="exercise"] [data-type="problem"]::before {
   container: span;
-  content: ".";
+  content: ". ";
   class: os-divider; }
 
 :pass(5) .os-eoc [data-type="exercise"] [data-type="problem"]::before {
@@ -1568,7 +1568,7 @@
 
 :pass(5) .os-eoc [data-type="exercise"] [data-type="solution"]::before {
   container: span;
-  content: ".";
+  content: ". ";
   class: os-divider; }
 
 :pass(5) .os-eoc [data-type="exercise"] [data-type="solution"]::before {

--- a/recipes/output/statistics.css
+++ b/recipes/output/statistics.css
@@ -1192,7 +1192,7 @@ Formula Review page
 
 :pass(5) .os-eoc [data-type="exercise"] [data-type="problem"]::before {
   container: span;
-  content: ".";
+  content: ". ";
   class: os-divider; }
 
 :pass(5) .os-eoc [data-type="exercise"] [data-type="problem"]::before {
@@ -1202,7 +1202,7 @@ Formula Review page
 
 :pass(5) .os-eoc [data-type="exercise"] [data-type="solution"]::before {
   container: span;
-  content: ".";
+  content: ". ";
   class: os-divider; }
 
 :pass(5) .os-eoc [data-type="exercise"] [data-type="solution"]::before {

--- a/recipes/output/u-physics.css
+++ b/recipes/output/u-physics.css
@@ -1191,7 +1191,7 @@
 
 :pass(5) .os-eoc [data-type="exercise"] [data-type="problem"]::before {
   container: span;
-  content: ".";
+  content: ". ";
   class: os-divider; }
 
 :pass(5) .os-eoc [data-type="exercise"] [data-type="problem"]::before {
@@ -1201,7 +1201,7 @@
 
 :pass(5) .os-eoc [data-type="exercise"] [data-type="solution"]::before {
   container: span;
-  content: ".";
+  content: ". ";
   class: os-divider; }
 
 :pass(5) .os-eoc [data-type="exercise"] [data-type="solution"]::before {


### PR DESCRIPTION
All books now use the following format in end of chapter exercises and end of book solutions:

`#. Exercise`

Example:
```
<span class="os-number">1</span><span class="os-divider">. </span>
<div class="os-problem-container"> .... </div>
```

This should prevent future issues with spacing between the number, the divider and the content in exercises. 

This affects: https://github.com/Connexions/webview/issues/1910#issuecomment-419982152