### PR TITLE
Fix Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,10 @@ addons:
       - xsltproc
       - libxml2-utils
       # For building kcov
-      - libcurl4-openssl-dev
-      - libelf-dev
-      - libdw-dev
-      - cmake
+      # - libcurl4-openssl-dev
+      # - libelf-dev
+      # - libdw-dev
+      # - cmake
 
 # Cache the 3rd-party packages. From https://blog.travis-ci.com/2016-11-21-travis-ci-now-supports-yarn
 cache:
@@ -29,17 +29,18 @@ cache:
 before_install:
   - rvm default
   # Build https://github.com/SimonKagstrom/kcov (shell code coverage)
-  - wget https://github.com/SimonKagstrom/kcov/archive/master.tar.gz &&
-    tar xzf master.tar.gz &&
-    rm master.tar.gz &&
-    mkdir "${HOME}/kcov-build/" &&
-    cd kcov-master &&
-    mkdir build &&
-    cd build &&
-    cmake -DCMAKE_INSTALL_PREFIX=${HOME}/kcov-build/ .. &&
-    make &&
-    make install &&
-    cd ../.. &&
-    rm -rf kcov-master
-script: ${HOME}/kcov-build/bin/kcov ./coverage/ ./script/ci
+#   - wget https://github.com/SimonKagstrom/kcov/archive/master.tar.gz &&
+#     tar xzf master.tar.gz &&
+#     rm master.tar.gz &&
+#     mkdir "${HOME}/kcov-build/" &&
+#     cd kcov-master &&
+#     mkdir build &&
+#     cd build &&
+#     cmake -DCMAKE_INSTALL_PREFIX=${HOME}/kcov-build/ .. &&
+#     make &&
+#     make install &&
+#     cd ../.. &&
+#     rm -rf kcov-master
+# script: ${HOME}/kcov-build/bin/kcov ./coverage/ ./script/ci
+script: ./script/ci
 after_success: bash <(curl -s https://codecov.io/bash)

--- a/script/ci
+++ b/script/ci
@@ -1,10 +1,10 @@
 #!/bin/bash
 cd "$(dirname "$0")/.." || exit 111
 
-LOG_LEVEL="debug" ./script/setup || exit 111
+LOG_LEVEL=${LOG_LEVEL:-debug} ./script/setup || exit 111
 
 # Run the tests (which happens to re-generate the CSS files)
-LOG_LEVEL="debug" ./script/test || exit 111
+./script/test || exit 111
 
 # Verify that the CSS files were regenerated so they never become out-of-sync
 

--- a/script/test
+++ b/script/test
@@ -3,7 +3,8 @@ cd "$(dirname "$0")/.." || exit 111
 source ./script/bootstrap || exit 111
 
 # Verify exportable recipes
-try pytest tests
+do_progress_quiet "Running python tests" \
+  try pytest tests
 
 # Make sure the snippets are well-formed XML
 do_progress_quiet "Linting and checking XML snippets" \
@@ -28,12 +29,15 @@ do_progress_quiet "Generating sass docs" \
 source ./books.txt || exit 1
 
 for recipe_name in "${RECIPE_NAMES[@]}"; do
+  # Travis _might_ run out of space in the future. This is here "just in case"
+  if [[ ${TRAVIS} = 'true' ]]; then
+    if [[ -d "./tmp/" ]]; then
+      try rm -rf "./tmp/"
+    fi
+  fi
+
   do_progress_quiet "Generating styleguide for ${recipe_name}" \
     ./script/generate-guide "${recipe_name}"
-  if [[ ${CI} = 'true' ]]; then
-    do_progress_quiet "Cleaning up temporary dir so Travis does not run out of space" \
-      try rm -rf "./tmp/${recipe_name}/"
-  fi
 done
 
 


### PR DESCRIPTION
closes #470 #424 . From https://openstax.slack.com/archives/C0F5DE456/p1545157466441700

This:

- removes `kcov` which was causing the immediate problem of Travis running out of space
- reduces the Travis output when making style guides and just outputs how long it took

Example output:

![image](https://user-images.githubusercontent.com/253202/50185272-f5b74480-02dc-11e9-8ac0-34eb30b5acf0.png)
