### PR TITLE
removed visual connection note config from apbiology

### DIFF
--- a/recipes/books/ap-biology/_config.scss
+++ b/recipes/books/ap-biology/_config.scss
@@ -135,7 +135,6 @@ $Config_BookCompositePages: (
 $Config_Notes: join($Config_Notes, (
   (className: "ap-connection",        moveSolutionTo: $AREA_NONE, replaceHeader: true, labelText: "Connection for AP\00ae\00a0 Courses"),
   (className: "os-teacher",           moveSolutionTo: $AREA_NONE, replaceHeader: true, labelText: "Teacher Support"),
-  (className: "visual-connection",    moveSolutionTo: $AREA_NONE, replaceHeader: true, labelText: "Visual Connection"),
   (className: "ap-everyday",          moveSolutionTo: $AREA_NONE, replaceHeader: true, labelText: "Everyday Connection for AP\00ae\00a0 Courses"),
   (className: "ap-science-practices", moveSolutionTo: $AREA_NONE, replaceHeader: true, labelText: "Science Practice Connection for AP\00ae\00a0 Courses"),
   (className: "ost-sciprac-activity", moveSolutionTo: $AREA_NONE, replaceHeader: true, labelText: "Activity"),

--- a/recipes/output/ap-biology.css
+++ b/recipes/output/ap-biology.css
@@ -1135,62 +1135,6 @@
   class: "os-title";
   attr-data-type: "title"; }
 
-:pass(2) :not([data-type="note"]) > :not([data-type="note"]) > :not([data-type="note"]) > [data-type="note"].visual-connection > div[data-type="title"] {
-  move-to: trash; }
-
-:pass(2) :not([data-type="note"]) > :not([data-type="note"]) > :not([data-type="note"]) > [data-type="note"].visual-connection > p:first-of-type > span[data-type="title"]::deferred {
-  container: h4;
-  class: "os-subtitle";
-  move-to: noteSubtitle; }
-
-:pass(2) :not([data-type="note"]) > :not([data-type="note"]) > :not([data-type="note"]) > [data-type="note"].visual-connection > p:first-of-type > span[data-type="title"]::inside {
-  container: span;
-  class: "os-subtitle-label"; }
-
-:pass(2) :not([data-type="note"]) > :not([data-type="note"]) > :not([data-type="note"]) > [data-type="note"].visual-connection::inside {
-  class: "os-note-body";
-  content: pending(noteSubtitle) content(); }
-
-:pass(2) :not([data-type="note"]) > :not([data-type="note"]) > :not([data-type="note"]) > [data-type="note"].visual-connection:deferred::before {
-  container: span;
-  class: "os-title-label";
-  content: "Visual Connection";
-  move-to: bNoteLabel; }
-
-:pass(2) :not([data-type="note"]) > :not([data-type="note"]) > :not([data-type="note"]) > [data-type="note"].visual-connection:deferred::before {
-  container: h3;
-  content: pending(bNoteLabel);
-  class: "os-title";
-  attr-data-type: "title"; }
-
-:pass(2) [data-type="note"] [data-type="note"].visual-connection > div[data-type="title"] {
-  move-to: trash; }
-
-:pass(2) [data-type="note"] [data-type="note"].visual-connection > p:first-of-type > span[data-type="title"]::deferred {
-  container: h5;
-  class: "os-subtitle";
-  move-to: noteSubtitledepth1; }
-
-:pass(2) [data-type="note"] [data-type="note"].visual-connection > p:first-of-type > span[data-type="title"]::inside {
-  container: span;
-  class: "os-subtitle-label"; }
-
-:pass(2) [data-type="note"] [data-type="note"].visual-connection::inside {
-  class: "os-note-body";
-  content: pending(noteSubtitledepth1) content(); }
-
-:pass(2) [data-type="note"] [data-type="note"].visual-connection:deferred::before {
-  container: span;
-  class: "os-title-label";
-  content: "Visual Connection";
-  move-to: bNoteLabel; }
-
-:pass(2) [data-type="note"] [data-type="note"].visual-connection:deferred::before {
-  container: h4;
-  content: pending(bNoteLabel);
-  class: "os-title";
-  attr-data-type: "title"; }
-
 :pass(2) :not([data-type="note"]) > :not([data-type="note"]) > :not([data-type="note"]) > [data-type="note"].ap-everyday > div[data-type="title"] {
   move-to: trash; }
 


### PR DESCRIPTION
https://github.com/Connexions/cnx-recipes/issues/642

I have removed the `visual connection` note config from the `ap-biology` config, because it's imported from `biology` config too and this causes the doubled headers.
It's done by
`$Config_Notes: join($Config_Notes, (`
