### PR TITLE
quick fix to the headings in appendices

### DIFF
--- a/recipes/mixins/_modify.scss
+++ b/recipes/mixins/_modify.scss
@@ -494,11 +494,11 @@
   }
   .appendix {
     > section {
-       :not(p) > [data-type="title"], [data-type="document-title"]  {
-          container: h2;
-       }
-       > section {
-        :not(p) > [data-type="title"], [data-type="document-title"] {
+      > [data-type="title"], [data-type="document-title"]  {
+        container: h2;
+      }
+      > section {
+        > [data-type="title"], [data-type="document-title"] {
           container: h3;
         }
       }

--- a/recipes/output/accounting.css
+++ b/recipes/output/accounting.css
@@ -2023,10 +2023,10 @@
 :pass(8) [data-type="composite-page"].os-eob > .os-chapter-area > section > [data-type="document-title"] {
   container: h3; }
 
-:pass(8) .appendix > section :not(p) > [data-type="title"], :pass(8) .appendix > section [data-type="document-title"] {
+:pass(8) .appendix > section > [data-type="title"], :pass(8) .appendix > section [data-type="document-title"] {
   container: h2; }
 
-:pass(8) .appendix > section > section :not(p) > [data-type="title"], :pass(8) .appendix > section > section [data-type="document-title"] {
+:pass(8) .appendix > section > section > [data-type="title"], :pass(8) .appendix > section > section [data-type="document-title"] {
   container: h3; }
 
 :pass(9) .os-index-link-separator:last-child {

--- a/recipes/output/ap-biology.css
+++ b/recipes/output/ap-biology.css
@@ -2303,10 +2303,10 @@
 :pass(8) [data-type="composite-page"].os-eob > .os-chapter-area > section > [data-type="document-title"] {
   container: h3; }
 
-:pass(8) .appendix > section :not(p) > [data-type="title"], :pass(8) .appendix > section [data-type="document-title"] {
+:pass(8) .appendix > section > [data-type="title"], :pass(8) .appendix > section [data-type="document-title"] {
   container: h2; }
 
-:pass(8) .appendix > section > section :not(p) > [data-type="title"], :pass(8) .appendix > section > section [data-type="document-title"] {
+:pass(8) .appendix > section > section > [data-type="title"], :pass(8) .appendix > section > section [data-type="document-title"] {
   container: h3; }
 
 :pass(9) .os-eoc [data-type="solution"] {

--- a/recipes/output/ap-physics.css
+++ b/recipes/output/ap-physics.css
@@ -1459,10 +1459,10 @@
 :pass(8) [data-type="composite-page"].os-eob > .os-chapter-area > section > [data-type="document-title"] {
   container: h3; }
 
-:pass(8) .appendix > section :not(p) > [data-type="title"], :pass(8) .appendix > section [data-type="document-title"] {
+:pass(8) .appendix > section > [data-type="title"], :pass(8) .appendix > section [data-type="document-title"] {
   container: h2; }
 
-:pass(8) .appendix > section > section :not(p) > [data-type="title"], :pass(8) .appendix > section > section [data-type="document-title"] {
+:pass(8) .appendix > section > section > [data-type="title"], :pass(8) .appendix > section > section [data-type="document-title"] {
   container: h3; }
 
 :pass(9) .os-index-link-separator:last-child {

--- a/recipes/output/astronomy.css
+++ b/recipes/output/astronomy.css
@@ -1846,10 +1846,10 @@
 :pass(8) [data-type="composite-page"].os-eob > .os-chapter-area > section > [data-type="document-title"] {
   container: h3; }
 
-:pass(8) .appendix > section :not(p) > [data-type="title"], :pass(8) .appendix > section [data-type="document-title"] {
+:pass(8) .appendix > section > [data-type="title"], :pass(8) .appendix > section [data-type="document-title"] {
   container: h2; }
 
-:pass(8) .appendix > section > section :not(p) > [data-type="title"], :pass(8) .appendix > section > section [data-type="document-title"] {
+:pass(8) .appendix > section > section > [data-type="title"], :pass(8) .appendix > section > section [data-type="document-title"] {
   container: h3; }
 
 :pass(9) .os-index-link-separator:last-child {

--- a/recipes/output/biology.css
+++ b/recipes/output/biology.css
@@ -1777,10 +1777,10 @@
 :pass(8) [data-type="composite-page"].os-eob > .os-chapter-area > section > [data-type="document-title"] {
   container: h3; }
 
-:pass(8) .appendix > section :not(p) > [data-type="title"], :pass(8) .appendix > section [data-type="document-title"] {
+:pass(8) .appendix > section > [data-type="title"], :pass(8) .appendix > section [data-type="document-title"] {
   container: h2; }
 
-:pass(8) .appendix > section > section :not(p) > [data-type="title"], :pass(8) .appendix > section > section [data-type="document-title"] {
+:pass(8) .appendix > section > section > [data-type="title"], :pass(8) .appendix > section > section [data-type="document-title"] {
   container: h3; }
 
 :pass(9) .os-eoc [data-type="solution"] {

--- a/recipes/output/business-ethics.css
+++ b/recipes/output/business-ethics.css
@@ -1719,10 +1719,10 @@
 :pass(8) [data-type="composite-page"].os-eob > .os-chapter-area > section > [data-type="document-title"] {
   container: h3; }
 
-:pass(8) .appendix > section :not(p) > [data-type="title"], :pass(8) .appendix > section [data-type="document-title"] {
+:pass(8) .appendix > section > [data-type="title"], :pass(8) .appendix > section [data-type="document-title"] {
   container: h2; }
 
-:pass(8) .appendix > section > section :not(p) > [data-type="title"], :pass(8) .appendix > section > section [data-type="document-title"] {
+:pass(8) .appendix > section > section > [data-type="title"], :pass(8) .appendix > section > section [data-type="document-title"] {
   container: h3; }
 
 :pass(9) .os-index-link-separator:last-child {

--- a/recipes/output/chemistry.css
+++ b/recipes/output/chemistry.css
@@ -1674,10 +1674,10 @@
 :pass(8) [data-type="composite-page"].os-eob > .os-chapter-area > section > [data-type="document-title"] {
   container: h3; }
 
-:pass(8) .appendix > section :not(p) > [data-type="title"], :pass(8) .appendix > section [data-type="document-title"] {
+:pass(8) .appendix > section > [data-type="title"], :pass(8) .appendix > section [data-type="document-title"] {
   container: h2; }
 
-:pass(8) .appendix > section > section :not(p) > [data-type="title"], :pass(8) .appendix > section > section [data-type="document-title"] {
+:pass(8) .appendix > section > section > [data-type="title"], :pass(8) .appendix > section > section [data-type="document-title"] {
   container: h3; }
 
 :pass(9) .os-index-link-separator:last-child {

--- a/recipes/output/dev-math.css
+++ b/recipes/output/dev-math.css
@@ -1920,10 +1920,10 @@
 :pass(8) [data-type="composite-page"].os-eob > .os-chapter-area > section > [data-type="document-title"] {
   container: h3; }
 
-:pass(8) .appendix > section :not(p) > [data-type="title"], :pass(8) .appendix > section [data-type="document-title"] {
+:pass(8) .appendix > section > [data-type="title"], :pass(8) .appendix > section [data-type="document-title"] {
   container: h2; }
 
-:pass(8) .appendix > section > section :not(p) > [data-type="title"], :pass(8) .appendix > section > section [data-type="document-title"] {
+:pass(8) .appendix > section > section > [data-type="title"], :pass(8) .appendix > section > section [data-type="document-title"] {
   container: h3; }
 
 :pass(9) .os-index-link-separator:last-child {

--- a/recipes/output/economics.css
+++ b/recipes/output/economics.css
@@ -1723,10 +1723,10 @@
 :pass(8) [data-type="composite-page"].os-eob > .os-chapter-area > section > [data-type="document-title"] {
   container: h3; }
 
-:pass(8) .appendix > section :not(p) > [data-type="title"], :pass(8) .appendix > section [data-type="document-title"] {
+:pass(8) .appendix > section > [data-type="title"], :pass(8) .appendix > section [data-type="document-title"] {
   container: h2; }
 
-:pass(8) .appendix > section > section :not(p) > [data-type="title"], :pass(8) .appendix > section > section [data-type="document-title"] {
+:pass(8) .appendix > section > section > [data-type="title"], :pass(8) .appendix > section > section [data-type="document-title"] {
   container: h3; }
 
 :pass(9) .os-index-link-separator:last-child {

--- a/recipes/output/entrepreneurship.css
+++ b/recipes/output/entrepreneurship.css
@@ -1809,10 +1809,10 @@
 :pass(8) [data-type="composite-page"].os-eob > .os-chapter-area > section > [data-type="document-title"] {
   container: h3; }
 
-:pass(8) .appendix > section :not(p) > [data-type="title"], :pass(8) .appendix > section [data-type="document-title"] {
+:pass(8) .appendix > section > [data-type="title"], :pass(8) .appendix > section [data-type="document-title"] {
   container: h2; }
 
-:pass(8) .appendix > section > section :not(p) > [data-type="title"], :pass(8) .appendix > section > section [data-type="document-title"] {
+:pass(8) .appendix > section > section > [data-type="title"], :pass(8) .appendix > section > section [data-type="document-title"] {
   container: h3; }
 
 :pass(9) .os-index-link-separator:last-child {

--- a/recipes/output/intro-business.css
+++ b/recipes/output/intro-business.css
@@ -2104,10 +2104,10 @@
 :pass(8) [data-type="composite-page"].os-eob > .os-chapter-area > section > [data-type="document-title"] {
   container: h3; }
 
-:pass(8) .appendix > section :not(p) > [data-type="title"], :pass(8) .appendix > section [data-type="document-title"] {
+:pass(8) .appendix > section > [data-type="title"], :pass(8) .appendix > section [data-type="document-title"] {
   container: h2; }
 
-:pass(8) .appendix > section > section :not(p) > [data-type="title"], :pass(8) .appendix > section > section [data-type="document-title"] {
+:pass(8) .appendix > section > section > [data-type="title"], :pass(8) .appendix > section > section [data-type="document-title"] {
   container: h3; }
 
 :pass(9) .os-index-link-separator:last-child {

--- a/recipes/output/physics.css
+++ b/recipes/output/physics.css
@@ -1311,10 +1311,10 @@
 :pass(8) [data-type="composite-page"].os-eob > .os-chapter-area > section > [data-type="document-title"] {
   container: h3; }
 
-:pass(8) .appendix > section :not(p) > [data-type="title"], :pass(8) .appendix > section [data-type="document-title"] {
+:pass(8) .appendix > section > [data-type="title"], :pass(8) .appendix > section [data-type="document-title"] {
   container: h2; }
 
-:pass(8) .appendix > section > section :not(p) > [data-type="title"], :pass(8) .appendix > section > section [data-type="document-title"] {
+:pass(8) .appendix > section > section > [data-type="title"], :pass(8) .appendix > section > section [data-type="document-title"] {
   container: h3; }
 
 :pass(9) .os-eoc [data-type="solution"] {

--- a/recipes/output/principles-management.css
+++ b/recipes/output/principles-management.css
@@ -2161,10 +2161,10 @@
 :pass(8) [data-type="composite-page"].os-eob > .os-chapter-area > section > [data-type="document-title"] {
   container: h3; }
 
-:pass(8) .appendix > section :not(p) > [data-type="title"], :pass(8) .appendix > section [data-type="document-title"] {
+:pass(8) .appendix > section > [data-type="title"], :pass(8) .appendix > section [data-type="document-title"] {
   container: h2; }
 
-:pass(8) .appendix > section > section :not(p) > [data-type="title"], :pass(8) .appendix > section > section [data-type="document-title"] {
+:pass(8) .appendix > section > section > [data-type="title"], :pass(8) .appendix > section > section [data-type="document-title"] {
   container: h3; }
 
 :pass(9) .os-index-link-separator:last-child {

--- a/recipes/output/statistics.css
+++ b/recipes/output/statistics.css
@@ -1822,10 +1822,10 @@ Formula Review page
 :pass(8) [data-type="composite-page"].os-eob > .os-chapter-area > section > [data-type="document-title"] {
   container: h3; }
 
-:pass(8) .appendix > section :not(p) > [data-type="title"], :pass(8) .appendix > section [data-type="document-title"] {
+:pass(8) .appendix > section > [data-type="title"], :pass(8) .appendix > section [data-type="document-title"] {
   container: h2; }
 
-:pass(8) .appendix > section > section :not(p) > [data-type="title"], :pass(8) .appendix > section > section [data-type="document-title"] {
+:pass(8) .appendix > section > section > [data-type="title"], :pass(8) .appendix > section > section [data-type="document-title"] {
   container: h3; }
 
 :pass(9) .os-index-link-separator:last-child {

--- a/recipes/output/u-physics.css
+++ b/recipes/output/u-physics.css
@@ -1838,10 +1838,10 @@
 :pass(8) [data-type="composite-page"].os-eob > .os-chapter-area > section > [data-type="document-title"] {
   container: h3; }
 
-:pass(8) .appendix > section :not(p) > [data-type="title"], :pass(8) .appendix > section [data-type="document-title"] {
+:pass(8) .appendix > section > [data-type="title"], :pass(8) .appendix > section [data-type="document-title"] {
   container: h2; }
 
-:pass(8) .appendix > section > section :not(p) > [data-type="title"], :pass(8) .appendix > section > section [data-type="document-title"] {
+:pass(8) .appendix > section > section > [data-type="title"], :pass(8) .appendix > section > section [data-type="document-title"] {
   container: h3; }
 
 :pass(9) .os-index-link-separator:last-child {


### PR DESCRIPTION
Latest fix to headings in examples in appendices didn't take into the consideration headings which weren't inside `p` tags, so their levels weren't assigned correctly. 
1st depth section had h3, 2nd depth section had h2.
Now it should be correct.