### PR TITLE
End of Section custom titles

### DIFF
--- a/recipes/books/_generator.scss
+++ b/recipes/books/_generator.scss
@@ -330,12 +330,13 @@
   }
 }
 :pass(7) {
+  @include count_countChapters(chapter);
+  @include count_countSections(section);
+
   //Only move solutions after exercises/solutions are numbered
   @include reference_refSectionHeaderNodeAs(sectionHeaderNode);
   @each $page in $Config_SectionCompositePages {
-    $name: map-get($page, name);
     $moveSolutionsTo: map-get($page, moveSolutionsTo);
-    @include validate_type($name, string);
     @include validate_enumOptional($moveSolutionsTo, $AREA__PREFIX__);
 
     @if $moveSolutionsTo == $AREA_EOC {
@@ -409,6 +410,7 @@
 
   //After: composite page creation
   @include count_countChapters(chapter);
+  @include count_countSections(section);
   @include count_countAppendices(appendix);
 
   @if map-get($Config_PartType_Exercise, moveTo) == $AREA_EOC { //check to see if this code is redundent,   same block above

--- a/recipes/books/dev-math/_config.scss
+++ b/recipes/books/dev-math/_config.scss
@@ -63,9 +63,10 @@ $RECIPE_NAME: "dev-math";
   Style guide: book.compoundcomposite.exercises
 */
 
+$_eosTitle: (os-title-label: "Exercises ",  os-number: counter(chapter) "." counter(section));
 
 $Config_SectionCompositePages: (
-  (className: "section-exercises",    clusterBy: $CLUSTER_NONE, hasSolutions: true, name: "Section Exercises" ),
+  (className: "section-exercises",    clusterBy: $CLUSTER_NONE, hasSolutions: true, titleContent: $_eosTitle),
 );
 
 $_chapterExercises: (

--- a/recipes/mixins/_compose.scss
+++ b/recipes/mixins/_compose.scss
@@ -3,17 +3,20 @@
 @mixin compose_titleEOSComposites($compositePages) {
   @each $page in $compositePages {
     $name: map-get($page, name);
+    $titleContent: map-get($page, titleContent);
     $className: map-get($page, className);
     $childPages: map-get($page, childPages);
 
     // Validate
-    @include validate_type($name, string);
     @include validate_type($className, string);
 
     [data-type="composite-page"].os-eos.os-#{$className}-container {
-      $titleContent: (
-        os-text: $name
-        );
+      @if ($name != null) {
+        @include validate_type($name, string);
+        $titleContent: (
+          os-text: $name
+          );
+      }
       @include utils_title($titleContent, null, h3, "document-title");
     }
   }
@@ -591,11 +594,21 @@
     $hasSolutions: map-get($section, hasSolutions);
     $className: map-get($section, className);
     $sectionName: map-get($section, name);
+    $titleContent: map-get($section, titleContent);
 
     // Validate
     @include validate_typeOptional($hasSolutions, bool);
     @include validate_type($className, string);
-    @include validate_type($sectionName, string);
+
+    @if ($sectionName != null) {
+      @include validate_type($sectionName, string);
+    }
+    @else {
+      $sectionName: ();
+      @each $elementClass in map-keys($titleContent) {
+        $sectionName: append($sectionName, map-get($titleContent, $elementClass));
+      }
+    }
 
     @if $hasSolutions {
       [data-type="chapter"] { .os-eos.os-#{$className}-container {

--- a/recipes/output/dev-math.css
+++ b/recipes/output/dev-math.css
@@ -1309,6 +1309,18 @@
       container: a;
       attr-href: "#" string(exerciseId); }
 
+:pass(7) body {
+  counter-reset: chapter; }
+
+:pass(7) div[data-type="chapter"] {
+  counter-increment: chapter; }
+
+:pass(7) [data-type="chapter"], :pass(7) .appendix {
+  counter-reset: section; }
+
+:pass(7) div[data-type="chapter"] > div[data-type="page"]:not(.introduction) {
+  counter-increment: section; }
+
 :pass(7) div[data-type="page"] > [data-type="document-title"],
 :pass(7) div[data-type="composite-page"] > [data-type="document-title"] {
   node-set: sectionHeaderNode; }
@@ -1338,7 +1350,7 @@
 
 :pass(7) [data-type="chapter"] .os-eos.os-section-exercises-container::after {
   container: span;
-  content: "Section Exercises";
+  content: "Exercises " counter(chapter) "." counter(section);
   class: "os-title-label";
   move-to: section-exercises-title; }
 
@@ -1439,6 +1451,12 @@
 :pass(8) div[data-type="chapter"] {
   counter-increment: chapter; }
 
+:pass(8) [data-type="chapter"], :pass(8) .appendix {
+  counter-reset: section; }
+
+:pass(8) div[data-type="chapter"] > div[data-type="page"]:not(.introduction) {
+  counter-increment: section; }
+
 :pass(8) body {
   counter-reset: appendix; }
 
@@ -1524,8 +1542,14 @@
 
 :pass(8) [data-type="composite-page"].os-eos.os-section-exercises-container::before {
   container: span;
-  content: "Section Exercises";
-  class: os-text;
+  content: "Exercises ";
+  class: os-title-label;
+  move-to: h3-TITLECONTAINER; }
+
+:pass(8) [data-type="composite-page"].os-eos.os-section-exercises-container::before {
+  container: span;
+  content: counter(chapter) "." counter(section);
+  class: os-number;
   move-to: h3-TITLECONTAINER; }
 
 :pass(8) [data-type="composite-page"].os-eos.os-section-exercises-container::before {


### PR DESCRIPTION
I've added an option to create custom titles with counters. Right now it looks like this (first number is the chapter number and the second one is section number):
![image](https://user-images.githubusercontent.com/20907906/49589839-b72f9a80-f96a-11e8-9f42-5991f046a7d3.png)
